### PR TITLE
Fix CodeQL security alerts

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -1209,8 +1209,8 @@ void show_account_menu(struct descriptor_data *d)
                   if (CLASS_LEVEL(tch, inc))
                   {
                     if (classCount)
-                      len += snprintf(buf + len, sizeof(buf) - len, "/");
-                    len += snprintf(buf + len, sizeof(buf) - len, "%s", CLSLIST_CLRABBRV(inc));
+                      len = snprintf_append(buf, sizeof(buf), len, "/");
+                    len = snprintf_append(buf, sizeof(buf), len, "%s", CLSLIST_CLRABBRV(inc));
                     classCount++;
                   }
                 }

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -3300,7 +3300,7 @@ void add_history(struct char_data *ch, const char *str, int type)
 
   tmp = GET_HISTORY(ch, type);
   ct = time(0);
-  strftime(time_str, sizeof(time_str), "%H:%M ", localtime(&ct));
+  format_time_string(ct, "%H:%M ", time_str, sizeof(time_str));
 
   snprintf(buf, sizeof(buf), "%s%s", time_str, str);
 
@@ -7774,16 +7774,16 @@ ACMD(do_who)
             if (CLASS_LEVEL(tch, inc))
             {
               if (classCount)
-                len += snprintf(classes_list + len, sizeof(classes_list) - len, "/");
-              len += snprintf(classes_list + len, sizeof(classes_list) - len, "%s",
-                              CLSLIST_CLRABBRV(inc));
+                len = snprintf_append(classes_list, sizeof(classes_list), len, "/");
+              len = snprintf_append(classes_list, sizeof(classes_list), len, "%s",
+                                    CLSLIST_CLRABBRV(inc));
               classCount++;
             }
           }
           class_len = strlen(classes_list) - count_color_chars(classes_list);
           while (class_len < 11)
           {
-            len += snprintf(classes_list + len, sizeof(classes_list) - len, " ");
+            len = snprintf_append(classes_list, sizeof(classes_list), len, " ");
             class_len++;
           }
           send_to_char(ch, "%s]", classes_list);
@@ -8047,7 +8047,7 @@ ACMD(do_users)
              state, idletime, timestr);
 
     if (*d->host)
-      sprintf(line + strlen(line), "[%s]\r\n", d->host);
+      snprintf(line + strlen(line), sizeof(line) - strlen(line), "[%s]\r\n", d->host);
     else
       strlcat(line, "[Hostname unknown]\r\n", sizeof(line));
 
@@ -8142,7 +8142,7 @@ ACMD(do_where)
 ACMD(do_levels)
 {
   char buf[MAX_STRING_LENGTH] = {'\0'}, arg[MAX_STRING_LENGTH] = {'\0'};
-  size_t len = 0, nlen;
+  size_t len = 0;
   int i, ret, min_lev = 1, max_lev = LVL_IMMORT, val;
 
   if (IS_NPC(ch))
@@ -8192,11 +8192,10 @@ ACMD(do_levels)
 
   for (i = min_lev; i < max_lev; i++)
   {
-    nlen = snprintf(buf + len, sizeof(buf) - len, "[%2d] %8ld-%-8ld : ", (int)i, level_exp(ch, i),
-                    level_exp(ch, i + 1) - 1);
-    if (len + nlen >= sizeof(buf))
+    len = snprintf_append(buf, sizeof(buf), len, "[%2d] %8ld-%-8ld : ", (int)i, level_exp(ch, i),
+                          level_exp(ch, i + 1) - 1);
+    if (len >= sizeof(buf) - 1)
       break;
-    len += nlen;
 
     // why are we checking sex for titles?  titles used to be sex
     // dependent...  -zusuk
@@ -8204,23 +8203,22 @@ ACMD(do_levels)
     {
     case SEX_MALE:
     case SEX_NEUTRAL:
-      nlen = snprintf(buf + len, sizeof(buf) - len, "%s\r\n", titles(GET_CLASS(ch), i));
+      len = snprintf_append(buf, sizeof(buf), len, "%s\r\n", titles(GET_CLASS(ch), i));
       break;
     case SEX_FEMALE:
-      nlen = snprintf(buf + len, sizeof(buf) - len, "%s\r\n", titles(GET_CLASS(ch), i));
+      len = snprintf_append(buf, sizeof(buf), len, "%s\r\n", titles(GET_CLASS(ch), i));
       break;
     default:
-      nlen = snprintf(buf + len, sizeof(buf) - len, "Oh dear.  You seem to be sexless.\r\n");
+      len = snprintf_append(buf, sizeof(buf), len, "Oh dear.  You seem to be sexless.\r\n");
       break;
     }
-    if (len + nlen >= sizeof(buf))
+    if (len >= sizeof(buf) - 1)
       break;
-    len += nlen;
   }
 
-  if (len < sizeof(buf) && max_lev == LVL_IMMORT)
-    snprintf(buf + len, sizeof(buf) - len, "[%2d] %8ld          : Immortality\r\n", LVL_IMMORT,
-             level_exp(ch, LVL_IMMORT));
+  if (max_lev == LVL_IMMORT)
+    len = snprintf_append(buf, sizeof(buf), len, "[%2d] %8ld          : Immortality\r\n", LVL_IMMORT,
+                          level_exp(ch, LVL_IMMORT));
   page_string(ch->desc, buf, TRUE);
 }
 
@@ -9243,7 +9241,7 @@ bool get_zone_levels(zone_rnum znum, char *buf)
 
 ACMD(do_areas)
 {
-  int i, hilev = -1, lolev = -1, zcount = 0, lev_set, len = 0, name_width, tmp_len = 0;
+  int i, hilev = -1, lolev = -1, zcount = 0, lev_set, len = 0, name_width;
   char arg[MAX_INPUT_LENGTH] = {'\0'}, *second, lev_str[MAX_INPUT_LENGTH] = {'\0'},
        buf[MAX_STRING_LENGTH] = {'\0'};
   //  char zvn[MAX_INPUT_LENGTH] = {'\0'};
@@ -9378,46 +9376,38 @@ ACMD(do_areas)
         overlap_shown = TRUE;
       lev_set = get_zone_levels(i, lev_str);
       name_width = count_color_chars(zone_table[i].name) + 40;
-      tmp_len =
-          snprintf(buf + len, sizeof(buf) - len, "\tn(%3d) %s%-*.*s\tn %s%.64s\tn\r\n", ++zcount,
-                   overlap ? QRED : QCYN, name_width, name_width, zone_table[i].name,
-                   lev_set ? "\tc" : "\tn", lev_set ? lev_str : "All Levels");
+      len = snprintf_append(buf, sizeof(buf), len, "\tn(%3d) %s%-*.*s\tn %s%.64s\tn\r\n",
+                            ++zcount, overlap ? QRED : QCYN, name_width, name_width,
+                            zone_table[i].name, lev_set ? "\tc" : "\tn",
+                            lev_set ? lev_str : "All Levels");
       snprintf(zone_num, sizeof(zone_num), " \tc[%3d]\tn  ", zone_table[i].number);
       snprintf(areas[num_areas], sizeof(areas[num_areas]), "\tn %-*.*s\tn %s%s%.64s\tn\r\n",
                name_width, name_width, zone_table[i].name, zone_num, lev_set ? "\tc" : "\tn",
                lev_set ? lev_str : "All Levels");
       num_areas++;
-      len += tmp_len;
     }
   }
 
-  tmp_len = snprintf(buf + len, sizeof(buf) - len, "\r\n\r\n");
-  len += tmp_len;
-
-  tmp_len = snprintf(buf + len, sizeof(buf) - len, "%s%d%s area%s found.\r\n", QYEL, zcount, QNRM,
-                     zcount == 1 ? "" : "s");
-  len += tmp_len;
+  len = snprintf_append(buf, sizeof(buf), len, "\r\n\r\n");
+  len = snprintf_append(buf, sizeof(buf), len, "%s%d%s area%s found.\r\n", QYEL, zcount, QNRM,
+                        zcount == 1 ? "" : "s");
 
   if (overlap_shown)
   {
-    tmp_len = snprintf(
-        buf + len, sizeof(buf) - len,
+    len = snprintf_append(
+        buf, sizeof(buf), len,
         "Areas shown in \trred\tn may have some creatures outside the specified range.\r\n");
-    len += tmp_len;
   }
 
 #if defined(CAMPAIGN_DL)
-  tmp_len = snprintf(
-      buf + len, sizeof(buf) - len,
+  len = snprintf_append(
+      buf, sizeof(buf), len,
       "To show all areas type 'areas all', or to filter zones by level see HELP AREAS.\r\n");
-  len += tmp_len;
-  tmp_len = snprintf(buf + len, sizeof(buf) - len,
-                     "To show more information on a specific zone, type HELP (zone name as shown "
-                     "in areas command).\r\n");
-  len += tmp_len;
+  len = snprintf_append(buf, sizeof(buf), len,
+                        "To show more information on a specific zone, type HELP (zone name as shown "
+                        "in areas command).\r\n");
 #else
-  tmp_len = snprintf(buf + len, sizeof(buf) - len, "More areas are listed in HELP ZONES");
-  len += tmp_len;
+  len = snprintf_append(buf, sizeof(buf), len, "More areas are listed in HELP ZONES");
 #endif
 
   // if (zcount == 0)

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -5426,9 +5426,9 @@ void record_quit_feedback(struct char_data *ch, const char *reason)
   if (!counter)
     strlcpy(class_breakdown, "(no class)", sizeof(class_breakdown));
 
-  strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M:%S", localtime(&now));
+  format_time_string(now, "%Y-%m-%d %H:%M:%S", time_buf, sizeof(time_buf));
 
-  FILE *logfile = fopen(QUIT_FEEDBACK_FILE, "a");
+  FILE *logfile = fopen_restricted(QUIT_FEEDBACK_FILE, "a");
   if (!logfile)
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: Could not open %s for quit feedback: %s",
@@ -6960,7 +6960,7 @@ ACMDU(do_arcanemark)
   if (!*argument)
   {
     if ((tmark = GET_ARCANE_MARK(ch)) &&
-        !(!tmark || !*tmark || tmark == NULL || !strcmp(tmark, "(null)") || !strcmp(tmark, "null")))
+        *tmark && strcmp(tmark, "(null)") && strcmp(tmark, "null"))
     {
       send_to_char(ch, "Your arcane mark is set to: %s\r\n", GET_ARCANE_MARK(ch));
       return;
@@ -9779,7 +9779,12 @@ ACMD(do_todo)
   else
   {
     int num, i, success = 0;
-    sscanf(argument, "%d", &num);
+
+    if (sscanf(argument, "%d", &num) != 1)
+    {
+      send_to_char(ch, "Please specify the number of the completed item.\r\n");
+      return;
+    }
 
     if (num == 1 && GET_TODO(ch) && (success = 1))
       GET_TODO(ch) = GET_TODO(ch)->next;
@@ -11701,11 +11706,11 @@ ACMDU(do_device)
                      circle_level, ordinal, max_circles[i], used_circles[i]);
         /* Build spell list for user feedback */
         char spell_list_o[MAX_STRING_LENGTH * 4];
-        strcpy(spell_list_o, spell_info[spell_nums[0]].name);
+        strlcpy(spell_list_o, spell_info[spell_nums[0]].name, sizeof(spell_list_o));
         for (j = 1; j < num_spells; j++)
         {
-          strcat(spell_list_o, "/");
-          strcat(spell_list_o, spell_info[spell_nums[j]].name);
+          strlcat(spell_list_o, "/", sizeof(spell_list_o));
+          strlcat(spell_list_o, spell_info[spell_nums[j]].name, sizeof(spell_list_o));
         }
         send_to_char(ch, "Spells attempted to add: %s\r\n", spell_list_o);
         return;
@@ -11796,11 +11801,11 @@ ACMDU(do_device)
 
     /* Build spell list for user feedback */
     char spell_list[MAX_STRING_LENGTH * 4];
-    strcpy(spell_list, spell_info[spell_nums[0]].name);
+    strlcpy(spell_list, spell_info[spell_nums[0]].name, sizeof(spell_list));
     for (i = 1; i < num_spells; i++)
     {
-      strcat(spell_list, "/");
-      strcat(spell_list, spell_info[spell_nums[i]].name);
+      strlcat(spell_list, "/", sizeof(spell_list));
+      strlcat(spell_list, spell_info[spell_nums[i]].name, sizeof(spell_list));
     }
 
     send_to_char(ch, "You begin crafting a %s device. This will take %d seconds to complete.\r\n",
@@ -13211,7 +13216,7 @@ EVENTFUNC(event_device_progress)
   {
     /* Parse the invention data from the event variables */
     char invention_data[MAX_STRING_LENGTH];
-    strcpy(invention_data, pMudEvent->sVariables);
+    strlcpy(invention_data, pMudEvent->sVariables, sizeof(invention_data));
 
     char *spells_part = strtok(invention_data, "|");
     char *num_spells_str = strtok(NULL, "|");
@@ -13236,13 +13241,13 @@ EVENTFUNC(event_device_progress)
       {
         /* Build spell list for device name */
         int j;
-        strcpy(device_name, spell_info[spell_nums[0]].name);
+        strlcpy(device_name, spell_info[spell_nums[0]].name, sizeof(device_name));
         for (j = 1; j < num_spells; j++)
         {
-          strcat(device_name, "/");
-          strcat(device_name, spell_info[spell_nums[j]].name);
+          strlcat(device_name, "/", sizeof(device_name));
+          strlcat(device_name, spell_info[spell_nums[j]].name, sizeof(device_name));
         }
-        strcat(device_name, " device");
+        strlcat(device_name, " device", sizeof(device_name));
       }
     }
   }

--- a/src/act.social.c
+++ b/src/act.social.c
@@ -58,7 +58,7 @@ ACMD(do_action)
   if (!action->char_found)
     *arg = '\0';
 
-  if (action->char_found && argument)
+  if (action->char_found)
     one_argument(argument, arg, sizeof(arg));
   else
     *arg = '\0';

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -182,7 +182,7 @@ ACMD(do_quitlog)
     }
 
     /* Write all lines except the one to delete */
-    temp_fp = fopen(QUIT_FEEDBACK_FILE, "w");
+    temp_fp = fopen_restricted(QUIT_FEEDBACK_FILE, "w");
     if (!temp_fp)
     {
       send_to_char(ch, "Unable to open quit feedback log for writing.\r\n");
@@ -267,7 +267,7 @@ ACMD(do_quitlog)
           continue;
 
         size_t needed = strlen(entries[i]) + 32; /* line number + line + CRLF */
-        if (out_len + needed >= out_cap)
+        while (needed >= out_cap - out_len)
         {
           out_cap *= 2;
           char *tmp = realloc(out, out_cap);
@@ -281,7 +281,9 @@ ACMD(do_quitlog)
           out = tmp;
         }
 
-        out_len += snprintf(out + out_len, out_cap - out_len, "[%d] %s", line_num++, entries[i]);
+        if (!out)
+          break;
+        out_len = snprintf_append(out, out_cap, out_len, "[%d] %s", line_num++, entries[i]);
       }
 
       if (out)
@@ -2770,7 +2772,7 @@ void add_llog_entry(struct char_data *ch, int type)
     llast->close_time = 0;
     llast->close_type = type;
 
-    if (!(fp = fopen(LAST_FILE, "a")))
+    if (!(fp = fopen_restricted(LAST_FILE, "a")))
     {
       log("error opening last_file for appending");
       free(llast);
@@ -2806,7 +2808,7 @@ void clean_llog_entries(void)
     return;
   }
 
-  if (!(nfp = fopen("etc/nlast", "w")))
+  if (!(nfp = fopen_restricted("etc/nlast", "w")))
   {
     log("Error trying to open new last file.");
     fclose(ofp);
@@ -3765,21 +3767,19 @@ ACMD(do_show)
           continue;
         if (W_EXIT(i, j)->to_room == 0)
         {
-          nlen = snprintf(buf + len, sizeof(buf) - len, "%2d: (void   ) [%5d] %-*s%s (%s)\r\n", ++k,
-                          GET_ROOM_VNUM(i), count_color_chars(world[i].name) + 40, world[i].name,
-                          QNRM, dirs[j]);
-          if (len + nlen >= sizeof(buf))
+          len = snprintf_append(buf, sizeof(buf), len,
+                                "%2d: (void   ) [%5d] %-*s%s (%s)\r\n", ++k, GET_ROOM_VNUM(i),
+                                count_color_chars(world[i].name) + 40, world[i].name, QNRM, dirs[j]);
+          if (len >= sizeof(buf) - 1)
             break;
-          len += nlen;
         }
         if (W_EXIT(i, j)->to_room == NOWHERE && !W_EXIT(i, j)->general_description)
         {
-          nlen = snprintf(buf + len, sizeof(buf) - len, "%2d: (Nowhere) [%5d] %-*s%s (%s)\r\n", ++k,
-                          GET_ROOM_VNUM(i), count_color_chars(world[i].name) + 40, world[i].name,
-                          QNRM, dirs[j]);
-          if (len + nlen >= sizeof(buf))
+          len = snprintf_append(buf, sizeof(buf), len,
+                                "%2d: (Nowhere) [%5d] %-*s%s (%s)\r\n", ++k, GET_ROOM_VNUM(i),
+                                count_color_chars(world[i].name) + 40, world[i].name, QNRM, dirs[j]);
+          if (len >= sizeof(buf) - 1)
             break;
-          len += nlen;
         }
       }
     page_string(ch->desc, buf, TRUE);
@@ -3791,11 +3791,10 @@ ACMD(do_show)
     for (i = 0, j = 0; i <= (int)top_of_world; i++)
       if (ROOM_FLAGGED(i, ROOM_DEATH))
       {
-        nlen = snprintf(buf + len, sizeof(buf) - len, "%2d: [%5d] %s%s\r\n", ++j, GET_ROOM_VNUM(i),
-                        world[i].name, QNRM);
-        if (len + nlen >= sizeof(buf))
+        len = snprintf_append(buf, sizeof(buf), len, "%2d: [%5d] %s%s\r\n", ++j,
+                              GET_ROOM_VNUM(i), world[i].name, QNRM);
+        if (len >= sizeof(buf) - 1)
           break;
-        len += nlen;
       }
     page_string(ch->desc, buf, TRUE);
     break;
@@ -3806,11 +3805,10 @@ ACMD(do_show)
     for (i = 0, j = 0; i <= (int)top_of_world; i++)
       if (ROOM_FLAGGED(i, ROOM_STAFFROOM))
       {
-        nlen = snprintf(buf + len, sizeof(buf) - len, "%2d: [%5d] %s%s\r\n", ++j, GET_ROOM_VNUM(i),
-                        world[i].name, QNRM);
-        if (len + nlen >= sizeof(buf))
+        len = snprintf_append(buf, sizeof(buf), len, "%2d: [%5d] %s%s\r\n", ++j,
+                              GET_ROOM_VNUM(i), world[i].name, QNRM);
+        if (len >= sizeof(buf) - 1)
           break;
-        len += nlen;
       }
     page_string(ch->desc, buf, TRUE);
     break;
@@ -3870,11 +3868,10 @@ ACMD(do_show)
         for (b = 0; b < 6; b++)
         {
           snprintf(colour, sizeof(colour), "F%d%d%d", r, g, b);
-          nlen = snprintf(buf + len, sizeof(buf) - len, "%s%s%s", ColourRGB(ch->desc, colour),
-                          colour, ++k % 6 == 0 ? "\tn\r\n" : "    ");
-          if (len + nlen >= sizeof(buf))
+          len = snprintf_append(buf, sizeof(buf), len, "%s%s%s", ColourRGB(ch->desc, colour),
+                                colour, ++k % 6 == 0 ? "\tn\r\n" : "    ");
+          if (len >= sizeof(buf) - 1)
             break;
-          len += nlen;
         }
     page_string(ch->desc, buf, TRUE);
     break;
@@ -5298,7 +5295,7 @@ void show_set_help(struct char_data *ch)
   const char *const set_targets[] = {"PC", "NPC", "BOTH"};
   const char *const set_types[] = {"MISC", "BINARY", "NUMBER", "ADDER"};
   char buf[MAX_STRING_LENGTH] = {'\0'};
-  int i, len = 0, add_len = 0;
+  int i, len = 0;
 
   len = snprintf(buf, sizeof(buf), "%sCommand             Lvl    Who?  Type%s\r\n",
                  CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
@@ -5306,11 +5303,10 @@ void show_set_help(struct char_data *ch)
   {
     if (set_fields[i].level <= GET_LEVEL(ch))
     {
-      add_len = snprintf(buf + len, sizeof(buf) - len, "%-20s%-5s  %-4s  %-6s\r\n",
-                         set_fields[i].cmd, set_levels[((int)(set_fields[i].level) - LVL_IMMORT)],
-                         set_targets[(int)(set_fields[i].pcnpc) - 1],
-                         set_types[(int)(set_fields[i].type)]);
-      len += add_len;
+      len = snprintf_append(buf, sizeof(buf), len, "%-20s%-5s  %-4s  %-6s\r\n", set_fields[i].cmd,
+                            set_levels[((int)(set_fields[i].level) - LVL_IMMORT)],
+                            set_targets[(int)(set_fields[i].pcnpc) - 1],
+                            set_types[(int)(set_fields[i].type)]);
     }
   }
   page_string(ch->desc, buf, TRUE);
@@ -5528,28 +5524,29 @@ ACMD(do_keycheck)
       {
         if (keynum < bottom || keynum > top)
         {
-          len += snprintf(buf + len, sizeof(buf) - len, "[%s%-6d%s] %s%-*s%s %s%-5s:%d%s\r\n", QGRN,
-                          i, QNRM, QCYN, count_color_chars(world[real_room(i)].name) + 44,
-                          world[real_room(i)].name, QNRM, QBRED, dirs[j], keynum, QNRM);
+          len = snprintf_append(
+              buf, sizeof(buf), len, "[%s%-6d%s] %s%-*s%s %s%-5s:%d%s\r\n", QGRN, i, QNRM, QCYN,
+              count_color_chars(world[real_room(i)].name) + 44, world[real_room(i)].name, QNRM,
+              QBRED, dirs[j], keynum, QNRM);
         }
       }
     }
 
-    if ((size_t)len >= sizeof(buf))
+    if ((size_t)len >= sizeof(buf) - 1)
       break;
   }
 
   /* going through the objects now! */
-  len += snprintf(buf + len, sizeof(buf) - len,
-                  "\r\n"
-                  "VNum     Object Name                                  Key-VNum\r\n"
-                  "-------- -------------------------------------------- --------\r\n");
+  len = snprintf_append(buf, sizeof(buf), len,
+                        "\r\n"
+                        "VNum     Object Name                                  Key-VNum\r\n"
+                        "-------- -------------------------------------------- --------\r\n");
 
   /* here is a loop that will go through the list of objects by vnum */
   for (i = bottom; i <= top; i++)
   {
     /* in case we overflowed earlier */
-    if ((size_t)len >= sizeof(buf))
+    if ((size_t)len >= sizeof(buf) - 1)
       break;
 
     /* easy out, object doesn't exist */
@@ -5571,9 +5568,9 @@ ACMD(do_keycheck)
     {
       if ((room_vnum)GET_OBJ_VAL(obj, 2) < bottom || (room_vnum)GET_OBJ_VAL(obj, 2) > top)
       {
-        len += snprintf(buf + len, sizeof(buf) - len, "[%s%-6d%s] %s%-*s%s %s%d%s\r\n", QGRN, i,
-                        QNRM, QCYN, count_color_chars(GET_OBJ_SHORT(obj)) + 44, GET_OBJ_SHORT(obj),
-                        QNRM, QBRED, GET_OBJ_VAL(obj, 2), QNRM);
+        len = snprintf_append(buf, sizeof(buf), len, "[%s%-6d%s] %s%-*s%s %s%d%s\r\n", QGRN, i,
+                              QNRM, QCYN, count_color_chars(GET_OBJ_SHORT(obj)) + 44,
+                              GET_OBJ_SHORT(obj), QNRM, QBRED, GET_OBJ_VAL(obj, 2), QNRM);
       }
     }
   }
@@ -5806,74 +5803,77 @@ ACMD(do_zcheck)
     { /*is mob in this zone?*/
       mob = &mob_proto[i];
       if (!strcmp(mob->player.name, "mob unfinished") && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Alias hasn't been set.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len, "- Alias hasn't been set.\r\n");
 
       if (!strcmp(mob->player.short_descr, "the unfinished mob") && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Short description hasn't been set.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len, "- Short description hasn't been set.\r\n");
 
       if (!strncmp(mob->player.long_descr, "An unfinished mob stands here.", 30) && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Long description hasn't been set.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len, "- Long description hasn't been set.\r\n");
 
       if (mob->player.description && *mob->player.description)
       {
         if (!strncmp(mob->player.description, "It looks unfinished.", 20) && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- Description hasn't been set.\r\n");
+          len = snprintf_append(buf, sizeof(buf), len, "- Description hasn't been set.\r\n");
         /*else if (strncmp(mob->player.description, "   ", 3) && (found = 1))
           len += snprintf(buf + len, sizeof (buf) - len,
                 "- Description hasn't been formatted. (/fi)\r\n");*/
       }
 
       if (GET_LEVEL(mob) > MAX_LEVEL_ALLOWED && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Is level %d (limit: 1-%d)\r\n",
-                        GET_LEVEL(mob), MAX_LEVEL_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len, "- Is level %d (limit: 1-%d)\r\n",
+                              GET_LEVEL(mob), MAX_LEVEL_ALLOWED);
 
       if (GET_DAMROLL(mob) > MAX_DAMROLL_ALLOWED && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Damroll of %d is too high (limit: %d)\r\n",
-                        GET_DAMROLL(mob), MAX_DAMROLL_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- Damroll of %d is too high (limit: %d)\r\n", GET_DAMROLL(mob),
+                              MAX_DAMROLL_ALLOWED);
 
       if (GET_HITROLL(mob) > MAX_HITROLL_ALLOWED && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Hitroll of %d is too high (limit: %d)\r\n",
-                        GET_HITROLL(mob), MAX_HITROLL_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- Hitroll of %d is too high (limit: %d)\r\n", GET_HITROLL(mob),
+                              MAX_HITROLL_ALLOWED);
 
       /* avg. dam including damroll per round of combat */
       avg_dam = (((mob->mob_specials.damsizedice / 2.0) * mob->mob_specials.damnodice) +
                  GET_DAMROLL(mob));
       if (avg_dam > MAX_MOB_DAM_ALLOWED && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- average damage of %4.1f is too high (limit: %d)\r\n", avg_dam,
-                        MAX_MOB_DAM_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- average damage of %4.1f is too high (limit: %d)\r\n", avg_dam,
+                              MAX_MOB_DAM_ALLOWED);
 
       if (mob->mob_specials.damsizedice == 1 && mob->mob_specials.damnodice == 1 &&
           GET_LEVEL(mob) == 0 && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Needs to be fixed - %sAutogenerate!%s\r\n",
-                        CCYEL(ch, C_NRM), CCNRM(ch, C_NRM));
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- Needs to be fixed - %sAutogenerate!%s\r\n", CCYEL(ch, C_NRM),
+                              CCNRM(ch, C_NRM));
 
       if (MOB_FLAGGED(mob, MOB_AGGRESSIVE) &&
           (MOB_FLAGGED(mob, MOB_AGGR_GOOD) || MOB_FLAGGED(mob, MOB_AGGR_EVIL) ||
            MOB_FLAGGED(mob, MOB_AGGR_NEUTRAL)) &&
           (found = 1))
-        len +=
-            snprintf(buf + len, sizeof(buf) - len, "- Both aggresive and agressive to align.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- Both aggresive and agressive to align.\r\n");
 
       if ((GET_GOLD(mob) > MAX_MOB_GOLD_ALLOWED) && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Set to %d Gold (limit : %d).\r\n",
-                        GET_GOLD(mob), MAX_MOB_GOLD_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len, "- Set to %d Gold (limit : %d).\r\n",
+                              GET_GOLD(mob), MAX_MOB_GOLD_ALLOWED);
 
       if (GET_EXP(mob) > MAX_EXP_ALLOWED && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- Has %ld experience (limit: %d)\r\n",
-                        GET_EXP(mob), MAX_EXP_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len, "- Has %ld experience (limit: %d)\r\n",
+                              GET_EXP(mob), MAX_EXP_ALLOWED);
       if ((AFF_FLAGGED(mob, AFF_CHARM) || AFF_FLAGGED(mob, AFF_POISON)) && (found = 1))
-        len +=
-            snprintf(buf + len, sizeof(buf) - len, "- Has illegal affection bits set (%s %s)\r\n",
-                     AFF_FLAGGED(mob, AFF_CHARM) ? "CHARM" : "",
-                     AFF_FLAGGED(mob, AFF_POISON) ? "POISON" : "");
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- Has illegal affection bits set (%s %s)\r\n",
+                              AFF_FLAGGED(mob, AFF_CHARM) ? "CHARM" : "",
+                              AFF_FLAGGED(mob, AFF_POISON) ? "POISON" : "");
 
       if (!MOB_FLAGGED(mob, MOB_SENTINEL) && !MOB_FLAGGED(mob, MOB_STAY_ZONE) && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- Neither SENTINEL nor STAY_ZONE bits set.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- Neither SENTINEL nor STAY_ZONE bits set.\r\n");
 
       if (MOB_FLAGGED(mob, MOB_SPEC) && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- SPEC flag needs to be removed.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len, "- SPEC flag needs to be removed.\r\n");
 
       /* Additional mob checks.*/
       if (found)
@@ -5900,28 +5900,29 @@ ACMD(do_zcheck)
       {
       case ITEM_MONEY:
         if ((value = GET_OBJ_VAL(obj, 0)) > MAX_OBJ_GOLD_ALLOWED && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- Is worth %d (money limit %d coins).\r\n",
-                          value, MAX_OBJ_GOLD_ALLOWED);
+          len = snprintf_append(buf, sizeof(buf), len,
+                                "- Is worth %d (money limit %d coins).\r\n", value,
+                                MAX_OBJ_GOLD_ALLOWED);
         break;
       case ITEM_WEAPON:
         if (GET_OBJ_VAL(obj, 3) >= NUM_ATTACK_TYPES && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- has out of range attack type %d.\r\n",
-                          GET_OBJ_VAL(obj, 3));
+          len = snprintf_append(buf, sizeof(buf), len, "- has out of range attack type %d.\r\n",
+                                GET_OBJ_VAL(obj, 3));
 
         if (GET_OBJ_AVG_DAM(obj) > MAX_DAM_ALLOWED && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- Damroll is %2.1f (limit %d)\r\n",
-                          GET_OBJ_AVG_DAM(obj), MAX_DAM_ALLOWED);
+          len = snprintf_append(buf, sizeof(buf), len, "- Damroll is %2.1f (limit %d)\r\n",
+                                GET_OBJ_AVG_DAM(obj), MAX_DAM_ALLOWED);
         break;
       case ITEM_CLANARMOR:
         if (GET_OBJ_CLAN(obj) == 0 || GET_OBJ_CLAN(obj) == NO_CLAN)
         {
           found = 1;
-          len += snprintf(buf + len, sizeof(buf) - len, "- Clan ID not set on CLANARMOR\r\n");
+          len = snprintf_append(buf, sizeof(buf), len, "- Clan ID not set on CLANARMOR\r\n");
         }
         else if (real_clan(GET_OBJ_CLAN(obj)) == NO_CLAN)
         {
           found = 1;
-          len += snprintf(buf + len, sizeof(buf) - len, "- Invalid Clan ID on CLANARMOR\r\n");
+          len = snprintf_append(buf, sizeof(buf), len, "- Invalid Clan ID on CLANARMOR\r\n");
         }
         __attribute__((fallthrough));
       case ITEM_ARMOR:
@@ -5929,8 +5930,8 @@ ACMD(do_zcheck)
         for (j = 0; j < TOTAL_WEAR_CHECKS; j++)
         {
           if (CAN_WEAR(obj, zarmor[j].bitvector) && (ac > zarmor[j].ac_allowed) && (found = 1))
-            len += snprintf(buf + len, sizeof(buf) - len, "- Has AC %d (%s limit is %d)\r\n", ac,
-                            zarmor[j].message, zarmor[j].ac_allowed);
+            len = snprintf_append(buf, sizeof(buf), len, "- Has AC %d (%s limit is %d)\r\n", ac,
+                                  zarmor[j].message, zarmor[j].ac_allowed);
         }
         break;
 
@@ -5941,36 +5942,38 @@ ACMD(do_zcheck)
         if ((GET_OBJ_COST(obj) || (GET_OBJ_WEIGHT(obj) && GET_OBJ_TYPE(obj) != ITEM_FOUNTAIN) ||
              GET_OBJ_RENT(obj)) &&
             (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len,
-                          "- is NO_TAKE, but has cost (%d) weight (%d) or rent (%d) set.\r\n",
-                          GET_OBJ_COST(obj), GET_OBJ_WEIGHT(obj), GET_OBJ_RENT(obj));
+          len = snprintf_append(
+              buf, sizeof(buf), len,
+              "- is NO_TAKE, but has cost (%d) weight (%d) or rent (%d) set.\r\n",
+              GET_OBJ_COST(obj), GET_OBJ_WEIGHT(obj), GET_OBJ_RENT(obj));
       }
       else
       {
         if (GET_OBJ_COST(obj) == 0 && (found = 1) && GET_OBJ_TYPE(obj) != ITEM_TRASH)
-          len += snprintf(buf + len, sizeof(buf) - len, "- has 0 cost (min. 1).\r\n");
+          len = snprintf_append(buf, sizeof(buf), len, "- has 0 cost (min. 1).\r\n");
 
         if (GET_OBJ_WEIGHT(obj) == 0 && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- has 0 weight (min. 1).\r\n");
+          len = snprintf_append(buf, sizeof(buf), len, "- has 0 weight (min. 1).\r\n");
 
         if (GET_OBJ_WEIGHT(obj) > MAX_OBJ_WEIGHT && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "  Weight is too high: %d (limit  %d).\r\n",
-                          GET_OBJ_WEIGHT(obj), MAX_OBJ_WEIGHT);
+          len = snprintf_append(buf, sizeof(buf), len,
+                                "  Weight is too high: %d (limit  %d).\r\n", GET_OBJ_WEIGHT(obj),
+                                MAX_OBJ_WEIGHT);
 
         if (GET_OBJ_COST(obj) > MAX_OBJ_COST && (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- has %d cost (max %d).\r\n",
-                          GET_OBJ_COST(obj), MAX_OBJ_COST);
+          len = snprintf_append(buf, sizeof(buf), len, "- has %d cost (max %d).\r\n",
+                                GET_OBJ_COST(obj), MAX_OBJ_COST);
       }
 
       if (GET_OBJ_LEVEL(obj) > LVL_IMMORT - 1 && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- has min level set to %d (max %d).\r\n",
-                        GET_OBJ_LEVEL(obj), LVL_IMMORT - 1);
+        len = snprintf_append(buf, sizeof(buf), len, "- has min level set to %d (max %d).\r\n",
+                              GET_OBJ_LEVEL(obj), LVL_IMMORT - 1);
 
       if (obj->action_description && *obj->action_description && GET_OBJ_TYPE(obj) != ITEM_STAFF &&
           GET_OBJ_TYPE(obj) != ITEM_WAND && GET_OBJ_TYPE(obj) != ITEM_SCROLL &&
           GET_OBJ_TYPE(obj) != ITEM_NOTE && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- has action_description set, but is inappropriate type.\r\n");
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- has action_description set, but is inappropriate type.\r\n");
 
       /*first check for over-all affections*/
       for (affs = 0, j = 0; j < MAX_OBJ_AFFECT; j++)
@@ -5978,8 +5981,8 @@ ACMD(do_zcheck)
           affs++;
 
       if (affs > MAX_AFFECTS_ALLOWED && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len, "- has %d affects (limit %d).\r\n", affs,
-                        MAX_AFFECTS_ALLOWED);
+        len = snprintf_append(buf, sizeof(buf), len, "- has %d affects (limit %d).\r\n", affs,
+                              MAX_AFFECTS_ALLOWED);
 
       /*check for out of range affections. */
       for (j = 0; j < MAX_OBJ_AFFECT; j++)
@@ -5987,13 +5990,15 @@ ACMD(do_zcheck)
                 -99 && /* only care if a range is set */
             (obj->affected[j].modifier > zaffs[(int)obj->affected[j].location].max_aff ||
              obj->affected[j].modifier < zaffs[(int)obj->affected[j].location].min_aff ||
-             zaffs[(int)obj->affected[j].location].min_aff ==
+            zaffs[(int)obj->affected[j].location].min_aff ==
                  zaffs[(int)obj->affected[j].location].max_aff) &&
             (found = 1))
-          len += snprintf(buf + len, sizeof(buf) - len, "- apply to %s is %d (limit %d - %d).\r\n",
-                          zaffs[(int)obj->affected[j].location].message, obj->affected[j].modifier,
-                          zaffs[(int)obj->affected[j].location].min_aff,
-                          zaffs[(int)obj->affected[j].location].max_aff);
+          len = snprintf_append(buf, sizeof(buf), len,
+                                "- apply to %s is %d (limit %d - %d).\r\n",
+                                zaffs[(int)obj->affected[j].location].message,
+                                obj->affected[j].modifier,
+                                zaffs[(int)obj->affected[j].location].min_aff,
+                                zaffs[(int)obj->affected[j].location].max_aff);
 
       /* special handling of +hit and +dam because of +hit_n_dam */
       for (todam = 0, tohit = 0, j = 0; j < MAX_OBJ_AFFECT; j++)
@@ -6004,13 +6009,13 @@ ACMD(do_zcheck)
           todam += obj->affected[j].modifier;
       }
       if (abs(todam) > MAX_APPLY_DAMROLL_TOTAL && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- total damroll %d out of range (limit +/-%d.\r\n", todam,
-                        MAX_APPLY_DAMROLL_TOTAL);
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- total damroll %d out of range (limit +/-%d.\r\n", todam,
+                              MAX_APPLY_DAMROLL_TOTAL);
       if (abs(tohit) > MAX_APPLY_HITROLL_TOTAL && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- total hitroll %d out of range (limit +/-%d).\r\n", tohit,
-                        MAX_APPLY_HITROLL_TOTAL);
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "- total hitroll %d out of range (limit +/-%d).\r\n", tohit,
+                              MAX_APPLY_HITROLL_TOTAL);
 
       /*for (ext2 = NULL, ext = obj->ex_description; ext; ext = ext->next)
         if (strncmp(ext->description, "   ", 3))
@@ -6053,17 +6058,17 @@ ACMD(do_zcheck)
         for (k = 0; offlimit_zones[k] != -1; k++)
         {
           if (world[exroom].zone == real_zone(offlimit_zones[k]) && (found = 1))
-            len += snprintf(buf + len, sizeof(buf) - len,
-                            "- Exit %s cannot connect to %d (zone off limits).\r\n", dirs[j],
-                            world[exroom].number);
+            len = snprintf_append(buf, sizeof(buf), len,
+                                  "- Exit %s cannot connect to %d (zone off limits).\r\n", dirs[j],
+                                  world[exroom].number);
         } /* for (k.. */
       } /* cycle directions */
 
       if (ROOM_FLAGGED(i, ROOM_ATRIUM) || ROOM_FLAGGED(i, ROOM_HOUSE) ||
           ROOM_FLAGGED(i, ROOM_HOUSE_CRASH) || ROOM_FLAGGED(i, ROOM_OLC) ||
           ROOM_FLAGGED(i, ROOM_BFS_MARK))
-        len += snprintf(
-            buf + len, sizeof(buf) - len, "- Has illegal affection bits set (%s %s %s %s %s)\r\n",
+        len = snprintf_append(
+            buf, sizeof(buf), len, "- Has illegal affection bits set (%s %s %s %s %s)\r\n",
             ROOM_FLAGGED(i, ROOM_ATRIUM) ? "ATRIUM" : "",
             ROOM_FLAGGED(i, ROOM_HOUSE) ? "HOUSE" : "",
             ROOM_FLAGGED(i, ROOM_HOUSE_CRASH) ? "HCRSH" : "",
@@ -6071,19 +6076,22 @@ ACMD(do_zcheck)
 
       if ((MIN_ROOM_DESC_LENGTH) && strlen(world[i].description) < MIN_ROOM_DESC_LENGTH &&
           (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- Room description is too short. (%4.4d of min. %d characters).\r\n",
-                        (int)strlen(world[i].description), MIN_ROOM_DESC_LENGTH);
+        len = snprintf_append(
+            buf, sizeof(buf), len,
+            "- Room description is too short. (%4.4d of min. %d characters).\r\n",
+            (int)strlen(world[i].description), MIN_ROOM_DESC_LENGTH);
 
       if (strncmp(world[i].description, "   ", 3) && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- Room description not formatted with indent (/fi in the editor).\r\n");
+        len = snprintf_append(
+            buf, sizeof(buf), len,
+            "- Room description not formatted with indent (/fi in the editor).\r\n");
 
       /* strcspan = size of text in first arg before any character in second arg */
       if ((strcspn(world[i].description, "\r\n") > MAX_COLUMN_WIDTH) && (found = 1))
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "- Room description not wrapped at %d chars (/fi in the editor).\r\n",
-                        MAX_COLUMN_WIDTH);
+        len = snprintf_append(
+            buf, sizeof(buf), len,
+            "- Room description not wrapped at %d chars (/fi in the editor).\r\n",
+            MAX_COLUMN_WIDTH);
 
       /*for (ext2 = NULL, ext = world[i].ex_description; ext; ext = ext->next)
         if (strncmp(ext->description, "   ", 3))
@@ -6440,7 +6448,7 @@ static bool validate_copyover_environment()
   }
 
   /* Check if we can create files in current directory */
-  FILE *test = fopen("copyover.test", "w");
+  FILE *test = fopen_restricted("copyover.test", "w");
   if (!test)
   {
     log("SYSERR: copyover: Cannot create files in current directory: %s", strerror(errno));
@@ -6530,7 +6538,7 @@ void perform_do_copyover()
   /* Update state to writing */
   copyover_status = COPYOVER_WRITING;
 
-  fp = fopen(temp_file, "w");
+  fp = fopen_restricted(temp_file, "w");
   if (!fp)
   {
     log("SYSERR: Copyover temp file not writeable: %s", strerror(errno));
@@ -7635,7 +7643,7 @@ ACMD(do_changelog)
     return;
   }
 
-  if (!(new = fopen(CHANGE_LOG_FILE, "w")))
+  if (!(new = fopen_restricted(CHANGE_LOG_FILE, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: Error opening new changelog file (%s)", CHANGE_LOG_FILE);
     return;
@@ -7653,7 +7661,7 @@ ACMD(do_changelog)
   }
 
   rawtime = time(0);
-  strftime(tmstr, sizeof(tmstr), "%b %d %Y", localtime(&rawtime));
+  format_time_string(rawtime, "%b %d %Y", tmstr, sizeof(tmstr));
 
   snprintf(buf, sizeof(buf), "[%s] - %s", tmstr, GET_NAME(ch));
 
@@ -7739,10 +7747,10 @@ ACMD(do_plist)
   }
 
   len = 0;
-  len += snprintf(buf + len, sizeof(buf) - len,
-                  "\tW[ Id] (Lv) Name         Last\tn\r\n"
-                  "%s-------------------------------------%s\r\n",
-                  CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
+  len = snprintf_append(buf, sizeof(buf), len,
+                        "\tW[ Id] (Lv) Name         Last\tn\r\n"
+                        "%s-------------------------------------%s\r\n",
+                        CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
 
   for (i = 0; i <= top_of_p_table; i++)
   {
@@ -7761,15 +7769,15 @@ ACMD(do_plist)
 
     format_time_string(player_table[i].last, "%c", time_str, sizeof(time_str));
 
-    len += snprintf(buf + len, sizeof(buf) - len, "[%3ld] (%2d) %c%-15s %s\r\n", player_table[i].id,
-                    player_table[i].level, UPPER(*player_table[i].name), player_table[i].name + 1,
-                    time_str);
+    len = snprintf_append(buf, sizeof(buf), len, "[%3ld] (%2d) %c%-15s %s\r\n",
+                          player_table[i].id, player_table[i].level,
+                          UPPER(*player_table[i].name), player_table[i].name + 1, time_str);
     count++;
   }
-  snprintf(buf + len, sizeof(buf) - len,
-           "%s-------------------------------------%s\r\n"
-           "%d players listed.\r\n",
-           CCCYN(ch, C_NRM), CCNRM(ch, C_NRM), count);
+  len = snprintf_append(buf, sizeof(buf), len,
+                        "%s-------------------------------------%s\r\n"
+                        "%d players listed.\r\n",
+                        CCCYN(ch, C_NRM), CCNRM(ch, C_NRM), count);
   page_string(ch->desc, buf, TRUE);
 }
 
@@ -8141,8 +8149,7 @@ bool AddRecentPlayer(char *chname, char *chhost, bool newplr, bool cpyplr)
   this->new_player = newplr;
   this->copyover_player = cpyplr;
   strlcpy(this->host, chhost ? chhost : "", sizeof(this->host));
-  if (chname)
-    strlcpy(this->name, chname, sizeof(this->name));
+  strlcpy(this->name, chname, sizeof(this->name));
   max_vnum = get_max_recent();
   this->vnum = max_vnum; /* Possibly should be +1 ? */
 
@@ -9443,7 +9450,7 @@ ACMD(do_eqrating)
 
   int i = 0, j = 0;         /* counter */
   int a = 0, b = 0;         /* used for sorting */
-  int len = 0, tmp_len = 0; /* string length */
+  int len = 0; /* string length */
   int wearloc = 0;          /* the wear-location of item */
 
   zone_vnum zone = 0;                           /* zone vnum to restrict search */
@@ -9567,36 +9574,31 @@ ACMD(do_eqrating)
 
     /* start building our string, begin with listing vnum, score, and short
      description */
-    tmp_len =
-        snprintf(buf + len, sizeof(buf) - len, "%7ld | %5d | %-45s | ", (long int)obj_index[a].vnum,
-                 get_eq_score(a), obj_proto[a].short_description);
-    len += tmp_len;
+    len = snprintf_append(buf, sizeof(buf), len, "%7ld | %5d | %-45s | ",
+                          (long int)obj_index[a].vnum, get_eq_score(a),
+                          obj_proto[a].short_description);
 
     /* now, if we have a weapon, display dice */
     if (GET_OBJ_TYPE(&obj_proto[a]) == ITEM_WEAPON)
     {
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "%dD%d | ", GET_OBJ_VAL(&obj_proto[a], 1),
-                         GET_OBJ_VAL(&obj_proto[a], 2));
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "%dD%d | ", GET_OBJ_VAL(&obj_proto[a], 1),
+                            GET_OBJ_VAL(&obj_proto[a], 2));
     }
 
     if (CAN_WEAR(&obj_proto[a], ITEM_WEAR_SHIELD))
     { /* shield weight */
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "wt %d | ", GET_OBJ_WEIGHT(&obj_proto[a]));
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "wt %d | ", GET_OBJ_WEIGHT(&obj_proto[a]));
     }
 
     if (GET_OBJ_TYPE(&obj_proto[a]) == ITEM_ARMOR)
     { /* ac-apply */
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "AC %d | ", GET_OBJ_VAL(&obj_proto[a], 0));
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "AC %d | ", GET_OBJ_VAL(&obj_proto[a], 0));
     }
 
     if (GET_OBJ_AFFECT(&obj_proto[a]))
     { /* perm affects */
       sprintbitarray(GET_OBJ_AFFECT(&obj_proto[a]), affected_bits, AF_ARRAY_MAX, bitbuf);
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "%s | ", bitbuf);
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "%s | ", bitbuf);
     }
 
     *bitbuf = '\0';
@@ -9610,21 +9612,18 @@ ACMD(do_eqrating)
       if ((obj->affected[b].location != APPLY_NONE) && (obj->affected[b].modifier != 0))
       {
         sprinttype(obj->affected[b].location, apply_types, bitbuf, sizeof(bitbuf));
-        tmp_len =
-            snprintf(buf + len, sizeof(buf) - len, "%s %d ", bitbuf, obj->affected[b].modifier);
-        len += tmp_len;
+        len = snprintf_append(buf, sizeof(buf), len, "%s %d ", bitbuf,
+                              obj->affected[b].modifier);
       }
     }
 
-    tmp_len = snprintf(buf + len, sizeof(buf) - len, "|\r\n");
-    len += tmp_len;
+    len = snprintf_append(buf, sizeof(buf), len, "|\r\n");
 
     /* yeah we have to cap things, wish i had a better solution at this stage!
      -zusuk */
     if (i >= 350)
     {
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "\r\n**OVERLOADED BUFF***\r\n");
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "\r\n**OVERLOADED BUFF***\r\n");
       break;
     }
   }

--- a/src/aedit.c
+++ b/src/aedit.c
@@ -218,7 +218,7 @@ static void aedit_save_to_disk(struct descriptor_data *d __attribute__((unused))
   FILE *fp;
   int i;
   char buf[MAX_STRING_LENGTH] = {'\0'};
-  if (!(fp = fopen(SOCMESS_FILE_NEW, "w+")))
+  if (!(fp = fopen_restricted(SOCMESS_FILE_NEW, "w+")))
   {
     char error[MAX_STRING_LENGTH] = {'\0'};
     snprintf(error, sizeof(error), "Can't open socials file '%s'", SOCMESS_FILE);
@@ -237,25 +237,25 @@ static void aedit_save_to_disk(struct descriptor_data *d __attribute__((unused))
              ((soc_mess_list[i].others_no_arg) ? soc_mess_list[i].others_no_arg : "#"),
              ((soc_mess_list[i].char_found) ? soc_mess_list[i].char_found : "#"),
              ((soc_mess_list[i].others_found) ? soc_mess_list[i].others_found : "#"));
-    fprintf(fp, convert_from_tabs(buf), 0);
+    fprintf(fp, "%s", convert_from_tabs(buf));
 
     snprintf(buf, sizeof(buf), "%s\n%s\n%s\n%s\n",
              ((soc_mess_list[i].vict_found) ? soc_mess_list[i].vict_found : "#"),
              ((soc_mess_list[i].not_found) ? soc_mess_list[i].not_found : "#"),
              ((soc_mess_list[i].char_auto) ? soc_mess_list[i].char_auto : "#"),
              ((soc_mess_list[i].others_auto) ? soc_mess_list[i].others_auto : "#"));
-    fprintf(fp, convert_from_tabs(buf), 0);
+    fprintf(fp, "%s", convert_from_tabs(buf));
 
     snprintf(buf, sizeof(buf), "%s\n%s\n%s\n",
              ((soc_mess_list[i].char_body_found) ? soc_mess_list[i].char_body_found : "#"),
              ((soc_mess_list[i].others_body_found) ? soc_mess_list[i].others_body_found : "#"),
              ((soc_mess_list[i].vict_body_found) ? soc_mess_list[i].vict_body_found : "#"));
-    fprintf(fp, convert_from_tabs(buf), 0);
+    fprintf(fp, "%s", convert_from_tabs(buf));
 
     snprintf(buf, sizeof(buf), "%s\n%s\n\n",
              ((soc_mess_list[i].char_obj_found) ? soc_mess_list[i].char_obj_found : "#"),
              ((soc_mess_list[i].others_obj_found) ? soc_mess_list[i].others_obj_found : "#"));
-    fprintf(fp, convert_from_tabs(buf), 0);
+    fprintf(fp, "%s", convert_from_tabs(buf));
   }
 
   fprintf(fp, "$\n");

--- a/src/assign_wpn_armor.c
+++ b/src/assign_wpn_armor.c
@@ -1808,17 +1808,17 @@ ACMD(do_weaponlist_old)
     sprintbit(weapon_list[type].weaponFlags, weapon_flags, buf2, sizeof(buf2));
     sprintbit(weapon_list[type].damageTypes, weapon_damage_types, buf3, sizeof(buf3));
 
-    len += snprintf(buf + len, sizeof(buf) - len,
-                    "\tW%s\tn, Dam: %dd%d, Threat: %d, Crit-Multi: %d, Flags: %s, Cost: %d, "
-                    "Dam-Types: %s, Weight: %d, Range: %d, Family: %s, Size: %s, Material: %s, "
-                    "Handle: %s, Head: %s.\r\n",
-                    weapon_list[type].name, weapon_list[type].numDice, weapon_list[type].diceSize,
-                    (20 - weapon_list[type].critRange), crit_multi, buf2, weapon_list[type].cost,
-                    buf3, weapon_list[type].weight, weapon_list[type].range,
-                    weapon_family[weapon_list[type].weaponFamily], sizes[weapon_list[type].size],
-                    material_name[weapon_list[type].material],
-                    weapon_handle_types[weapon_list[type].handle_type],
-                    weapon_head_types[weapon_list[type].head_type]);
+    len = snprintf_append(
+        buf, sizeof(buf), len,
+        "\tW%s\tn, Dam: %dd%d, Threat: %d, Crit-Multi: %d, Flags: %s, Cost: %d, "
+        "Dam-Types: %s, Weight: %d, Range: %d, Family: %s, Size: %s, Material: %s, "
+        "Handle: %s, Head: %s.\r\n",
+        weapon_list[type].name, weapon_list[type].numDice, weapon_list[type].diceSize,
+        (20 - weapon_list[type].critRange), crit_multi, buf2, weapon_list[type].cost, buf3,
+        weapon_list[type].weight, weapon_list[type].range,
+        weapon_family[weapon_list[type].weaponFamily], sizes[weapon_list[type].size],
+        material_name[weapon_list[type].material], weapon_handle_types[weapon_list[type].handle_type],
+        weapon_head_types[weapon_list[type].head_type]);
   }
   page_string(ch->desc, buf, 1);
 }
@@ -1832,14 +1832,14 @@ ACMD(do_armorlist_old)
 
   for (i = 1; i < NUM_SPEC_ARMOR_TYPES; i++)
   {
-    len += snprintf(buf + len, sizeof(buf) - len,
-                    "\tW%s\tn, Type: %s, Cost: %d, "
-                    "AC: %.1f, Max Dex: %d, Armor Penalty: %d, Spell Fail: %d, Weight: %d, "
-                    "Material: %s\r\n",
-                    armor_list[i].name, armor_type[armor_list[i].armorType], armor_list[i].cost,
-                    (float)armor_list[i].armorBonus / 10.0, armor_list[i].dexBonus,
-                    armor_list[i].armorCheck, armor_list[i].spellFail, armor_list[i].weight,
-                    material_name[armor_list[i].material]);
+    len = snprintf_append(buf, sizeof(buf), len,
+                          "\tW%s\tn, Type: %s, Cost: %d, "
+                          "AC: %.1f, Max Dex: %d, Armor Penalty: %d, Spell Fail: %d, Weight: %d, "
+                          "Material: %s\r\n",
+                          armor_list[i].name, armor_type[armor_list[i].armorType],
+                          armor_list[i].cost, (float)armor_list[i].armorBonus / 10.0,
+                          armor_list[i].dexBonus, armor_list[i].armorCheck, armor_list[i].spellFail,
+                          armor_list[i].weight, material_name[armor_list[i].material]);
   }
   page_string(ch->desc, buf, 1);
 }

--- a/src/ban.c
+++ b/src/ban.c
@@ -109,7 +109,7 @@ static void write_ban_list(void)
 {
   FILE *fl;
 
-  if (!(fl = fopen(BAN_FILE, "w")))
+  if (!(fl = fopen_restricted(BAN_FILE, "w")))
   {
     perror("SYSERR: Unable to open '" BAN_FILE "' for writing");
     return;

--- a/src/boards.c
+++ b/src/boards.c
@@ -248,7 +248,7 @@ int board_write_message(int board_type, struct char_data *ch, char *arg, struct 
     return (1);
   }
   ct = time(0);
-  strftime(tmstr, sizeof(tmstr), "%a %b %d %Y", localtime(&ct));
+  format_time_string(ct, "%a %b %d %Y", tmstr, sizeof(tmstr));
 
   snprintf(buf2, sizeof(buf2), "(%s)", GET_NAME(ch));
   snprintf(buf, sizeof(buf), "%s %-12s :: %s", tmstr, buf2, arg);
@@ -484,7 +484,7 @@ void board_save_board(int board_type)
     remove(FILENAME(board_type));
     return;
   }
-  if (!(fl = fopen(FILENAME(board_type), "wb")))
+  if (!(fl = fopen_restricted(FILENAME(board_type), "wb")))
   {
     perror("SYSERR: Error writing board");
     return;

--- a/src/cedit.c
+++ b/src/cedit.c
@@ -497,7 +497,7 @@ int save_config(IDXTYPE nowhere __attribute__((unused)))
   FILE *fl;
   char buf[MAX_STRING_LENGTH] = {'\0'};
 
-  if (!(fl = fopen(CONFIG_CONFFILE, "w")))
+  if (!(fl = fopen_restricted(CONFIG_CONFFILE, "w")))
   {
     perror("SYSERR: save_config");
     return (FALSE);
@@ -3430,7 +3430,12 @@ void cedit_parse(struct descriptor_data *d, char *arg)
     }
     break;
   case CEDIT_POPULARITY:
-    sscanf(arg, "%f", &f_num);
+    if (sscanf(arg, "%f", &f_num) != 1)
+    {
+      write_to_output(d, "Please enter a number from 0 to 100.\r\n");
+      cedit_disp_game_play_options(d);
+      break;
+    }
     OLC_CONFIG(d)->play.min_pop_to_claim = FLOATMIN(FLOATMAX(f_num, 0.0), 100.0);
     cedit_disp_game_play_options(d);
     break;

--- a/src/clan.c
+++ b/src/clan.c
@@ -876,14 +876,14 @@ void log_clan_activity(clan_vnum c, const char *format, ...)
   snprintf(filename, sizeof(filename), "%sclan_%d.log", CLAN_LOG_DIR, c);
 
   /* Open file in append mode */
-  if (!(fl = fopen(filename, "a")))
+  if (!(fl = fopen_restricted(filename, "a")))
   {
     /* Try to create the directory if it doesn't exist */
     if (!ensure_dir_exists(CLAN_LOG_DIR))
     {
       log("SYSERR: Failed to ensure clan_logs directory exists");
     }
-    if (!(fl = fopen(filename, "a")))
+    if (!(fl = fopen_restricted(filename, "a")))
     {
       log("SYSERR: Could not open clan log file %s", filename);
       return;
@@ -934,7 +934,7 @@ void log_clan_error(const char *function, const char *format, ...)
 
     snprintf(filename, sizeof(filename), "%sclan_errors.log", CLAN_LOG_DIR);
 
-    if ((fl = fopen(filename, "a")))
+    if ((fl = fopen_restricted(filename, "a")))
     {
       ct = time(0);
       format_time_string(ct, "%c", timestr, sizeof(timestr));
@@ -4124,11 +4124,11 @@ ACMD(do_clanstats)
   send_to_char(ch, "%sBasic Information:%s\r\n", QCYN, QNRM);
 
   /* Format date founded */
-  strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M", localtime(&clan->date_founded));
+  format_time_string(clan->date_founded, "%Y-%m-%d %H:%M", time_buf, sizeof(time_buf));
   send_to_char(ch, "  Founded: %s%s%s\r\n", QGRN, time_buf, QNRM);
 
   /* Format last activity */
-  strftime(time_buf, sizeof(time_buf), "%Y-%m-%d %H:%M", localtime(&clan->last_activity));
+  format_time_string(clan->last_activity, "%Y-%m-%d %H:%M", time_buf, sizeof(time_buf));
   send_to_char(ch, "  Last Activity: %s%s%s\r\n", QGRN, time_buf, QNRM);
 
   /* Financial Statistics */

--- a/src/clan_economy.c
+++ b/src/clan_economy.c
@@ -418,7 +418,7 @@ void save_clan_investments(void)
   FILE *fl;
   struct clan_investment *invest;
 
-  if (!(fl = fopen("etc/clan_investments", "w")))
+  if (!(fl = fopen_restricted("etc/clan_investments", "w")))
   {
     log("SYSERR: Cannot save clan investments!");
     return;

--- a/src/clan_edit.c
+++ b/src/clan_edit.c
@@ -57,7 +57,7 @@ void save_clans(void)
   int i, j, x;
   char buf[MAX_STRING_LENGTH] = {'\0'};
 
-  if (!(fl = fopen(CLAN_FILE, "w")))
+  if (!(fl = fopen_restricted(CLAN_FILE, "w")))
   {
     mudlog(CMP, LVL_IMPL, TRUE, "SYSERR: Unable to open clan file");
     return;
@@ -213,7 +213,7 @@ void save_single_clan(clan_rnum c)
   }
 
   /* Open temporary file for writing */
-  if (!(new_fl = fopen(tmpname, "w")))
+  if (!(new_fl = fopen_restricted(tmpname, "w")))
   {
     fclose(fl);
     log("SYSERR: Unable to open temporary clan file for writing");
@@ -577,7 +577,14 @@ void load_clans(void)
               }
               else
               {
-                sscanf(line, "%d %d", &priv, &lev);
+                if (sscanf(line, "%d %d", &priv, &lev) != 2)
+                {
+                  log("SYSERR: Invalid privilege line in clan file (clan ID: %d, rank line %d)",
+                      c.vnum, j + 1);
+                  get_line(fl, line);
+                  j++;
+                  continue;
+                }
                 if (priv >= 21 || priv < 0)
                 {
                   log("SYSERR: Invalid priv in clan file (clan ID: %d, "
@@ -702,7 +709,7 @@ bool save_claims(void)
   int i;
   struct claim_data *this_claim;
 
-  if (!(fl = fopen(CLAIMS_FILE, "w")))
+  if (!(fl = fopen_restricted(CLAIMS_FILE, "w")))
   {
     mudlog(CMP, LVL_IMPL, TRUE, "SYSERR: Unable to open claims file");
     return FALSE;
@@ -813,8 +820,15 @@ void load_claims(void)
               }
               else
               {
-                sscanf(line, "%d %f", &cn, &pop);
-                if (pop >= 100.0 || pop < 0.0)
+                if (sscanf(line, "%d %f", &cn, &pop) != 2)
+                {
+                  log("SYSERR: Invalid popularity line in claims file (zone ID: %d, line %d)",
+                      c.zn, j + 1);
+                  get_line(fl, line);
+                  j++;
+                  continue;
+                }
+                if (cn < 0 || cn >= MAX_CLANS || pop >= 100.0 || pop < 0.0)
                 {
                   log("SYSERR: Invalid popularity value in claims file "
                       "(zone ID: %d, popularity line %d, clan=%d, "

--- a/src/class.c
+++ b/src/class.c
@@ -1019,12 +1019,12 @@ bool display_class_info(struct char_data *ch, const char *classname)
     {
       if (first_skill)
       {
-        len += snprintf(buf + len, sizeof(buf) - len, "\tcClass Skills:\tn  %s", ability_names[i]);
+        len = snprintf_append(buf, sizeof(buf), len, "\tcClass Skills:\tn  %s", ability_names[i]);
         first_skill = FALSE;
       }
       else
       {
-        len += snprintf(buf + len, sizeof(buf) - len, ", %s", ability_names[i]);
+        len = snprintf_append(buf, sizeof(buf), len, ", %s", ability_names[i]);
       }
     }
   }
@@ -1135,8 +1135,8 @@ void display_imm_classlist(struct char_data *ch)
 
   for (i = 0; i < NUM_CLASSES; i++)
   {
-    len += snprintf(
-        buf + len, sizeof(buf) - len,
+    len = snprintf_append(
+        buf, sizeof(buf), len,
         "\r\n%d] %s %s %s | %s | %d %s %s %s %d %d %d %s %d %d %s\r\n     %s\r\n"
         "  %s %s %s\r\n"
         "     %s %s %s %s %s %s %s\r\n"
@@ -1214,10 +1214,9 @@ void display_imm_classlist(struct char_data *ch)
                                                 : (CLSLIST_ABIL(i, ABILITY_PERFORM) ? "CC" : "NA"));
     for (j = 0; j < MAX_NUM_TITLES; j++)
     {
-      len += snprintf(buf + len, sizeof(buf) - len, "%s\r\n", CLSLIST_TITLE(i, j));
+      len = snprintf_append(buf, sizeof(buf), len, "%s\r\n", CLSLIST_TITLE(i, j));
     }
-    len +=
-        snprintf(buf + len, sizeof(buf) - len, "============================================\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "============================================\r\n");
   }
   page_string(ch->desc, buf, 1);
 }

--- a/src/comm.c
+++ b/src/comm.c
@@ -511,17 +511,18 @@ void copyover_recover()
   {
     fOld = TRUE;
     i = fscanf(fp, "%d %ld %511s %1023s %1023s\n", &desc, &pref, name, host, guiopt);
-    if (desc == -1)
+    if (i >= 1 && desc == -1)
     {
       COPYOVER_DEBUG("copyover_recover: Found end marker (-1), finishing recovery");
       break;
     }
-
     if (i != 5)
     {
       log("SYSERR: copyover_recover: Invalid line format in copyover file (read %d values, "
           "expected 5)",
           i);
+      if (i == EOF)
+        break;
       continue;
     }
 
@@ -2346,7 +2347,7 @@ size_t vwrite_to_output(struct descriptor_data *t, const char *format, va_list a
   wantsize = size = vsnprintf(txt, sizeof(txt), format, args);
 
   /* this block is Kavir's protocol */
-  strcpy(txt, ProtocolOutput(t, txt, (int *)&wantsize));
+  strlcpy(txt, ProtocolOutput(t, txt, (int *)&wantsize), sizeof(txt));
   size = wantsize;
   if (t->pProtocol->WriteOOB > 0)
     --t->pProtocol->WriteOOB;
@@ -2355,7 +2356,8 @@ size_t vwrite_to_output(struct descriptor_data *t, const char *format, va_list a
   if (size < 0 || wantsize >= sizeof(txt))
   {
     size = sizeof(txt) - 1;
-    strcpy(txt + size - strlen(text_overflow), text_overflow); /* strcpy: OK */
+    strlcpy(txt + size - strlen(text_overflow), text_overflow,
+            sizeof(txt) - (size - strlen(text_overflow)));
   }
 
   /* If the text is too big to fit into even a large buffer, truncate
@@ -2661,10 +2663,10 @@ static int process_output(struct descriptor_data *t)
   int result;
 
   /* we may need this \r\n for later -- see below */
-  strcpy(i, "\r\n"); /* strcpy: OK (for 'MAX_SOCK_BUF >= 3') */
+  strlcpy(i, "\r\n", sizeof(i));
 
   /* now, append the 'real' output */
-  strcpy(osb, t->output); /* strcpy: OK (t->output:LARGE_BUFSIZE < osb:MAX_SOCK_BUF-2) */
+  strlcpy(osb, t->output, sizeof(i) - 2);
 
   // color code fix attempt -zusuk
   // parse_at(osb);
@@ -2677,7 +2679,7 @@ static int process_output(struct descriptor_data *t)
   else*/
   if (t->bufspace == 0)
   {
-    strcat(osb, "**OVERFLOW**");
+    strlcat(osb, "**OVERFLOW**", sizeof(i) - 2);
   }
 
   /* add the extra CRLF if the person isn't in compact mode */
@@ -2685,11 +2687,11 @@ static int process_output(struct descriptor_data *t)
       !PRF_FLAGGED(t->character, PRF_COMPACT))
   {
     if (!t->pProtocol->WriteOOB)
-      strcat(osb, "\r\n"); /* strcpy: OK (osb:MAX_SOCK_BUF-2 reserves space) */
+      strlcat(osb, "\r\n", sizeof(i) - 2);
   }
 
   if (!t->pProtocol->WriteOOB) /* add a prompt */
-    strcat(i, make_prompt(t)); /* strcpy: OK (i:MAX_SOCK_BUF reserves space) */
+    strlcat(i, make_prompt(t), sizeof(i));
 
   /* now, send the output.  If this is an 'interruption', use the prepended
    * CRLF, otherwise send the straight output sans CRLF. */
@@ -4161,7 +4163,7 @@ static int open_logfile(const char *filename, FILE *stderr_fp)
   if (stderr_fp) /* freopen() the descriptor. */
     logfile = freopen(filename, "w", stderr_fp);
   else
-    logfile = fopen(filename, "w");
+    logfile = fopen_restricted(filename, "w");
 
   if (logfile)
   {

--- a/src/comm.c
+++ b/src/comm.c
@@ -2374,7 +2374,7 @@ size_t vwrite_to_output(struct descriptor_data *t, const char *format, va_list a
    * text just barely fits, then it's switched to a large buffer instead. */
   if (t->bufspace > size)
   {
-    strcpy(t->output + t->bufptr, txt); /* strcpy: OK (size checked above) */
+    strlcpy(t->output + t->bufptr, txt, t->bufspace);
     t->bufspace -= size;
     t->bufptr += size;
     return (t->bufspace);
@@ -2413,13 +2413,12 @@ size_t vwrite_to_output(struct descriptor_data *t, const char *format, va_list a
    * "Source and destination overlap in strcpy" was reported. */
   if (t->output != t->large_outbuf->text)
   {
-    /* Source and destination are different - safe to use strcpy */
-    strcpy(t->large_outbuf->text, t->output); /* strcpy: OK (no overlap) */
+    strlcpy(t->large_outbuf->text, t->output, LARGE_BUFSIZE);
   }
   /* else: source and destination are the same - no copy needed, data already there */
 
   t->output = t->large_outbuf->text; /* make big buffer primary */
-  strcat(t->output, txt);            /* strcat: OK (size checked) */
+  strlcat(t->output, txt, LARGE_BUFSIZE);
 
   /* set the pointer for the next write */
   t->bufptr = strlen(t->output);

--- a/src/copyover_diagnostic.c
+++ b/src/copyover_diagnostic.c
@@ -104,10 +104,9 @@ void init_copyover_diagnostics(void)
 {
   char timestamp[100];
   time_t now;
-  struct tm *tm_info;
 
   /* Open diagnostic log file in append mode */
-  diag_file = fopen(COPYOVER_DIAG_FILE, "a");
+  diag_file = fopen_restricted(COPYOVER_DIAG_FILE, "a");
   if (!diag_file)
   {
     log("SYSERR: Could not open copyover diagnostic file: %s", strerror(errno));
@@ -117,8 +116,7 @@ void init_copyover_diagnostics(void)
   /* Log start of copyover */
   now = time(NULL);
   copyover_start_time = now;
-  tm_info = localtime(&now);
-  strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", tm_info);
+  format_time_string(now, "%Y-%m-%d %H:%M:%S", timestamp, sizeof(timestamp));
 
   fprintf(diag_file, "\n========================================\n");
   fprintf(diag_file, "COPYOVER DIAGNOSTIC START: %s\n", timestamp);
@@ -142,15 +140,13 @@ void log_copyover_phase(const char *phase, const char *details)
 {
   char timestamp[100];
   time_t now;
-  struct tm *tm_info;
   FILE *state_file;
 
   if (!diag_file)
     return;
 
   now = time(NULL);
-  tm_info = localtime(&now);
-  strftime(timestamp, sizeof(timestamp), "%H:%M:%S", tm_info);
+  format_time_string(now, "%H:%M:%S", timestamp, sizeof(timestamp));
 
   fprintf(diag_file, "\n[%s] PHASE: %s\n", timestamp, phase);
   if (details)
@@ -164,7 +160,7 @@ void log_copyover_phase(const char *phase, const char *details)
   fflush(diag_file);
 
   /* Also write current state to a separate file for post-mortem analysis */
-  state_file = fopen(COPYOVER_LAST_STATE_FILE, "w");
+  state_file = fopen_restricted(COPYOVER_LAST_STATE_FILE, "w");
   if (state_file)
   {
     fprintf(state_file, "Last Phase: %s\n", phase);
@@ -302,14 +298,12 @@ void close_copyover_diagnostics(int success)
 {
   char timestamp[100];
   time_t now;
-  struct tm *tm_info;
 
   if (!diag_file)
     return;
 
   now = time(NULL);
-  tm_info = localtime(&now);
-  strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", tm_info);
+  format_time_string(now, "%Y-%m-%d %H:%M:%S", timestamp, sizeof(timestamp));
 
   fprintf(diag_file, "\n========================================\n");
   fprintf(diag_file, "COPYOVER DIAGNOSTIC END: %s\n", timestamp);

--- a/src/crafting_new.c
+++ b/src/crafting_new.c
@@ -9304,10 +9304,13 @@ int get_event_contract_availability(void)
 {
   // Simple time-based event system - events every 7 days
   time_t now = time(0);
-  struct tm *local = localtime(&now);
+  struct tm local;
+
+  if (!localtime_r(&now, &local))
+    return 0;
 
   // Event active on Sundays (day 0)
-  return (local->tm_wday == 0) ? 1 : 0;
+  return (local.tm_wday == 0) ? 1 : 0;
 }
 
 bool is_special_event_active(void)

--- a/src/crafts.c
+++ b/src/crafts.c
@@ -225,7 +225,7 @@ static void save_crafts_to_disk(void)
   struct requirement_data *r;
   struct iterator_data Iterator;
 
-  if ((fp = fopen(CRAFT_FILE, "w")) == NULL)
+  if ((fp = fopen_restricted(CRAFT_FILE, "w")) == NULL)
   {
     log("Cannot open craft file for writing!");
     return;

--- a/src/db.c
+++ b/src/db.c
@@ -1550,7 +1550,7 @@ void save_mud_time(struct time_info_data *when)
 {
   FILE *bgtime;
 
-  if ((bgtime = fopen(TIME_FILE, "w")) == NULL)
+  if ((bgtime = fopen_restricted(TIME_FILE, "w")) == NULL)
     log("SYSERR: Can't write to '%s' time file.", TIME_FILE);
   else
   {
@@ -1684,6 +1684,11 @@ void index_boot(int mode)
   }
   while (*buf1 != '$')
   {
+    if (!is_safe_path_component(buf1))
+    {
+      log("SYSERR: Unsafe data filename '%s' in index '%s'.", buf1, index_filename);
+      exit(1);
+    }
     strlcpy(buf2, prefix, sizeof(buf2));
     if (strlcat(buf2, buf1, sizeof(buf2)) >= sizeof(buf2))
     {
@@ -1790,6 +1795,11 @@ void index_boot(int mode)
   }
   while (*buf1 != '$')
   {
+    if (!is_safe_path_component(buf1))
+    {
+      log("SYSERR: Unsafe data filename '%s' in index '%s'.", buf1, index_filename);
+      exit(1);
+    }
     strlcpy(buf2, prefix, sizeof(buf2));
     if (strlcat(buf2, buf1, sizeof(buf2)) >= sizeof(buf2))
     {
@@ -2895,6 +2905,7 @@ static void parse_simple_mob(FILE *mob_f, int i, int nr)
 #define CASE(test) if (value && !matched && !str_cmp(keyword, test) && (matched = TRUE))
 #define BOOL_CASE(test) if (!value && !matched && !str_cmp(keyword, test) && (matched = TRUE))
 #define RANGE(low, high) (num_arg = MAX((low), MIN((high), (num_arg))))
+#define MAX_MOB_ECHOES 20
 
 static void interpret_espec(const char *keyword, const char *value, int i, int nr)
 {
@@ -3017,13 +3028,21 @@ static void interpret_espec(const char *keyword, const char *value, int i, int n
 
   CASE("MFeat")
   {
-    sscanf(value, "%d %d", &num, &num2);
+    if (sscanf(value, "%d %d", &num, &num2) != 2)
+    {
+      log("SYSERR: Mob #%d has invalid MFeat data: %s", nr, value);
+      return;
+    }
     MOB_SET_FEAT(mob_proto + i, num, num2);
   }
 
   CASE("Aff2")
   {
-    sscanf(value, "%d %d %d %d", &num, &num2, &num3, &num4);
+    if (sscanf(value, "%d %d %d %d", &num, &num2, &num3, &num4) != 4)
+    {
+      log("SYSERR: Mob #%d has invalid Aff2 data: %s", nr, value);
+      return;
+    }
     AFF2_FLAGS(mob_proto + i)[0] = num;
     AFF2_FLAGS(mob_proto + i)[1] = num2;
     AFF2_FLAGS(mob_proto + i)[2] = num3;
@@ -3207,7 +3226,11 @@ static void interpret_espec(const char *keyword, const char *value, int i, int n
 
   CASE("Feat")
   {
-    sscanf(value, "%d %d", &num, &num2);
+    if (sscanf(value, "%d %d", &num, &num2) != 2)
+    {
+      log("SYSERR: Mob #%d has invalid Feat data: %s", nr, value);
+      return;
+    }
     SET_FEAT(mob_proto + i, num, num2);
   }
 
@@ -3241,10 +3264,9 @@ static void interpret_espec(const char *keyword, const char *value, int i, int n
 
   CASE("EchoCount")
   {
-    // RANGE(0, 20);
-    // ECHO_COUNT(mob_proto + i) = num_arg;
-    // ECHO_ENTRIES(mob_proto + i) = new char*[num_arg];
-    CREATE(ECHO_ENTRIES(mob_proto + i), char *, num_arg);
+    RANGE(0, MAX_MOB_ECHOES);
+    if (num_arg > 0)
+      CREATE(ECHO_ENTRIES(mob_proto + i), char *, MAX_MOB_ECHOES);
   }
 
   CASE("EchoSequential")
@@ -3255,10 +3277,15 @@ static void interpret_espec(const char *keyword, const char *value, int i, int n
 
   CASE("Echo")
   {
-    ECHO_ENTRIES(mob_proto + i)
-    [ECHO_COUNT(mob_proto + i)] = strdup(value);
-    ECHO_COUNT(mob_proto + i)
-    ++;
+    if (ECHO_ENTRIES(mob_proto + i) && ECHO_COUNT(mob_proto + i) < MAX_MOB_ECHOES)
+    {
+      ECHO_ENTRIES(mob_proto + i)[ECHO_COUNT(mob_proto + i)] = strdup(value);
+      ECHO_COUNT(mob_proto + i)++;
+    }
+    else
+    {
+      log("SYSERR: Mob #%d has more than %d echo entries.", nr, MAX_MOB_ECHOES);
+    }
   }
 
   CASE("Path")
@@ -3343,9 +3370,11 @@ static void parse_enhanced_mob(FILE *mob_f, int i, int nr)
 void parse_mobile(FILE *mob_f, int nr)
 {
   static int i = 0;
-  int j, t[10], retval, counter;
-  char line[READ_SIZE], *tmpptr, letter;
-  char f1[128], f2[128], f3[128], f4[128], f5[128], f6[128], f7[128], f8[128], buf2[128];
+  int j, t[10] = {0}, retval, counter;
+  char line[READ_SIZE], *tmpptr, letter = '\0';
+  char f1[128] = {'\0'}, f2[128] = {'\0'}, f3[128] = {'\0'}, f4[128] = {'\0'};
+  char f5[128] = {'\0'}, f6[128] = {'\0'}, f7[128] = {'\0'}, f8[128] = {'\0'};
+  char buf2[128] = {'\0'};
   //  char walk[MAX_STRING_LENGTH] = {'\0'};
   //  char *message;
 
@@ -7696,12 +7725,13 @@ void load_config(void)
         CONFIG_HOLLER_MOVE_COST = num;
       else if (!str_cmp(tag, "huh"))
       {
+        char *replacement = NULL;
         size_t len = strlen(line);
 
-        if (CONFIG_HUH)
-          free(CONFIG_HUH);
-        CREATE(CONFIG_HUH, char, len + 3);
-        snprintf(CONFIG_HUH, len + 3, "%s\r\n", line);
+        CREATE(replacement, char, len + 3);
+        snprintf(replacement, len + 3, "%s\r\n", line);
+        free(CONFIG_HUH);
+        CONFIG_HUH = replacement;
       }
       else if (!str_cmp(tag, "happy_hour_chance"))
         CONFIG_HAPPY_HOUR_CHANCE = num;
@@ -7852,30 +7882,36 @@ void load_config(void)
         CONFIG_NO_MORT_TO_IMMORT = num;
       else if (!str_cmp(tag, "noperson"))
       {
+        char *replacement = NULL;
         size_t len = strlen(line);
-        if (CONFIG_NOPERSON)
-          free(CONFIG_NOPERSON);
-        CREATE(CONFIG_NOPERSON, char, len + 4);
-        sprintf(CONFIG_NOPERSON, "%s\r\n", line);
+
+        CREATE(replacement, char, len + 3);
+        snprintf(replacement, len + 3, "%s\r\n", line);
+        free(CONFIG_NOPERSON);
+        CONFIG_NOPERSON = replacement;
       }
       else if (!str_cmp(tag, "noeffect"))
       {
+        char *replacement = NULL;
         size_t len = strlen(line);
-        if (CONFIG_NOEFFECT)
-          free(CONFIG_NOEFFECT);
-        CREATE(CONFIG_NOEFFECT, char, len + 4);
-        sprintf(CONFIG_NOEFFECT, "%s\r\n", line);
+
+        CREATE(replacement, char, len + 3);
+        snprintf(replacement, len + 3, "%s\r\n", line);
+        free(CONFIG_NOEFFECT);
+        CONFIG_NOEFFECT = replacement;
       }
       break;
 
     case 'o':
       if (!str_cmp(tag, "ok"))
       {
+        char *replacement = NULL;
         size_t len = strlen(line);
-        if (CONFIG_OK)
-          free(CONFIG_OK);
-        CREATE(CONFIG_OK, char, len + 4);
-        sprintf(CONFIG_OK, "%s\r\n", line);
+
+        CREATE(replacement, char, len + 3);
+        snprintf(replacement, len + 3, "%s\r\n", line);
+        free(CONFIG_OK);
+        CONFIG_OK = replacement;
       }
       break;
 

--- a/src/db.c
+++ b/src/db.c
@@ -2066,8 +2066,8 @@ void parse_room(FILE *fl, int virtual_nr, const char *filename)
     exit(1);
   }
 
-  if (((retval = sscanf(line, " %d %s %s %s %s %d ", t, flags, flags2, flags3, flags4, t + 2)) ==
-       3) &&
+  if (((retval = sscanf(line, " %d %127s %127s %127s %127s %d ", t, flags, flags2, flags3,
+                        flags4, t + 2)) == 3) &&
       (bitwarning == TRUE))
   {
     log("WARNING: Conventional world files detected. See config.c.");
@@ -2321,7 +2321,7 @@ void setup_moving_room(FILE *fl, int rroom, int vroom, char *line)
   }
   if (lineIn[0] != '~')
   {
-    strcpy(msg1, lineIn);
+    strlcpy(msg1, lineIn, sizeof(msg1));
   }
 
   if (!get_line(fl, lineIn))
@@ -2331,7 +2331,7 @@ void setup_moving_room(FILE *fl, int rroom, int vroom, char *line)
   }
   if (lineIn[0] != '~')
   {
-    strcpy(msg2, lineIn);
+    strlcpy(msg2, lineIn, sizeof(msg2));
   }
 
   if (!get_line(fl, lineIn))
@@ -2341,7 +2341,7 @@ void setup_moving_room(FILE *fl, int rroom, int vroom, char *line)
   }
   if (lineIn[0] != '~')
   {
-    strcpy(msg3, lineIn);
+    strlcpy(msg3, lineIn, sizeof(msg3));
   }
 
   if (!get_line(fl, lineIn))
@@ -3410,8 +3410,8 @@ void parse_mobile(FILE *mob_f, int nr)
     exit(1);
   }
 
-  if (((retval = sscanf(line, "%s %s %s %s %s %s %s %s %d %c", f1, f2, f3, f4, f5, f6, f7, f8,
-                        t + 2, &letter)) != 10) &&
+  if (((retval = sscanf(line, "%127s %127s %127s %127s %127s %127s %127s %127s %d %c", f1, f2,
+                        f3, f4, f5, f6, f7, f8, t + 2, &letter)) != 10) &&
       (bitwarning == TRUE))
   {
     /* Let's make the implementor read some, before converting his world files. */
@@ -3602,8 +3602,11 @@ const char *parse_object(FILE *obj_f, int nr)
     exit(1);
   }
 
-  if (((retval = sscanf(line, " %d %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s", t, f1, f2, f3,
-                        f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16)) == 4) &&
+  if (((retval = sscanf(line,
+                        " %d %511s %511s %511s %511s %511s %511s %511s %511s %511s %511s %511s "
+                        "%511s %511s %511s %511s %511s",
+                        t, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15,
+                        f16)) == 4) &&
       (bitwarning == TRUE))
   {
     /* Let's make the implementor read some, before converting his world files. */
@@ -3928,8 +3931,8 @@ const char *parse_object(FILE *obj_f, int nr)
             buf2);
         exit(1);
       }
-      if ((retval = sscanf(line, "%d %d %d %d %d %d %d %s", t, t + 1, t + 2, t + 3, t + 4, t + 5,
-                           t + 6, f1)) < 7)
+      if ((retval = sscanf(line, "%d %d %d %d %d %d %d %511s", t, t + 1, t + 2, t + 3, t + 4,
+                           t + 5, t + 6, f1)) < 7)
       {
         log("SYSERR: Format error in 'C' field, %s\n"
             "...expecting 7 numeric arguments, got %d\n"
@@ -4184,17 +4187,19 @@ static void load_zones(FILE *fl, char *zonename)
           &Z.reset_mode, zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level, &Z.max_level,
           &Z.show_weather) != 11) {
    */
-  if (sscanf(buf, " %d %d %d %d %s %s %s %s %d %d %d %d %d %d", &Z.bot, &Z.top, &Z.lifespan,
-             &Z.reset_mode, zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level, &Z.max_level, &Z.show_weather,
-             &Z.region, &Z.faction, &Z.city) != 14)
+  if (sscanf(buf, " %d %d %d %d %511s %511s %511s %511s %d %d %d %d %d %d", &Z.bot, &Z.top,
+             &Z.lifespan, &Z.reset_mode, zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level, &Z.max_level,
+             &Z.show_weather, &Z.region, &Z.faction, &Z.city) != 14)
   {
     // not 14 values, lets try 11
-    if (sscanf(buf, " %d %d %d %d %s %s %s %s %d %d %d", &Z.bot, &Z.top, &Z.lifespan, &Z.reset_mode,
-               zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level, &Z.max_level, &Z.show_weather) != 11)
+    if (sscanf(buf, " %d %d %d %d %511s %511s %511s %511s %d %d %d", &Z.bot, &Z.top,
+               &Z.lifespan, &Z.reset_mode, zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level, &Z.max_level,
+               &Z.show_weather) != 11)
     {
       // not 11 values, lets try 10
-      if (sscanf(buf, " %d %d %d %d %s %s %s %s %d %d", &Z.bot, &Z.top, &Z.lifespan, &Z.reset_mode,
-                 zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level, &Z.max_level) != 10)
+      if (sscanf(buf, " %d %d %d %d %511s %511s %511s %511s %d %d", &Z.bot, &Z.top,
+                 &Z.lifespan, &Z.reset_mode, zbuf1, zbuf2, zbuf3, zbuf4, &Z.min_level,
+                 &Z.max_level) != 10)
       {
         // not 10 values, last try for 4 values
         if (sscanf(buf, " %d %d %d %d ", &Z.bot, &Z.top, &Z.lifespan, &Z.reset_mode) != 4)

--- a/src/dg_db_scripts.c
+++ b/src/dg_db_scripts.c
@@ -50,7 +50,7 @@ void parse_trigger(FILE *trig_f, int nr)
   trig->name = fread_string(trig_f, errors);
 
   if (!get_line(trig_f, line) ||
-      (k = sscanf(line, "%d %1023s %d", &attach_type, flags, t)) < 2)
+      (k = sscanf(line, "%d %255s %d", &attach_type, flags, t)) < 2)
   {
     log("SYSERR: Trigger #%d has an invalid numeric header.", nr);
     exit(1);

--- a/src/dg_db_scripts.c
+++ b/src/dg_db_scripts.c
@@ -49,8 +49,12 @@ void parse_trigger(FILE *trig_f, int nr)
   trig->nr = top_of_trigt;
   trig->name = fread_string(trig_f, errors);
 
-  get_line(trig_f, line);
-  k = sscanf(line, "%d %s %d", &attach_type, flags, t);
+  if (!get_line(trig_f, line) ||
+      (k = sscanf(line, "%d %1023s %d", &attach_type, flags, t)) < 2)
+  {
+    log("SYSERR: Trigger #%d has an invalid numeric header.", nr);
+    exit(1);
+  }
   trig->attach_type = (byte)attach_type;
   trig->trigger_type = (long)asciiflag_conv(flags);
   trig->narg = (k == 3) ? t[0] : 0;

--- a/src/dg_olc.c
+++ b/src/dg_olc.c
@@ -167,12 +167,12 @@ void trigedit_setup_existing(struct descriptor_data *d, int rtrg_num, int mode _
   /* convert cmdlist to a char string */
   c = trig->cmdlist;
   CREATE(OLC_STORAGE(d), char, MAX_CMD_LENGTH);
-  strcpy(OLC_STORAGE(d), "");
+  OLC_STORAGE(d)[0] = '\0';
 
   while (c)
   {
-    strcat(OLC_STORAGE(d), c->cmd);
-    strcat(OLC_STORAGE(d), "\r\n");
+    strlcat(OLC_STORAGE(d), c->cmd, MAX_CMD_LENGTH);
+    strlcat(OLC_STORAGE(d), "\r\n", MAX_CMD_LENGTH);
     c = c->next;
   }
   /* Now trig->cmdlist is something to pass to the text editor it will be
@@ -622,7 +622,7 @@ void trigedit_save(struct descriptor_data *d)
   snprintf(fname, sizeof(fname), "%s/%i.new", TRG_PREFIX, zone);
 #endif
 
-  if (!(trig_file = fopen(fname, "w")))
+  if (!(trig_file = fopen_restricted(fname, "w")))
   {
     mudlog(BRF, MAX(LVL_STAFF, GET_INVIS_LEV(d->character)), TRUE,
            "SYSERR: OLC: Can't open trig file \"%s\"", fname);
@@ -701,7 +701,7 @@ static void trigedit_create_index(int znum, const char *type)
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: DG_OLC: Failed to open %s", old_name);
     return;
   }
-  else if (!(newfile = fopen(new_name, "w")))
+  else if (!(newfile = fopen_restricted(new_name, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: DG_OLC: Failed to open %s", new_name);
     return;
@@ -719,7 +719,11 @@ static void trigedit_create_index(int znum, const char *type)
     }
     else if (!found)
     {
-      sscanf(buf, "%d", &num);
+      if (sscanf(buf, "%d", &num) != 1)
+      {
+        mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: Invalid trigger index entry: %s", buf);
+        continue;
+      }
       if (num == znum)
         found = TRUE;
       else if (num > znum)
@@ -857,12 +861,18 @@ int dg_script_edit_parse(struct descriptor_data *d, char *arg)
     return 1;
 
   case SCRIPT_NEW_TRIGGER:
+    pos = 0;
     vnum = -1;
     count = sscanf(arg, "%d, %d", &pos, &vnum);
     if (count == 1)
     {
       vnum = pos;
       pos = 999;
+    }
+    else if (count != 2)
+    {
+      write_to_output(d, "Please enter position, vnum   (ex: 1, 200):");
+      return 1;
     }
 
     if (pos <= 0)

--- a/src/dg_scripts.c
+++ b/src/dg_scripts.c
@@ -1669,7 +1669,8 @@ static int eval_lhs_op_rhs(char *expr, char *result, void *go, struct script_dat
   const char *const ops[] = {"||", "&&", "==", "!=", "<=", ">=", "<", ">",
                              "/=", "-",  "+",  "/",  "*",  "!",  "\n"};
 
-  p = strcpy(line, expr);
+  strlcpy(line, expr, sizeof(line));
+  p = line;
 
   /* Initialize tokens, an array of pointers to locations in line where the
    * ops could possibly occur. */
@@ -2677,7 +2678,7 @@ static void extract_value(struct script_data *sc, trig_data *trig, char *cmd)
 
   buf3 = any_one_arg(cmd, buf);
   half_chop(buf3, buf2, buf);
-  strcpy(to, buf2);
+  strlcpy(to, buf2, sizeof(to));
 
   num = atoi(buf);
   if (num < 1)
@@ -3512,7 +3513,7 @@ void save_char_vars(struct char_data *ch)
     return;
   vars = ch->script->global_vars;
 
-  file = fopen(fn, "wt");
+  file = fopen_restricted(fn, "wt");
   if (!file)
   {
     mudlog(NRM, LVL_STAFF, TRUE, "SYSERR: Could not open player variable file %s for writing.:%s",

--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -60,7 +60,7 @@ void add_var(struct trig_var_data **var_list, const char *name, const char *valu
     CREATE(vd, struct trig_var_data, 1);
 
     CREATE(vd->name, char, strlen(name) + 1);
-    strcpy(vd->name, name); /* strcpy: ok*/
+    memcpy(vd->name, name, strlen(name) + 1);
 
     CREATE(vd->value, char, strlen(value) + 1);
 
@@ -69,7 +69,7 @@ void add_var(struct trig_var_data **var_list, const char *name, const char *valu
     *var_list = vd;
   }
 
-  strcpy(vd->value, value); /* strcpy: ok*/
+  memcpy(vd->value, value, strlen(value) + 1);
 }
 
 int dg_has_feat(char_data *ch, const char *feat, int return_type __attribute__((unused)))
@@ -354,7 +354,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig, int typ
       if (!str_cmp(vd->name, var) && (vd->context == 0 || vd->context == sc->context))
         break;
 
-  if (!*field)
+  if (!field || !*field)
   {
     if (vd)
       snprintf(str, slen, "%s", vd->value);
@@ -566,7 +566,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig, int typ
          * Addition inspired by Jamie Nelson */
       else if (!str_cmp(var, "findmob"))
       {
-        if (!field || !*field || !subfield || !*subfield)
+        if (!*field || !subfield || !*subfield)
         {
           script_log("findmob.vnum(mvnum) - illegal syntax");
           strcpy(str, "0");
@@ -593,7 +593,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig, int typ
       } /* Addition inspired by Jamie Nelson. */
       else if (!str_cmp(var, "findobj"))
       {
-        if (!field || !*field || !subfield || !*subfield)
+        if (!*field || !subfield || !*subfield)
         {
           script_log("findobj.vnum(ovnum) - illegal syntax");
           strcpy(str, "0");
@@ -2415,13 +2415,14 @@ void var_subst(void *go, struct script_data *sc, trig_data *trig, int type, char
   /* skip out if no %'s */
   if (!strchr(line, '%'))
   {
-    strcpy(buf, line);
+    strlcpy(buf, line, MAX_INPUT_LENGTH);
     return;
   }
   /*lets just empty these to start with*/
   *repl_str = *tmp = *tmp2 = '\0';
 
-  p = strcpy(tmp, line);
+  strlcpy(tmp, line, sizeof(tmp));
+  p = tmp;
   subfield_p = subfield;
 
   left = MAX_INPUT_LENGTH - 1;
@@ -2501,15 +2502,16 @@ void var_subst(void *go, struct script_data *sc, trig_data *trig, int type, char
       if (*subfield)
       {
         var_subst(go, sc, trig, type, subfield, tmp2);
-        strcpy(subfield, tmp2);
+        strlcpy(subfield, tmp2, sizeof(subfield));
       }
 
       find_replacement(go, sc, trig, type, var, field, subfield, repl_str, sizeof(repl_str));
 
-      strncat(buf, repl_str, left);
-      len = strlen(repl_str);
+      len = MIN((int)strlen(repl_str), left);
+      memcpy(buf, repl_str, len);
       buf += len;
       left -= len;
+      *buf = '\0';
     } /* else if *p .. */
   } /* while *p .. */
   *buf = '\0';

--- a/src/discord_bridge.c
+++ b/src/discord_bridge.c
@@ -69,7 +69,7 @@ char *build_discord_json(const char *channel, const char *name, const char *mess
 
   /* Simple JSON escaping */
   j = 0;
-  for (i = 0; name[i] && i < 254 && j < 254; i++)
+  for (i = 0; i < 254 && j < 254 && name[i]; i++)
   {
     if (name[i] == '"' || name[i] == '\\')
     {
@@ -103,7 +103,7 @@ char *build_discord_json(const char *channel, const char *name, const char *mess
   escaped_message[j] = '\0';
 
   j = 0;
-  for (i = 0; channel[i] && i < 126 && j < 126; i++)
+  for (i = 0; i < 126 && j < 126 && channel[i]; i++)
   {
     if (channel[i] == '"' || channel[i] == '\\')
     {

--- a/src/domains_schools.c
+++ b/src/domains_schools.c
@@ -704,11 +704,11 @@ ACMD(do_domain)
   /* 0-value is undefined, it is used in the code, but not displayed */
   for (i = 1; i < NUM_DOMAINS; i++)
   {
-    len += snprintf(buf + len, sizeof(buf) - len,
-                    "%sDomain:%s %-20s %sFavored Weapon:%s %-22s\r\n%sDescription:%s %s\r\n", QCYN,
-                    QNRM, domain_list[i].name, QCYN, QNRM,
-                    weapon_list[domain_list[i].favored_weapon].name, QCYN, QNRM,
-                    domain_list[i].description);
+    len = snprintf_append(
+        buf, sizeof(buf), len,
+        "%sDomain:%s %-20s %sFavored Weapon:%s %-22s\r\n%sDescription:%s %s\r\n", QCYN, QNRM,
+        domain_list[i].name, QCYN, QNRM, weapon_list[domain_list[i].favored_weapon].name, QCYN, QNRM,
+        domain_list[i].description);
     /*
     send_to_char(ch, "%sDomain:%s %-20s %sFavored Weapon:%s %-22s\r\n%sDescription:%s %s\r\n",
                  QCYN, QNRM, domain_list[i].name,
@@ -716,7 +716,7 @@ ACMD(do_domain)
                  QCYN, QNRM, domain_list[i].description
                 );*/
 
-    len += snprintf(buf + len, sizeof(buf) - len, "%sGranted powers: |%s", QCYN, QNRM);
+    len = snprintf_append(buf, sizeof(buf), len, "%sGranted powers: |%s", QCYN, QNRM);
 
     /*                    send_to_char(ch, "%sGranted powers: |%s", QCYN, QNRM);*/
 
@@ -724,26 +724,26 @@ ACMD(do_domain)
     {
       if (domain_list[i].granted_powers[j] != DOMAIN_POWER_UNDEFINED)
       {
-        len += snprintf(buf + len, sizeof(buf) - len, "%s%s|%s",
-                        domainpower_names[domain_list[i].granted_powers[j]], QCYN, QNRM);
+        len = snprintf_append(buf, sizeof(buf), len, "%s%s|%s",
+                              domainpower_names[domain_list[i].granted_powers[j]], QCYN, QNRM);
         /*send_to_char(ch, "%s%s|%s", domainpower_names[domain_list[i].granted_powers[j]], QCYN, QNRM);*/
       }
     }
-    len += snprintf(buf + len, sizeof(buf) - len, "\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "\r\n");
     /*send_to_char(ch, "\r\n");*/
 
-    len += snprintf(buf + len, sizeof(buf) - len, "%sGranted spells: |%s", QCYN, QNRM);
+    len = snprintf_append(buf, sizeof(buf), len, "%sGranted spells: |%s", QCYN, QNRM);
     /*send_to_char(ch, "%sGranted spells: |%s", QCYN, QNRM);*/
     for (j = 0; j < MAX_DOMAIN_SPELLS; j++)
     {
       if (domain_list[i].domain_spells[j] != SPELL_RESERVED_DBC)
       {
-        len += snprintf(buf + len, sizeof(buf) - len, "%s%s|%s",
-                        spell_info[domain_list[i].domain_spells[j]].name, QCYN, QNRM);
+        len = snprintf_append(buf, sizeof(buf), len, "%s%s|%s",
+                              spell_info[domain_list[i].domain_spells[j]].name, QCYN, QNRM);
         /*send_to_char(ch, "%s%s|%s", spell_info[domain_list[i].domain_spells[j]].name, QCYN, QNRM);*/
       }
     }
-    len += snprintf(buf + len, sizeof(buf) - len, "\r\n\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "\r\n\r\n");
     /*send_to_char(ch, "\r\n\r\n");*/
   }
 

--- a/src/genmob.c
+++ b/src/genmob.c
@@ -404,7 +404,7 @@ int save_mobiles(zone_rnum rznum)
 
   vznum = zone_table[rznum].number;
   snprintf(mobfname, sizeof(mobfname), "%s%d.new", MOB_PREFIX, vznum);
-  if ((mobfd = fopen(mobfname, "w")) == NULL)
+  if ((mobfd = fopen_restricted(mobfname, "w")) == NULL)
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: GenOLC: Cannot open mob file for writing.");
     return FALSE;

--- a/src/genobj.c
+++ b/src/genobj.c
@@ -232,7 +232,7 @@ int save_objects(zone_rnum zone_num)
   }
 
   snprintf(filename, sizeof(filename), "%s/%d.new", OBJ_PREFIX, zone_table[zone_num].number);
-  if (!(fp = fopen(filename, "w+")))
+  if (!(fp = fopen_restricted(filename, "w+")))
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: OLC: Cannot open objects file %s!", filename);
     return FALSE;

--- a/src/genolc.c
+++ b/src/genolc.c
@@ -502,7 +502,7 @@ static int export_worldmap_html(zone_rnum zrnum, const char *output_file, char *
     return FALSE;
 
   snprintf(saved_path, saved_path_size, "../lib/world/export/%s", output_file);
-  if (!(out = fopen(saved_path + 7, "w")))
+  if (!(out = fopen_restricted(saved_path + 7, "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_worldmap_html: Cannot open %s", saved_path);
     return FALSE;
@@ -576,7 +576,7 @@ static int export_full_worldmap_html(const char *output_file, char *saved_path, 
     return FALSE;
 
   snprintf(saved_path, saved_path_size, "../lib/world/export/%s", output_file);
-  if (!(out = fopen(saved_path + 7, "w")))
+  if (!(out = fopen_restricted(saved_path + 7, "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_full_worldmap_html: Cannot open %s", saved_path);
     return FALSE;
@@ -1088,7 +1088,7 @@ static int export_info_file(zone_rnum zrnum)
   room_vnum i;
   FILE *info_file;
 
-  if (!(info_file = fopen("world/export/qq.info", "w")))
+  if (!(info_file = fopen_restricted("world/export/qq.info", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_info_file : Cannot open file!");
     return FALSE;
@@ -1171,7 +1171,7 @@ static int export_save_shops(zone_rnum zrnum)
   FILE *shop_file;
   struct shop_data *shop;
 
-  if (!(shop_file = fopen("world/export/qq.shp", "w")))
+  if (!(shop_file = fopen_restricted("world/export/qq.shp", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_save_shops : Cannot open shop file!");
     return FALSE;
@@ -1261,7 +1261,7 @@ static int export_save_mobiles(zone_rnum rznum)
   mob_vnum i;
   mob_rnum rmob;
 
-  if (!(mob_file = fopen("world/export/qq.mob", "w")))
+  if (!(mob_file = fopen_restricted("world/export/qq.mob", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_save_mobiles : Cannot open file!");
     return FALSE;
@@ -1331,7 +1331,7 @@ static int export_save_zone(zone_rnum zrnum)
   int subcmd;
   FILE *zone_file;
 
-  if (!(zone_file = fopen("world/export/qq.zon", "w")))
+  if (!(zone_file = fopen_restricted("world/export/qq.zon", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_save_zone : Cannot open file!");
     return FALSE;
@@ -1451,7 +1451,7 @@ static int export_save_objects(zone_rnum zrnum)
   struct obj_data *obj;
   struct extra_descr_data *ex_desc;
 
-  if (!(obj_file = fopen("world/export/qq.obj", "w")))
+  if (!(obj_file = fopen_restricted("world/export/qq.obj", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_save_objects : Cannot open file!");
     return FALSE;
@@ -1560,7 +1560,7 @@ static int export_save_rooms(zone_rnum zrnum)
   char buf[MAX_STRING_LENGTH] = {'\0'};
   char buf1[MAX_STRING_LENGTH] = {'\0'};
 
-  if (!(room_file = fopen("world/export/qq.wld", "w")))
+  if (!(room_file = fopen_restricted("world/export/qq.wld", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_save_rooms : Cannot open file!");
     return FALSE;
@@ -1714,7 +1714,7 @@ static int export_save_triggers(zone_rnum zrnum)
   FILE *trig_file;
   char bitBuf[MAX_INPUT_LENGTH] = {'\0'};
 
-  if (!(trig_file = fopen("world/export/qq.trg", "w")))
+  if (!(trig_file = fopen_restricted("world/export/qq.trg", "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: export_save_triggers : Cannot open file!");
     return FALSE;

--- a/src/genqst.c
+++ b/src/genqst.c
@@ -254,7 +254,7 @@ int save_quests(zone_rnum zone_num)
       genolc_zone_bottom(zone_num), zone_table[zone_num].top);
 
   snprintf(filename, sizeof(filename), "%s/%d.new", QST_PREFIX, zone_table[zone_num].number);
-  if (!(sf = fopen(filename, "w")))
+  if (!(sf = fopen_restricted(filename, "w")))
   {
     perror("SYSERR: save_quests");
     return FALSE;

--- a/src/genshp.c
+++ b/src/genshp.c
@@ -382,7 +382,7 @@ int save_shops(zone_rnum zone_num)
   }
 
   snprintf(fname, sizeof(fname), "%s/%d.new", SHP_PREFIX, zone_table[zone_num].number);
-  if (!(shop_file = fopen(fname, "w")))
+  if (!(shop_file = fopen_restricted(fname, "w")))
   {
     mudlog(BRF, LVL_STAFF, TRUE, "SYSERR: OLC: Cannot open shop file!");
     return FALSE;

--- a/src/genwld.c
+++ b/src/genwld.c
@@ -326,7 +326,7 @@ int save_rooms(zone_rnum rzone)
       genolc_zone_bottom(rzone), zone_table[rzone].top);
 
   snprintf(filename, sizeof(filename), "%s/%d.new", WLD_PREFIX, zone_table[rzone].number);
-  if (!(sf = fopen(filename, "w")))
+  if (!(sf = fopen_restricted(filename, "w")))
   {
     perror("SYSERR: save_rooms");
     return FALSE;

--- a/src/genzon.c
+++ b/src/genzon.c
@@ -127,7 +127,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the zone file. */
   snprintf(buf, sizeof(buf), "%s/%d.zon", ZON_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new zone file.");
     *error = "Could not write zone file.\r\n";
@@ -138,7 +138,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the room file. */
   snprintf(buf, sizeof(buf), "%s/%d.wld", WLD_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new world file.");
     *error = "Could not write world file.\r\n";
@@ -149,7 +149,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the mobile file. */
   snprintf(buf, sizeof(buf), "%s/%d.mob", MOB_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new mob file.");
     *error = "Could not write mobile file.\r\n";
@@ -160,7 +160,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the object file. */
   snprintf(buf, sizeof(buf), "%s/%d.obj", OBJ_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new obj file.");
     *error = "Could not write object file.\r\n";
@@ -171,7 +171,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the shop file. */
   snprintf(buf, sizeof(buf), "%s/%d.shp", SHP_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new shop file.");
     *error = "Could not write shop file.\r\n";
@@ -182,7 +182,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the quests file */
   snprintf(buf, sizeof(buf), "%s/%d.qst", QST_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new quest file");
     *error = "Could not write quest file.\r\n";
@@ -193,7 +193,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the hlquest file (homeland-port) */
   snprintf(buf, sizeof(buf), "%s/%d.hlq", HLQST_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new hlquest file");
     *error = "Could not write hlquest file.\r\n";
@@ -204,7 +204,7 @@ zone_rnum create_new_zone(zone_vnum vzone_num, room_vnum bottom, room_vnum top, 
 
   /* Create the trigger file. */
   snprintf(buf, sizeof(buf), "%s/%d.trg", TRG_PREFIX, vzone_num);
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Can't write new trigger file");
     *error = "Could not write trigger file.\r\n";
@@ -324,7 +324,7 @@ void create_world_index(int znum, const char *type)
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Failed to open %s.", old_name);
     return;
   }
-  else if (!(newfile = fopen(new_name, "w")))
+  else if (!(newfile = fopen_restricted(new_name, "w")))
   {
     mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: OLC: Failed to open %s.", new_name);
     fclose(oldfile);
@@ -345,7 +345,11 @@ void create_world_index(int znum, const char *type)
     }
     else if (!found)
     {
-      sscanf(buf, "%d", &num);
+      if (sscanf(buf, "%d", &num) != 1)
+      {
+        mudlog(BRF, LVL_IMPL, TRUE, "SYSERR: Invalid zone index entry: %s", buf);
+        continue;
+      }
       if (num > znum)
       {
         found = TRUE;
@@ -425,7 +429,7 @@ int save_zone(zone_rnum zone_num)
   }
 
   snprintf(fname, sizeof(fname), "%s/%d.new", ZON_PREFIX, zone_table[zone_num].number);
-  if (!(zfile = fopen(fname, "w")))
+  if (!(zfile = fopen_restricted(fname, "w")))
   {
     mudlog(BRF, LVL_BUILDER, TRUE, "SYSERR: OLC: save_zones:  Can't write zone %d.",
            zone_table[zone_num].number);

--- a/src/handler.c
+++ b/src/handler.c
@@ -2284,7 +2284,7 @@ int get_number(char **name)
   {
     *ppos++ = '\0';
     strlcpy(number, namebuf, sizeof(number));
-    strcpy(*name, ppos); /* strcpy: OK (always smaller) */
+    memmove(*name, ppos, strlen(ppos) + 1);
 
     for (i = 0; *(number + i); i++)
       if (!isdigit(*(number + i)))

--- a/src/hedit.c
+++ b/src/hedit.c
@@ -426,7 +426,7 @@ static void hedit_save_to_db(struct descriptor_data *d)
   strip_cr(buf1);
 
   /* Convert tag to lowercase for storage */
-  for (i = 0; OLC_HELP(d)->tag[i] && i < MAX_HELP_TAG_LENGTH; i++)
+  for (i = 0; i < MAX_HELP_TAG_LENGTH && OLC_HELP(d)->tag[i]; i++)
   {
     tag_lower[i] = LOWER(OLC_HELP(d)->tag[i]);
   }
@@ -1222,7 +1222,7 @@ ACMD(do_helpcheck)
 {
   char buf[MAX_STRING_LENGTH] = {'\0'};
   int i, count = 0;
-  size_t len = 0, nlen;
+  size_t len = 0;
 
   for (i = 1; *(complete_cmd_info[i].command) != '\n'; i++)
   {
@@ -1231,16 +1231,15 @@ ACMD(do_helpcheck)
     {
       if (search_help(complete_cmd_info[i].command, LVL_IMPL) == NULL)
       {
-        nlen = snprintf(buf + len, sizeof(buf) - len, "%-20.20s%s", complete_cmd_info[i].command,
-                        (++count % 3 ? "" : "\r\n"));
-        if (len + nlen >= sizeof(buf))
+        len = snprintf_append(buf, sizeof(buf), len, "%-20.20s%s", complete_cmd_info[i].command,
+                              (++count % 3 ? "" : "\r\n"));
+        if (len >= sizeof(buf) - 1)
           break;
-        len += nlen;
       }
     }
   }
-  if (count % 3 && len < sizeof(buf))
-    nlen = snprintf(buf + len, sizeof(buf) - len, "\r\n");
+  if (count % 3)
+    len = snprintf_append(buf, sizeof(buf), len, "\r\n");
 
   if (ch->desc)
   {
@@ -1325,7 +1324,8 @@ ACMD(do_hindex)
     char *tag = mysql_stmt_get_string(pstmt, 0);
     if (tag)
     {
-      len += snprintf(buf + len, sizeof(buf) - len, "%-20.20s%s", tag, (++count % 3 ? "" : "\r\n"));
+      len =
+          snprintf_append(buf, sizeof(buf), len, "%-20.20s%s", tag, (++count % 3 ? "" : "\r\n"));
     }
   }
 
@@ -1362,8 +1362,8 @@ ACMD(do_hindex)
             char *tag = mysql_stmt_get_string(pstmt, 0);
             if (tag)
             {
-              len2 += snprintf(buf2 + len2, sizeof(buf2) - len2, "%-20.20s%s", tag,
-                               (++count2 % 3 ? "" : "\r\n"));
+              len2 = snprintf_append(buf2, sizeof(buf2), len2, "%-20.20s%s", tag,
+                                     (++count2 % 3 ? "" : "\r\n"));
             }
           }
         }
@@ -1398,22 +1398,22 @@ ACMD(do_hindex)
 
   /* Format the output */
   if (count % 3)
-    len += snprintf(buf + len, sizeof(buf) - len, "\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "\r\n");
   if (count2 % 3)
-    len2 += snprintf(buf2 + len2, sizeof(buf2) - len2, "\r\n");
+    len2 = snprintf_append(buf2, sizeof(buf2), len2, "\r\n");
 
   if (!count)
-    len += snprintf(buf + len, sizeof(buf) - len, "  None.\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "  None.\r\n");
   if (!count2)
-    len2 += snprintf(buf2 + len2, sizeof(buf2) - len2, "  None.\r\n");
+    len2 = snprintf_append(buf2, sizeof(buf2), len2, "  None.\r\n");
 
   /* Join the two strings */
-  len += snprintf(buf + len, sizeof(buf) - len, "%s", buf2);
+  len = snprintf_append(buf, sizeof(buf), len, "%s", buf2);
 
-  len += snprintf(buf + len, sizeof(buf) - len,
-                  "\t1Applicable Index Entries: \t3%d\r\n"
-                  "\t1Total Index Entries: \t3%d\tn\r\n",
-                  count + count2, total_entries);
+  len = snprintf_append(buf, sizeof(buf), len,
+                        "\t1Applicable Index Entries: \t3%d\r\n"
+                        "\t1Total Index Entries: \t3%d\tn\r\n",
+                        count + count2, total_entries);
 
   page_string(ch->desc, buf, TRUE);
 }
@@ -2487,7 +2487,7 @@ static int export_help_to_hlp(struct char_data *ch, const char *options)
   char opt_arg[MAX_INPUT_LENGTH];
   char *token;
   time_t now;
-  struct tm *tm_info;
+  struct tm tm_info;
 
   /* Parse options - first token is the required mode, rest are optional filters */
   if (options && *options)
@@ -2573,16 +2573,20 @@ static int export_help_to_hlp(struct char_data *ch, const char *options)
   {
     /* Create timestamped backup */
     time(&now);
-    tm_info = localtime(&now);
+    if (!localtime_r(&now, &tm_info))
+    {
+      send_to_char(ch, "Unable to determine the current time for the backup filename.\r\n");
+      return 0;
+    }
     snprintf(backup_path, sizeof(backup_path), "text/help/help.hlp.%04d%02d%02d_%02d%02d%02d",
-             tm_info->tm_year + 1900, tm_info->tm_mon + 1, tm_info->tm_mday, tm_info->tm_hour,
-             tm_info->tm_min, tm_info->tm_sec);
+             tm_info.tm_year + 1900, tm_info.tm_mon + 1, tm_info.tm_mday, tm_info.tm_hour,
+             tm_info.tm_min, tm_info.tm_sec);
 
     /* Copy existing file to backup */
     FILE *src = fopen(filepath, "r");
     if (src)
     {
-      FILE *dst = fopen(backup_path, "w");
+      FILE *dst = fopen_restricted(backup_path, "w");
       if (dst)
       {
         char buffer[4096];
@@ -2628,7 +2632,7 @@ static int export_help_to_hlp(struct char_data *ch, const char *options)
   /* Open output file if not in preview mode */
   if (!preview_mode)
   {
-    fp = fopen(filepath, "w");
+    fp = fopen_restricted(filepath, "w");
     if (!fp)
     {
       send_to_char(ch, "Error: Cannot open %s for writing\r\n", filepath);
@@ -2852,7 +2856,7 @@ static struct help_entry_list *parse_help_entry(FILE *fp, int *min_level)
     int line_len = strlen(line);
     if ((size_t)(content_len + line_len) < sizeof(content) - 1)
     {
-      strcat(content, line);
+      strlcat(content, line, sizeof(content));
       content_len += line_len;
     }
   }
@@ -2954,7 +2958,7 @@ static int import_entry_with_resolution(struct char_data *ch __attribute__((unus
           escaped_size *= 2;
           RECREATE(escaped_keywords, char, escaped_size);
         }
-        escaped_len += snprintf(escaped_keywords + escaped_len, escaped_size - escaped_len, ", ");
+        escaped_len = snprintf_append(escaped_keywords, escaped_size, escaped_len, ", ");
       }
       first_keyword = 0;
 
@@ -2965,8 +2969,8 @@ static int import_entry_with_resolution(struct char_data *ch __attribute__((unus
         escaped_size *= 2;
         RECREATE(escaped_keywords, char, escaped_size);
       }
-      escaped_len += snprintf(escaped_keywords + escaped_len, escaped_size - escaped_len, "'%s'",
-                              escaped_keyword);
+      escaped_len =
+          snprintf_append(escaped_keywords, escaped_size, escaped_len, "'%s'", escaped_keyword);
 
       token = strtok_r(NULL, " ", &rest);
     }
@@ -3204,14 +3208,21 @@ static int import_help_hlp_file(struct char_data *ch, const char *mode)
 #define APPEND_TO_BUF(fmt, ...)                                                                    \
   do                                                                                               \
   {                                                                                                \
-    size_t needed = snprintf(NULL, 0, fmt, ##__VA_ARGS__) + 1;                                     \
-    if (output_len + needed > output_size - 1)                                                     \
+    int formatted_length = snprintf(NULL, 0, fmt, ##__VA_ARGS__);                                  \
+    size_t needed;                                                                                 \
+    size_t new_size;                                                                               \
+    if (formatted_length < 0)                                                                      \
+      break;                                                                                       \
+    needed = (size_t)formatted_length + 1;                                                         \
+    while (needed > output_size - output_len)                                                      \
     {                                                                                              \
-      size_t new_size = output_size * 2;                                                           \
+      new_size = output_size * 2;                                                                  \
+      if (new_size <= output_size)                                                                 \
+        break;                                                                                     \
       RECREATE(output_buf, char, new_size);                                                        \
       output_size = new_size;                                                                      \
     }                                                                                              \
-    output_len += snprintf(output_buf + output_len, output_size - output_len, fmt, ##__VA_ARGS__); \
+    output_len = snprintf_append(output_buf, output_size, output_len, fmt, ##__VA_ARGS__);          \
   } while (0)
 
   /* Open the help.hlp file */

--- a/src/hlqedit.c
+++ b/src/hlqedit.c
@@ -58,7 +58,7 @@ void zedit_create_index(int znum)
     log("%s", buf);
     return;
   }
-  else if (!(newfile = fopen(new_name, "w")))
+  else if (!(newfile = fopen_restricted(new_name, "w")))
   {
     snprintf(buf, sizeof(buf), "SYSERR: OLC: Failed to open %s", new_name);
     log("%s", buf);
@@ -79,7 +79,11 @@ void zedit_create_index(int znum)
     }
     else if (!found)
     {
-      sscanf(buf, "%d", &num);
+      if (sscanf(buf, "%d", &num) != 1)
+      {
+        log("SYSERR: Invalid high-level quest index entry: %s", buf);
+        continue;
+      }
       if (num == znum)
         found = TRUE;
       if (num > znum)
@@ -287,7 +291,7 @@ void hlqedit_save_to_disk(zone_rnum zone_num)
   }
 
   snprintf(buf, sizeof(buf), "%s/%u.new", HLQST_PREFIX, zone_table[zone_num].number);
-  if (!(fp = fopen(buf, "w+")))
+  if (!(fp = fopen_restricted(buf, "w+")))
   {
     log("SYSERR: OLC: Cannot open hl quest file!");
     return;

--- a/src/hlquest.c
+++ b/src/hlquest.c
@@ -914,7 +914,7 @@ void boot_the_quests(FILE *quest_f, char *filename, int rec_count __attribute__(
       {
         get_line(quest_f, inner);
         CREATE(qcom, struct quest_command, 1);
-        if (3 == sscanf(inner + 1, "%s%d%d", str, &qcom->value, &qcom->location))
+        if (3 == sscanf(inner + 1, "%255s%d%d", str, &qcom->value, &qcom->location))
         {
         }
         else

--- a/src/house.c
+++ b/src/house.c
@@ -266,7 +266,7 @@ void House_crashsave(room_vnum vnum)
     mysql_query(conn, "rollback;");
     return;
   }
-  if (!(fp = fopen(buf, "wb")))
+  if (!(fp = fopen_restricted(buf, "wb")))
   {
     perror("SYSERR: Error saving house file");
     mysql_query(conn, "rollback;");
@@ -339,9 +339,9 @@ static void House_listrent(struct char_data *ch, room_vnum vnum)
   loaded = objsave_parse_objects_db(NULL, vnum);
 
   for (current = loaded; current != NULL; current = current->next)
-    len +=
-        snprintf(buf + len, sizeof(buf) - len, " [%5d] (%5dau) %s\r\n", GET_OBJ_VNUM(current->obj),
-                 GET_OBJ_RENT(current->obj), current->obj->short_description);
+    len = snprintf_append(buf, sizeof(buf), len, " [%5d] (%5dau) %s\r\n",
+                          GET_OBJ_VNUM(current->obj), GET_OBJ_RENT(current->obj),
+                          current->obj->short_description);
 
   /* now it's safe to free the obj_save_data list - all members of it
    * have been put in the correct lists by obj_to_room()
@@ -375,7 +375,7 @@ void House_save_control(void)
 {
   FILE *fl;
 
-  if (!(fl = fopen(HCONTROL_FILE, "wb")))
+  if (!(fl = fopen_restricted(HCONTROL_FILE, "wb")))
   {
     perror("SYSERR: Unable to open house control file.");
     return;
@@ -1327,7 +1327,7 @@ static int ascii_convert_house(struct char_data *ch, obj_vnum vnum)
     return (0);
   }
 
-  if (!(out = fopen(outfile, "w")))
+  if (!(out = fopen_restricted(outfile, "w")))
   {
     send_to_char(ch, "...cannot open output file\r\n");
     free(outfile);

--- a/src/ibt.c
+++ b/src/ibt.c
@@ -386,7 +386,7 @@ void save_ibt_file(int mode)
     return;
   }
 
-  if ((fp = fopen(filename, "w")) == NULL)
+  if ((fp = fopen_restricted(filename, "w")) == NULL)
   {
     log("SYSERR: Unable to open IBT file for writing in save_ibt_file");
     log("        IBT File: %s", filename);

--- a/src/improved-edit.c
+++ b/src/improved-edit.c
@@ -104,7 +104,7 @@ int improved_editor_execute(struct descriptor_data *d, char *str)
 /* Handle some editor commands. */
 void parse_edit_action(int command, char *string, struct descriptor_data *d)
 {
-  int indent = 0, rep_all = 0, flags = 0, replaced, i, line_low, line_high, j = 0;
+  int indent = 0, rep_all = 0, flags = 0, replaced, i, line_low = 1, line_high = 999999, j = 0;
   unsigned int total_len;
   char *s, *t, temp;
   char buf[MAX_STRING_LENGTH] = {'\0'};
@@ -257,6 +257,7 @@ void parse_edit_action(int command, char *string, struct descriptor_data *d)
   case PARSE_DELETE:
     switch (sscanf(string, " %d - %d ", &line_low, &line_high))
     {
+    case EOF:
     case 0:
       write_to_output(d, "You must specify a line number or range to delete.\r\n");
       return;
@@ -325,6 +326,7 @@ void parse_edit_action(int command, char *string, struct descriptor_data *d)
     if (*string)
       switch (sscanf(string, " %d - %d ", &line_low, &line_high))
       {
+      case EOF:
       case 0:
         line_low = 1;
         line_high = 999999;
@@ -394,6 +396,7 @@ void parse_edit_action(int command, char *string, struct descriptor_data *d)
     if (*string)
       switch (sscanf(string, " %d - %d ", &line_low, &line_high))
       {
+      case EOF:
       case 0:
         line_low = 1;
         line_high = 999999;
@@ -501,11 +504,11 @@ void parse_edit_action(int command, char *string, struct descriptor_data *d)
         return;
       }
       if (*d->str && **d->str)
-        strcat(buf, *d->str);
+        strlcat(buf, *d->str, sizeof(buf));
       *s = temp;
-      strcat(buf, buf2);
-      if (s && *s)
-        strcat(buf, s);
+      strlcat(buf, buf2, sizeof(buf));
+      if (*s)
+        strlcat(buf, s, sizeof(buf));
       RECREATE(*d->str, char, strlen(buf) + 3);
 
       strcpy(*d->str, buf);
@@ -612,6 +615,8 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
     log("SYSERR: format_text: max_str is greater than buffer size.");
     return 0;
   }
+  if (maxlen == 0)
+    return 0;
 
   /* XXX: Want to make sure the string doesn't grow either... */
   if ((flow = *ptr_string) == NULL)
@@ -627,14 +632,15 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
       write_to_output(d, "There aren't that many lines!\r\n");
       return 0;
     }
-    strcat(formatted, strcat(start, "\n"));
+    strlcat(formatted, start, sizeof(formatted));
+    strlcat(formatted, "\n", sizeof(formatted));
     flow = strstr(flow, "\n");
     strlcpy(str, ++flow, sizeof(str));
   }
 
   if (IS_SET(mode, FORMAT_INDENT))
   {
-    strcat(formatted, "   ");
+    strlcat(formatted, "   ", sizeof(formatted));
     line_chars = 3;
   }
   else
@@ -715,7 +721,7 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
 
       if (line_chars + strlen(start) + 1 - color_chars > PAGE_WIDTH)
       {
-        strcat(formatted, "\r\n");
+        strlcat(formatted, "\r\n", sizeof(formatted));
         line_chars = 0;
         color_chars = count_color_chars(start);
       }
@@ -724,7 +730,7 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
       {
         if (line_chars > 0)
         {
-          strcat(formatted, " ");
+          strlcat(formatted, " ", sizeof(formatted));
           line_chars++;
         }
       }
@@ -735,7 +741,7 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
       }
 
       line_chars += strlen(start);
-      strcat(formatted, start);
+      strlcat(formatted, start, sizeof(formatted));
 
       *flow = temp;
     }
@@ -744,7 +750,7 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
     {
       if (line_chars + 3 - color_chars > PAGE_WIDTH)
       {
-        strcat(formatted, "\r\n");
+        strlcat(formatted, "\r\n", sizeof(formatted));
         line_chars = 0;
         color_chars = count_color_chars(start);
       }
@@ -752,27 +758,27 @@ int format_text(char **ptr_string, int mode, struct descriptor_data *d, unsigned
       {
         char buf[MAX_STRING_LENGTH] = {'\0'};
         snprintf(buf, sizeof(buf), "%c  ", *flow);
-        strcat(formatted, buf);
+        strlcat(formatted, buf, sizeof(formatted));
         flow++;
         line_chars++;
       }
       else
       {
-        strcat(formatted, "  ");
+        strlcat(formatted, "  ", sizeof(formatted));
         line_chars += 2;
       }
     }
   }
   if (*flow)
-    strcat(formatted, "\r\n");
-  strcat(formatted, flow);
+    strlcat(formatted, "\r\n", sizeof(formatted));
+  strlcat(formatted, flow, sizeof(formatted));
   if (!*flow)
-    strcat(formatted, "\r\n");
+    strlcat(formatted, "\r\n", sizeof(formatted));
 
   if (strlen(formatted) + 1 > maxlen)
     formatted[maxlen - 1] = '\0';
   RECREATE(*ptr_string, char, MIN(maxlen, strlen(formatted) + 1));
-  strcpy(*ptr_string, formatted);
+  memcpy(*ptr_string, formatted, strlen(formatted) + 1);
   return 1;
 }
 
@@ -785,7 +791,7 @@ int replace_str(char **string, char *pattern, char *replacement, int rep_all, un
   if ((strlen(*string) - strlen(pattern)) + strlen(replacement) > max_size)
     return -1;
 
-  CREATE(replace_buffer, char, max_size);
+  CREATE(replace_buffer, char, max_size + 1);
   i = 0;
   jetsam = *string;
   flow = *string;
@@ -803,13 +809,13 @@ int replace_str(char **string, char *pattern, char *replacement, int rep_all, un
         i = -1;
         break;
       }
-      strcat(replace_buffer, jetsam);
-      strcat(replace_buffer, replacement);
+      strlcat(replace_buffer, jetsam, max_size + 1);
+      strlcat(replace_buffer, replacement, max_size + 1);
       *flow = temp;
       flow += strlen(pattern);
       jetsam = flow;
     }
-    strcat(replace_buffer, jetsam);
+    strlcat(replace_buffer, jetsam, max_size + 1);
   }
   else
   {
@@ -818,9 +824,10 @@ int replace_str(char **string, char *pattern, char *replacement, int rep_all, un
       i++;
       flow += strlen(pattern);
       len = ((char *)flow - (char *)*string) - strlen(pattern);
-      strncpy(replace_buffer, *string, len);
-      strcat(replace_buffer, replacement);
-      strcat(replace_buffer, flow);
+      memcpy(replace_buffer, *string, len);
+      replace_buffer[len] = '\0';
+      strlcat(replace_buffer, replacement, max_size + 1);
+      strlcat(replace_buffer, flow, max_size + 1);
     }
   }
 
@@ -829,7 +836,7 @@ int replace_str(char **string, char *pattern, char *replacement, int rep_all, un
   else
   {
     RECREATE(*string, char, strlen(replace_buffer) + 3);
-    strcpy(*string, replace_buffer);
+    memcpy(*string, replace_buffer, strlen(replace_buffer) + 1);
   }
   free(replace_buffer);
   return i;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -6702,9 +6702,9 @@ EVENTFUNC(get_protocols)
   len += snprintf(buf + len, MAX_STRING_LENGTH - len, "\tO[\toGMCP\tO] \tw%s\tn\r\n\r\n",
                   d->pProtocol->bGMCP ? "Yes" : "No");
 
-  write_to_output(d, buf, 0);
+  write_to_output(d, "%s", buf);
 
-  write_to_output(d, GREETINGS, 0);
+  write_to_output(d, "%s", GREETINGS);
   STATE(d) = CON_ACCOUNT_NAME; // CON_GET_NAME;
   return 0;
 }

--- a/src/mail.c
+++ b/src/mail.c
@@ -170,7 +170,7 @@ void store_mail(long to, long from, char *message_pointer)
   FILE *mail_file;
   struct mail_t *record = NULL;
 
-  if (!(mail_file = fopen(MAIL_FILE, "a")))
+  if (!(mail_file = fopen_restricted(MAIL_FILE, "a")))
   {
     perror("store_mail: Mail file not accessible.");
     return;
@@ -207,7 +207,7 @@ char *read_delete(long recipient)
     return strdup("Mail system malfunction - please report this");
   }
 
-  if (!(new_file = fopen(MAIL_FILE_TMP, "w")))
+  if (!(new_file = fopen_restricted(MAIL_FILE_TMP, "w")))
   {
     perror("read_delete: new Mail file not accessible.");
     fclose(mail_file);

--- a/src/msgedit.c
+++ b/src/msgedit.c
@@ -116,7 +116,11 @@ void load_messages(void)
     {
       if (!fgets(chk, 128, fl))
         break;
-      sscanf(chk, " %d\n", &type);
+      if (sscanf(chk, " %d\n", &type) != 1)
+      {
+        log("SYSERR: Invalid combat message type line: %s", chk);
+        exit(1);
+      }
       for (i = 0;
            (i < MAX_MESSAGES) && (fight_messages[i].a_type != type) && (fight_messages[i].a_type);
            i++)
@@ -193,7 +197,7 @@ void save_messages_to_disk(void)
   int i;
   struct message_type *msg;
 
-  if (!(fp = fopen(MESS_FILE, "w")))
+  if (!(fp = fopen_restricted(MESS_FILE, "w")))
   {
     log("SYSERR: Error writing combat message file %s: %s", MESS_FILE, strerror(errno));
     exit(1);

--- a/src/mud_event.c
+++ b/src/mud_event.c
@@ -262,7 +262,11 @@ EVENTFUNC(event_countdown)
         room_rnum eroom_rnum = NOWHERE;
         int x, y;
 
-        sscanf(*it, "%d", &eroom_vnum);
+        if (sscanf(*it, "%d", &eroom_vnum) != 1)
+        {
+          log("SYSERR: Invalid encounter room vnum: %s", *it);
+          continue;
+        }
         eroom_rnum = real_room(eroom_vnum);
         /* This log is causing lots of spam in our syslog.  Removing it. */
         /* log("LOG: Processing encounter room vnum: %d", eroom_vnum); */

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -772,7 +772,7 @@ void connect_to_mysql()
       continue;
 
     /* Parse key = value pairs */
-    else if (sscanf(line, "%s = %s", key, val) == 2)
+    else if (sscanf(line, "%127s = %127s", key, val) == 2)
     {
       /* Host configuration (e.g., localhost, 192.168.1.100, db.example.com) */
       if (!str_cmp(key, "mysql_host"))
@@ -2932,6 +2932,7 @@ bool get_random_region_location(region_vnum region, int *x, int *y)
   MYSQL_ROW row;
   int xlow, xhigh, ylow, yhigh;
   int xp, yp;
+  bool found_coordinate = false;
 
   char buf[MAX_STRING_LENGTH] = {'\0'};
   char buf2[MAX_STRING_LENGTH] = {'\0'};
@@ -2976,7 +2977,11 @@ bool get_random_region_location(region_vnum region, int *x, int *y)
     /* Parse the polygon text data to get the vertices, etc.
        eg: LINESTRING(0 0,10 0,10 10,0 10,0 0) */
     log(" Envelope: %s", row[0]);
-    sscanf(row[0], "POLYGON((%[^)]))", buf2);
+    if (sscanf(row[0], "POLYGON((%49151[^)]))", buf2) != 1)
+    {
+      log("SYSERR: Invalid spatial envelope: %s", row[0]);
+      continue;
+    }
     tokens = tokenize(buf2, ",");
     if (!tokens)
     {
@@ -2989,7 +2994,12 @@ bool get_random_region_location(region_vnum region, int *x, int *y)
     for (it = tokens; it && *it; ++it)
     {
       log(" Token: %s", *it);
-      sscanf(*it, "%d %d", &newx, &newy);
+      if (sscanf(*it, "%d %d", &newx, &newy) != 2)
+      {
+        log("SYSERR: Invalid spatial coordinate: %s", *it);
+        continue;
+      }
+      found_coordinate = true;
       if (newx < xlow)
         xlow = newx;
       if (newx > xhigh)
@@ -3003,6 +3013,12 @@ bool get_random_region_location(region_vnum region, int *x, int *y)
   }
 
   mysql_free_result(result);
+
+  if (!found_coordinate)
+  {
+    log("SYSERR: Region %d has no valid spatial coordinates.", region);
+    return false;
+  }
 
   log("xrange: %d - %d yrange: %d - %d", xlow, xhigh, ylow, yhigh);
 

--- a/src/mysql_boards.c
+++ b/src/mysql_boards.c
@@ -682,8 +682,7 @@ void mysql_board_show_list(struct char_data *ch, int board_id, int page)
     char unread_marker[10] = "";
     int post_id_val = atoi(row[0]);
     time_t post_time = (time_t)atol(row[3]);
-    struct tm *timeinfo = localtime(&post_time);
-    strftime(time_buf, sizeof(time_buf), "%m/%d/%y", timeinfo);
+    format_time_string(post_time, "%m/%d/%y", time_buf, sizeof(time_buf));
 
     /* Check if this post is unread by the player */
     if (!IS_NPC(ch) && GET_IDNUM(ch) > 0)
@@ -2027,7 +2026,7 @@ ACMD(do_boardfind)
   {
     has_filter = true;
     /* Convert filter to lowercase for case-insensitive comparison */
-    for (i = 0; arg[i] && i < (int)sizeof(filter_lower) - 1; i++)
+    for (i = 0; i < (int)sizeof(filter_lower) - 1 && arg[i]; i++)
     {
       filter_lower[i] = LOWER(arg[i]);
     }
@@ -2078,7 +2077,7 @@ ACMD(do_boardfind)
       int j;
 
       /* Convert board name to lowercase */
-      for (j = 0; board->board_name[j] && j < (int)sizeof(name_lower) - 1; j++)
+      for (j = 0; j < (int)sizeof(name_lower) - 1 && board->board_name[j]; j++)
       {
         name_lower[j] = LOWER(board->board_name[j]);
       }

--- a/src/oasis_list.c
+++ b/src/oasis_list.c
@@ -578,7 +578,7 @@ void perform_obj_type_list(struct char_data *ch, char *arg)
 void perform_obj_worn_list(struct char_data *ch, char *arg)
 {
   obj_rnum num;
-  int wearloc, found = 0, len = 0, tmp_len = 0, i = 0;
+  int wearloc, found = 0, len = 0, i = 0;
   obj_vnum ov;
   char buf[MAX_STRING_LENGTH] = {'\0'}, bitbuf[MEDIUM_STRING] = {'\0'};
   struct obj_data *obj = NULL;
@@ -609,8 +609,7 @@ void perform_obj_worn_list(struct char_data *ch, char *arg)
       ov = obj_index[num].vnum;
 
       /* display index, vnum */
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "%s%3d %7d ", QNRM, ++found, ov);
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "%s%3d %7d ", QNRM, ++found, ov);
 
       /* has affects? */
       /*
@@ -620,10 +619,9 @@ void perform_obj_worn_list(struct char_data *ch, char *arg)
        */
 
       /* display short descrip */
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "%-*s%s | ",
-                         32 + count_color_chars(obj_proto[num].short_description),
-                         obj_proto[num].short_description, QNRM);
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "%-*s%s | ",
+                            32 + count_color_chars(obj_proto[num].short_description),
+                            obj_proto[num].short_description, QNRM);
 
       /* has affect locations? */
       for (i = 0; i < MAX_OBJ_AFFECT; i++)
@@ -631,22 +629,19 @@ void perform_obj_worn_list(struct char_data *ch, char *arg)
         if ((obj->affected[i].location != APPLY_NONE) && (obj->affected[i].modifier != 0))
         {
           sprinttype(obj->affected[i].location, apply_types, bitbuf, sizeof(bitbuf));
-          tmp_len =
-              snprintf(buf + len, sizeof(buf) - len, "%s %d ", bitbuf, obj->affected[i].modifier);
-          len += tmp_len;
+          len = snprintf_append(buf, sizeof(buf), len, "%s %d ", bitbuf,
+                                obj->affected[i].modifier);
         }
       }
 
       /* sending a carrier return */
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "\r\n");
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "\r\n");
     }
 
     /* another dummy check */
     if (found >= 700)
     {
-      tmp_len = snprintf(buf + len, sizeof(buf) - len, "**OVERLOADED BUFF***\r\n");
-      len += tmp_len;
+      len = snprintf_append(buf, sizeof(buf), len, "**OVERLOADED BUFF***\r\n");
 
       break;
     }
@@ -1441,8 +1436,8 @@ static void list_rooms(struct char_data *ch, zone_rnum rnum, room_vnum vmin, roo
     {
       counter++;
 
-      len += snprintf(
-          buf + len, sizeof(buf) - len, "%4d)%s%s%s [%s%-5d%s] %s%-*s%s %s", counter, QYEL,
+      len = snprintf_append(
+          buf, sizeof(buf), len, "%4d)%s%s%s [%s%-5d%s] %s%-*s%s %s", counter, QYEL,
           (has_zcmds != NULL ? (has_zcmds[world[i].number - bottom] == TRUE ? "Z" : " ") : ""),
           QNRM, QGRN, world[i].number, QNRM, QCYN, count_color_chars(world[i].name) + 44,
           world[i].name, QNRM, world[i].proto_script ? "[TRIG] " : "");
@@ -1455,20 +1450,20 @@ static void list_rooms(struct char_data *ch, zone_rnum rnum, room_vnum vmin, roo
           continue;
 
         if (world[W_EXIT(i, j)->to_room].zone != world[i].zone)
-          len += snprintf(buf + len, sizeof(buf) - len, "(%s%d%s)", QYEL,
-                          world[W_EXIT(i, j)->to_room].number, QNRM);
+          len = snprintf_append(buf, sizeof(buf), len, "(%s%d%s)", QYEL,
+                                world[W_EXIT(i, j)->to_room].number, QNRM);
       }
 
-      len += snprintf(buf + len, sizeof(buf) - len, "\r\n");
+      len = snprintf_append(buf, sizeof(buf), len, "\r\n");
 
-      if ((size_t)len >= sizeof(buf))
+      if ((size_t)len >= sizeof(buf) - 1)
         break;
 
       /* still having issues with overflow, guessing it is a miscalculation with color codes -zusuk */
       if (counter >= 200)
       {
-        len += snprintf(buf + len, sizeof(buf) - len,
-                        "\r\n OVERFLOW, use a range to view the rest! \r\n");
+        len = snprintf_append(buf, sizeof(buf), len,
+                              "\r\n OVERFLOW, use a range to view the rest! \r\n");
         break;
       }
     }
@@ -1614,12 +1609,12 @@ static void list_objects_full(struct char_data *ch, zone_rnum rnum, obj_vnum vmi
         for (j = 1; j < NUM_ITEM_WEARS; j++)
         {
           if (IS_SET_AR(obj_proto[i].obj_flags.wear_flags, j))
-            len2 += snprintf(wears_text + len2, sizeof(wears_text) - len2, "%s ", wear_bits[j]);
+            len2 = snprintf_append(wears_text, sizeof(wears_text), len2, "%s ", wear_bits[j]);
         }
       }
 
-      len += snprintf(
-          buf + len, sizeof(buf) - len, "%s%-7d%s %2d %s %s%-*s %s%-12s%s %2d [%d] %s%-16s%s %s ",
+      len = snprintf_append(
+          buf, sizeof(buf), len, "%s%-7d%s %2d %s %s%-*s %s%-12s%s %2d [%d] %s%-16s%s %s ",
           QGRN, obj_index[i].vnum, QNRM, num_found,
           (!obj_proto[i].ex_description ? "\tRN\tn" : "\tWY\tn"), QCYN,
           count_color_chars(obj_proto[i].short_description) + 28, obj_proto[i].short_description,
@@ -1651,23 +1646,23 @@ static void list_objects_full(struct char_data *ch, zone_rnum rnum, obj_vnum vmi
             case APPLY_FEAT:
               snprintf(buf2, sizeof(buf2), " (%s)",
                        feat_list[obj_proto[i].affected[k].modifier].name);
-              len += snprintf(buf + len, sizeof(buf) - len, " %s%s", bitbuf, buf2);
+              len = snprintf_append(buf, sizeof(buf), len, " %s%s", bitbuf, buf2);
               break;
             default:
               buf2[0] = 0;
-              len += snprintf(buf + len, sizeof(buf) - len, " %s%s %s%d (%s)", bitbuf, buf2,
-                              (obj_proto[i].affected[k].modifier > 0) ? "+" : "",
-                              obj_proto[i].affected[k].modifier,
-                              bonus_types[obj_proto[i].affected[k].bonus_type]);
+              len = snprintf_append(buf, sizeof(buf), len, " %s%s %s%d (%s)", bitbuf, buf2,
+                                    (obj_proto[i].affected[k].modifier > 0) ? "+" : "",
+                                    obj_proto[i].affected[k].modifier,
+                                    bonus_types[obj_proto[i].affected[k].bonus_type]);
               break;
             }
           }
         }
       }
 
-      len += snprintf(buf + len, sizeof(buf) - len, "\r\n");
+      len = snprintf_append(buf, sizeof(buf), len, "\r\n");
 
-      if ((size_t)len >= sizeof(buf))
+      if ((size_t)len >= sizeof(buf) - 1)
         break;
     }
   }
@@ -1757,7 +1752,7 @@ static void list_shops(struct char_data *ch, zone_rnum rnum, shop_vnum vmin, sho
 static void list_zones(struct char_data *ch, zone_rnum rnum, zone_vnum vmin, zone_vnum vmax,
                        char *name)
 {
-  int counter = 0, len = 0, tmp_len = 0;
+  int counter = 0, len = 0;
   zone_rnum i;
   zone_vnum bottom, top;
   char buf[MAX_STRING_LENGTH] = {'\0'};
@@ -1786,7 +1781,8 @@ static void list_zones(struct char_data *ch, zone_rnum rnum, zone_vnum vmin, zon
                  "VNum  Zone Name                  Status    Builder(s)\r\n"
                  "----- -------------------------- ------ -------------------------------\r\n");
 
-  len += snprintf(buf + len, sizeof(buf) - len, "NOTE:  <*> Means Reserved, See HELP RESERVED\r\n");
+  len = snprintf_append(buf, sizeof(buf), len,
+                        "NOTE:  <*> Means Reserved, See HELP RESERVED\r\n");
 
   if (!top_of_zone_table)
     return;
@@ -1805,11 +1801,10 @@ static void list_zones(struct char_data *ch, zone_rnum rnum, zone_vnum vmin, zon
         else
           buf2 = strdup("\tmN-Reva\tn");
 
-        tmp_len = snprintf(buf + len, sizeof(buf) - len, "[%s%3d%s] %s%-*s %s %s%-1s%s\r\n", QGRN,
-                           zone_table[i].number, QNRM, QCYN,
-                           count_color_chars(zone_table[i].name) + 26, zone_table[i].name, buf2,
-                           QYEL, zone_table[i].builders ? zone_table[i].builders : "None.", QNRM);
-        len += tmp_len;
+        len = snprintf_append(buf, sizeof(buf), len, "[%s%3d%s] %s%-*s %s %s%-1s%s\r\n", QGRN,
+                              zone_table[i].number, QNRM, QCYN,
+                              count_color_chars(zone_table[i].name) + 26, zone_table[i].name, buf2,
+                              QYEL, zone_table[i].builders ? zone_table[i].builders : "None.", QNRM);
         counter++;
       }
     }

--- a/src/objsave.c
+++ b/src/objsave.c
@@ -2076,7 +2076,11 @@ obj_save_data *objsave_parse_objects(FILE *fl)
     case 'F':
       if (!strcmp(tag, "Flag"))
       {
-        sscanf(line, "%s %s %s %s", f1, f2, f3, f4);
+        if (sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4) != 4)
+        {
+          log("SYSERR: Invalid Flag record in object save file: %s", line);
+          break;
+        }
         GET_OBJ_EXTRA(temp)
         [0] = asciiflag_conv(f1);
         GET_OBJ_EXTRA(temp)
@@ -2104,7 +2108,11 @@ obj_save_data *objsave_parse_objects(FILE *fl)
     case 'P':
       if (!strcmp(tag, "Perm"))
       {
-        sscanf(line, "%s %s %s %s", f1, f2, f3, f4);
+        if (sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4) != 4)
+        {
+          log("SYSERR: Invalid Perm record in object save file: %s", line);
+          break;
+        }
         GET_OBJ_AFFECT(temp)
         [0] = asciiflag_conv(f1);
         GET_OBJ_AFFECT(temp)
@@ -2116,7 +2124,11 @@ obj_save_data *objsave_parse_objects(FILE *fl)
       }
       else if (!strcmp(tag, "Prm2"))
       {
-        sscanf(line, "%s %s %s %s", f1, f2, f3, f4);
+        if (sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4) != 4)
+        {
+          log("SYSERR: Invalid Prm2 record in object save file: %s", line);
+          break;
+        }
         GET_OBJ2_PERM(temp)
         [0] = asciiflag_conv(f1);
         GET_OBJ2_PERM(temp)
@@ -2165,9 +2177,13 @@ obj_save_data *objsave_parse_objects(FILE *fl)
       }
       else if (!strcmp(tag, "SpAb"))
       {
+        if (sscanf(line, "%d %d %d %d %d %d %d %127s", &t[0], &t[1], &t[2], &t[3], &t[4],
+                   &t[5], &t[6], f1) != 8)
+        {
+          log("SYSERR: Invalid SpAb record in object save file: %s", line);
+          break;
+        }
         CREATE(temp->special_abilities, struct obj_special_ability, 1);
-        sscanf(line, "%d %d %d %d %d %d %d %s", &t[0], &t[1], &t[2], &t[3], &t[4], &t[5], &t[6],
-               f1);
         temp->special_abilities->ability = t[0];
         temp->special_abilities->level = t[1];
         temp->special_abilities->activation_method = t[2];
@@ -2185,7 +2201,11 @@ obj_save_data *objsave_parse_objects(FILE *fl)
     case 'W':
       if (!strcmp(tag, "Wear"))
       {
-        sscanf(line, "%s %s %s %s", f1, f2, f3, f4);
+        if (sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4) != 4)
+        {
+          log("SYSERR: Invalid Wear record in object save file: %s", line);
+          break;
+        }
         GET_OBJ_WEAR(temp)
         [0] = asciiflag_conv(f1);
         GET_OBJ_WEAR(temp)
@@ -2777,7 +2797,7 @@ static int Crash_load_objs(struct char_data *ch)
   int i, num_of_days, orig_rent_code, num_objs = 0;
   unsigned long cost;
   struct obj_data *cont_row[MAX_BAG_ROWS];
-  int rentcode, timed, netcost, gold, account, nitems;
+  int rentcode = RENT_UNDEF, timed = 0, netcost = 0, gold = 0, account = 0, nitems = 0;
   obj_save_data *loaded, *current;
 
   bool using_db = false; /* Needed outside the ifdefined */

--- a/src/objsave.c
+++ b/src/objsave.c
@@ -839,7 +839,11 @@ int Crash_delete_crashfile(struct char_data *ch)
 
   if (numread == FALSE)
     return FALSE;
-  sscanf(line, "%d ", &rentcode);
+  if (sscanf(line, "%d ", &rentcode) != 1)
+  {
+    log("SYSERR: Invalid rent code in object file %s.", filename);
+    return FALSE;
+  }
 
   if (rentcode == RENT_CRASH)
     Crash_delete_file(GET_NAME(ch));
@@ -871,7 +875,12 @@ int Crash_clean_file(char *name)
   if (numread == FALSE)
     return FALSE;
 
-  sscanf(line, "%d %d %d %d %d %d", &rentcode, &timed, &netcost, &gold, &account, &nitems);
+  if (sscanf(line, "%d %d %d %d %d %d", &rentcode, &timed, &netcost, &gold, &account,
+             &nitems) != 6)
+  {
+    log("SYSERR: Invalid rent header in object file %s.", filename);
+    return FALSE;
+  }
 
   if ((rentcode == RENT_CRASH) || (rentcode == RENT_FORCED) || (rentcode == RENT_TIMEDOUT))
   {
@@ -945,34 +954,40 @@ void Crash_listrent(struct char_data *ch, char *name)
     return;
   }
 
-  sscanf(line, "%d %d %d %d %d %d", &rentcode, &timed, &netcost, &gold, &account, &nitems);
+  if (sscanf(line, "%d %d %d %d %d %d", &rentcode, &timed, &netcost, &gold, &account,
+             &nitems) != 6)
+  {
+    send_to_char(ch, "Invalid rent information.\r\n");
+    fclose(fl);
+    return;
+  }
 
   switch (rentcode)
   {
   case RENT_RENTED:
-    len += snprintf(buf + len, sizeof(buf) - len, "Rent\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "Rent\r\n");
     break;
   case RENT_CRASH:
-    len += snprintf(buf + len, sizeof(buf) - len, "Crash\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "Crash\r\n");
     break;
   case RENT_CRYO:
-    len += snprintf(buf + len, sizeof(buf) - len, "Cryo\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "Cryo\r\n");
     break;
   case RENT_TIMEDOUT:
   case RENT_FORCED:
-    len += snprintf(buf + len, sizeof(buf) - len, "TimedOut\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "TimedOut\r\n");
     break;
   default:
-    len += snprintf(buf + len, sizeof(buf) - len, "Undef\r\n");
+    len = snprintf_append(buf, sizeof(buf), len, "Undef\r\n");
     break;
   }
 
   loaded = objsave_parse_objects(fl);
 
   for (current = loaded; current != NULL; current = current->next)
-    len += snprintf(buf + len, sizeof(buf) - len, "[%5d] (%5dau) %-20s\r\n",
-                    GET_OBJ_VNUM(current->obj), GET_OBJ_RENT(current->obj),
-                    current->obj->short_description);
+    len = snprintf_append(buf, sizeof(buf), len, "[%5d] (%5dau) %-20s\r\n",
+                          GET_OBJ_VNUM(current->obj), GET_OBJ_RENT(current->obj),
+                          current->obj->short_description);
 
   /* Now it's safe to free the obj_save_data list and the objects on it. */
   while (loaded != NULL)
@@ -1174,7 +1189,7 @@ void Crash_crashsave(struct char_data *ch)
   if (!get_filename(buf, sizeof(buf), CRASH_FILE, GET_NAME(ch)))
     return;
 
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
     return;
 
 #ifdef OBJSAVE_DB
@@ -1277,7 +1292,7 @@ void Crash_idlesave(struct char_data *ch)
   if (!get_filename(buf, sizeof(buf), CRASH_FILE, GET_NAME(ch)))
     return;
 
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
     return;
 
 #ifdef OBJSAVE_DB
@@ -1416,7 +1431,7 @@ void Crash_rentsave(struct char_data *ch, int cost)
   if (!get_filename(buf, sizeof(buf), CRASH_FILE, GET_NAME(ch)))
     return;
 
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
     return;
 
 #ifdef OBJSAVE_DB
@@ -1553,7 +1568,7 @@ static void Crash_cryosave(struct char_data *ch, int cost)
   if (!get_filename(buf, sizeof(buf), CRASH_FILE, GET_NAME(ch)))
     return;
 
-  if (!(fp = fopen(buf, "w")))
+  if (!(fp = fopen_restricted(buf, "w")))
     return;
 
   Crash_extract_norent_eq(ch);
@@ -1668,7 +1683,7 @@ static int Crash_offer_rent(struct char_data *ch, struct char_data *recep, int d
   if (norent)
     return FALSE;
 
-  totalcost = CONFIG_MIN_RENT_COST * factor;
+  totalcost = (long)CONFIG_MIN_RENT_COST * factor;
 
   Crash_report_rent(ch, recep, ch->carrying, &totalcost, &numitems, display, factor);
 
@@ -2850,8 +2865,12 @@ static int Crash_load_objs(struct char_data *ch)
   if (!using_db)
   {
     if (!get_line(fl, line))
+    {
       mudlog(NRM, MAX(LVL_IMMORT, GET_INVIS_LEV(ch)), TRUE,
              "Failed to read player's rent code: %s.", GET_NAME(ch));
+      fclose(fl);
+      return 1;
+    }
     else if (sscanf(line, "%d %d %d %d %d %d", &rentcode, &timed, &netcost, &gold, &account,
                     &nitems) != 6)
     {

--- a/src/player_rename.c
+++ b/src/player_rename.c
@@ -687,22 +687,58 @@ static int rename_pfile_scanner_complete(const struct rename_pfile_scanner *scan
          scanner->device_block == RENAME_DEVICE_BLOCK_NONE && scanner->opaque_lines_remaining == 0;
 }
 
+static FILE *rename_open_regular(const char *path, const char *mode, struct stat *file_stat)
+{
+  FILE *file;
+  struct stat opened_stat;
+  int fd;
+  int flags = O_RDONLY;
+
+#ifdef O_NOFOLLOW
+  flags |= O_NOFOLLOW;
+#endif
+
+  fd = open(path, flags);
+  if (fd < 0)
+    return NULL;
+  if (fstat(fd, &opened_stat) != 0)
+  {
+    close(fd);
+    return NULL;
+  }
+  if (!S_ISREG(opened_stat.st_mode))
+  {
+    close(fd);
+    errno = EINVAL;
+    return NULL;
+  }
+
+  file = fdopen(fd, mode);
+  if (!file)
+  {
+    close(fd);
+    return NULL;
+  }
+
+  if (file_stat)
+    *file_stat = opened_stat;
+  return file;
+}
+
 static int rename_file_contains_intro(const char *path, const char *old_name)
 {
   FILE *file;
-  struct stat file_stat;
   struct rename_pfile_scanner scanner = {0};
   char line[MAX_STRING_LENGTH + 2];
   int found = FALSE;
 
-  if (lstat(path, &file_stat) != 0)
+  file = rename_open_regular(path, "r", NULL);
+  if (!file)
   {
     if (errno == ENOENT)
       return FALSE;
     return -1;
   }
-  if (!S_ISREG(file_stat.st_mode) || !(file = fopen(path, "r")))
-    return -1;
 
   while (fgets(line, sizeof(line), file))
   {
@@ -732,7 +768,8 @@ static int rename_source_player_identity_matches(const char *path, const char *o
   int id_lines = 0;
   int account_lines = 0;
 
-  if (!(file = fopen(path, "r")))
+  file = rename_open_regular(path, "r", NULL);
+  if (!file)
     return FALSE;
   while (fgets(line, sizeof(line), file))
   {
@@ -969,8 +1006,8 @@ static int rename_copy_to_backup(const char *source, char *backup, size_t backup
   if (snprintf(backup, backup_size, "%s.rename-bak.XXXXXX", source) >= (int)backup_size)
     return FALSE;
 
-  if (lstat(source, &source_stat) != 0 || !S_ISREG(source_stat.st_mode) ||
-      !(input = fopen(source, "rb")))
+  input = rename_open_regular(source, "rb", &source_stat);
+  if (!input)
     return FALSE;
 
   if ((fd = mkstemp(backup)) < 0)
@@ -1058,14 +1095,13 @@ static int rename_file_matches_snapshot(const char *path, const char *snapshot)
   size_t saved_count;
   int matches = FALSE;
 
-  if (lstat(path, &current_stat) != 0 || lstat(snapshot, &saved_stat) != 0 ||
-      !S_ISREG(current_stat.st_mode) || !S_ISREG(saved_stat.st_mode) ||
-      current_stat.st_size != saved_stat.st_size ||
+  current = rename_open_regular(path, "rb", &current_stat);
+  saved = rename_open_regular(snapshot, "rb", &saved_stat);
+  if (!current || !saved || current_stat.st_size != saved_stat.st_size ||
       (current_stat.st_mode & 07777) != (saved_stat.st_mode & 07777) ||
       current_stat.st_uid != saved_stat.st_uid || current_stat.st_gid != saved_stat.st_gid ||
       current_stat.st_mtim.tv_sec != saved_stat.st_mtim.tv_sec ||
-      current_stat.st_mtim.tv_nsec != saved_stat.st_mtim.tv_nsec ||
-      !(current = fopen(path, "rb")) || !(saved = fopen(snapshot, "rb")))
+      current_stat.st_mtim.tv_nsec != saved_stat.st_mtim.tv_nsec)
     goto cleanup;
 
   do
@@ -1175,8 +1211,8 @@ static int rename_rewrite_player_file(const char *path, const char *old_name, co
   if (snprintf(temporary, sizeof(temporary), "%s.rename-tmp.XXXXXX", path) >=
       (int)sizeof(temporary))
     return FALSE;
-  if (lstat(path, &source_stat) != 0 || !S_ISREG(source_stat.st_mode) ||
-      !(input = fopen(path, "r")))
+  input = rename_open_regular(path, "r", &source_stat);
+  if (!input)
     return FALSE;
   if ((fd = mkstemp(temporary)) < 0)
   {
@@ -2275,7 +2311,8 @@ static int rename_verify_player_file(struct rename_context *ctx)
   int id_count = 0;
   int id_lines = 0;
 
-  if (!(file = fopen(ctx->files[0].new_path, "r")))
+  file = rename_open_regular(ctx->files[0].new_path, "r", NULL);
+  if (!file)
     return FALSE;
 
   while (fgets(line, sizeof(line), file))
@@ -2340,7 +2377,8 @@ static int rename_verify_index_file(struct rename_context *ctx)
   long id;
   int target_count = 0;
 
-  if (!(file = fopen(ctx->index_path, "r")))
+  file = rename_open_regular(ctx->index_path, "r", NULL);
+  if (!file)
     return FALSE;
   while (fgets(line, sizeof(line), file))
   {
@@ -2416,7 +2454,8 @@ static int rename_verify_old_index_file(struct rename_context *ctx)
   int player_id_count = 0;
   int old_name_count = 0;
 
-  if (!(file = fopen(ctx->index_path, "r")))
+  file = rename_open_regular(ctx->index_path, "r", NULL);
+  if (!file)
     return FALSE;
   while (fgets(line, sizeof(line), file))
   {

--- a/src/players.c
+++ b/src/players.c
@@ -170,11 +170,12 @@ void build_player_index(void)
   for (i = 0; i < rec_count; i++)
   {
     get_line(plr_index, line);
-    if ((nr = sscanf(line, "%ld %s %d %s %ld %d", &player_table[i].id, arg2, &player_table[i].level,
-                     bits, (long *)&player_table[i].last, &player_table[i].clan)) != 6)
+    if ((nr = sscanf(line, "%ld %79s %d %63s %ld %d", &player_table[i].id, arg2,
+                     &player_table[i].level, bits, (long *)&player_table[i].last,
+                     &player_table[i].clan)) != 6)
     {
-      if ((nr = sscanf(line, "%ld %s %d %s %ld", &player_table[i].id, arg2, &player_table[i].level,
-                       bits, (long *)&player_table[i].last)) != 5)
+      if ((nr = sscanf(line, "%ld %79s %d %63s %ld", &player_table[i].id, arg2,
+                       &player_table[i].level, bits, (long *)&player_table[i].last)) != 5)
       {
         log("SYSERR: Invalid line in player index (%s)", line);
         continue;
@@ -427,7 +428,7 @@ char *get_name_by_id(long id)
  * if not. */
 int load_char(const char *name, struct char_data *ch)
 {
-  int id, i, j;
+  int id, i, j, parsed;
   FILE *fl;
   char filename[40];
   char buf[128], buf2[128], line[MAX_INPUT_LENGTH + 1], tag[6];
@@ -800,7 +801,7 @@ int load_char(const char *name, struct char_data *ch)
         }
         else if (!strcmp(tag, "Act "))
         {
-          if (sscanf(line, "%s %s %s %s", f1, f2, f3, f4) == 4)
+          if (sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4) == 4)
           {
             PLR_FLAGS(ch)
             [0] = asciiflag_conv(f1);
@@ -817,7 +818,7 @@ int load_char(const char *name, struct char_data *ch)
         }
         else if (!strcmp(tag, "Aff "))
         {
-          if (sscanf(line, "%s %s %s %s", f1, f2, f3, f4) == 4)
+          if (sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4) == 4)
           {
             AFF_FLAGS(ch)
             [0] = asciiflag_conv(f1);
@@ -900,7 +901,11 @@ int load_char(const char *name, struct char_data *ch)
       case 'C':
         if (!strcmp(tag, "CbFt"))
         {
-          sscanf(line, "%d %s %s %s %s", &i, f1, f2, f3, f4);
+          if (sscanf(line, "%d %127s %127s %127s %127s", &i, f1, f2, f3, f4) != 5)
+          {
+            log("load_char: %s has an invalid combat feat record: %s", GET_NAME(ch), line);
+            break;
+          }
           if (i < 0 || i >= NUM_CFEATS)
           {
             log("load_char: %s combat feat record out of range: %s", GET_NAME(ch), line);
@@ -1359,7 +1364,7 @@ int load_char(const char *name, struct char_data *ch)
         if (!strcmp(tag, "Page"))
           GET_PAGE_LENGTH(ch) = atoi(line);
         else if (!strcmp(tag, "Pass"))
-          strcpy(GET_PASSWD(ch), line);
+          strlcpy(GET_PASSWD(ch), line, sizeof(ch->player.passwd));
         else if (!strcmp(tag, "Potn"))
           load_potions(fl, ch);
         else if (!strcmp(tag, "Plyd"))
@@ -1382,7 +1387,8 @@ int load_char(const char *name, struct char_data *ch)
           POOFOUT(ch) = strdup(line);
         else if (!strcmp(tag, "Pref"))
         {
-          if (sscanf(line, "%s %s %s %s", f1, f2, f3, f4) == 4)
+          parsed = sscanf(line, "%127s %127s %127s %127s", f1, f2, f3, f4);
+          if (parsed == 4)
           {
             PRF_FLAGS(ch)
             [0] = asciiflag_conv(f1);
@@ -1393,9 +1399,11 @@ int load_char(const char *name, struct char_data *ch)
             PRF_FLAGS(ch)
             [3] = asciiflag_conv(f4);
           }
-          else
+          else if (parsed == 1)
             PRF_FLAGS(ch)
           [0] = asciiflag_conv(f1);
+          else
+            log("load_char: %s has an invalid preference flag record: %s", GET_NAME(ch), line);
         }
         else if (!strcmp(tag, "PrQu"))
           load_spell_prep_queue(fl, ch);
@@ -1726,7 +1734,11 @@ int load_char(const char *name, struct char_data *ch)
           GET_BLOODLINE_SUBTYPE(ch) = atoi(line);
         else if (!strcmp(tag, "SclF"))
         {
-          sscanf(line, "%d %s", &i, f1);
+          if (sscanf(line, "%d %127s", &i, f1) != 2)
+          {
+            log("load_char: %s has an invalid school feat record: %s", GET_NAME(ch), line);
+            break;
+          }
           if (i < 0 || i >= NUM_SFEATS)
           {
             log("load_char: %s school feat record out of range: %s", GET_NAME(ch), line);

--- a/src/players.c
+++ b/src/players.c
@@ -130,6 +130,7 @@ void pet_load_objs(struct char_data *ch, struct char_data *owner, long int pet_i
 void build_player_index(void)
 {
   int rec_count = 0, i, nr;
+  size_t name_length;
   FILE *plr_index;
   char index_name[40], line[MEDIUM_STRING] = {'\0'}, bits[64];
   char arg2[80];
@@ -182,8 +183,9 @@ void build_player_index(void)
       }
       player_table[i].clan = NO_CLAN;
     }
-    CREATE(player_table[i].name, char, strlen(arg2) + 1);
-    strcpy(player_table[i].name, arg2);
+    name_length = strlen(arg2) + 1;
+    CREATE(player_table[i].name, char, name_length);
+    memcpy(player_table[i].name, arg2, name_length);
     player_table[i].flags = asciiflag_conv(bits);
     top_idnum = MAX(top_idnum, player_table[i].id);
   }

--- a/src/players.c
+++ b/src/players.c
@@ -2252,7 +2252,7 @@ bool save_char_checked(struct char_data *ch, int mode)
     free(write_buffer);
     return FALSE;
   }
-  if (!(fl = fopen(filename, "w")))
+  if (!(fl = fopen_restricted(filename, "w")))
   {
     mudlog(NRM, LVL_STAFF, TRUE, "SYSERR: Couldn't open player file %s for write", filename);
     free(write_buffer);
@@ -4159,8 +4159,17 @@ static void load_dr(FILE *f1, struct char_data *ch)
 
   do
   {
-    get_line(f1, line);
+    if (!get_line(f1, line))
+    {
+      log("SYSERR: Unexpected end of player file while loading damage reduction.");
+      return;
+    }
     n_vars = sscanf(line, "%d %d %d %d %d", &num, &num2, &num3, &num4, &num5);
+    if (n_vars < 1)
+    {
+      log("SYSERR: Invalid damage reduction line: %s", line);
+      return;
+    }
     if (num > 0)
     {
       /* Set the DR data.*/
@@ -5361,22 +5370,23 @@ void update_player_last_on(void)
     if (GET_LEVEL(ch) < LVL_IMMORT)
     {
       int inc, classCount = 0;
-      len += snprintf(classes_list + len, sizeof(classes_list) - len, "[%2d %4s ", GET_LEVEL(ch),
-                      RACE_ABBR_REAL(ch));
+      len = snprintf_append(classes_list, sizeof(classes_list), len, "[%2d %4s ", GET_LEVEL(ch),
+                            RACE_ABBR_REAL(ch));
       for (inc = 0; inc < MAX_CLASSES; inc++)
       {
         if (CLASS_LEVEL(ch, inc))
         {
           if (classCount)
-            len += snprintf(classes_list + len, sizeof(classes_list) - len, "|");
-          len += snprintf(classes_list + len, sizeof(classes_list) - len, "%s", CLSLIST_ABBRV(inc));
+            len = snprintf_append(classes_list, sizeof(classes_list), len, "|");
+          len =
+              snprintf_append(classes_list, sizeof(classes_list), len, "%s", CLSLIST_ABBRV(inc));
           classCount++;
         }
       }
       class_len = strlen(classes_list) - count_color_chars(classes_list);
       while (class_len < 11)
       {
-        len += snprintf(classes_list + len, sizeof(classes_list) - len, " ");
+        len = snprintf_append(classes_list, sizeof(classes_list), len, " ");
         class_len++;
       }
       snprintf(char_info, sizeof(char_info), "%s]", classes_list);

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -835,7 +835,7 @@ ssize_t ProtocolInput(descriptor_t *apDescriptor, char *apData, int aSize, char 
   /* Copy the input buffer back to the player. */
   if (strlen(apOut) + strlen(CmdBuf) + 1 < MAX_PROTOCOL_BUFFER)
   {
-    strcat(apOut, CmdBuf);
+    strlcat(apOut, CmdBuf, MAX_PROTOCOL_BUFFER);
   }
   else
   {
@@ -934,13 +934,14 @@ const char *ProtocolOutput(descriptor_t *apDescriptor, const char *apData, int *
 
           if (!bDone)
           {
-            sprintf(BugString, "BUG: Unicode substitute '%s' wasn't terminated with ']'.\n",
-                    Buffer);
+            snprintf(BugString, sizeof(BugString),
+                     "BUG: Unicode substitute '%s' wasn't terminated with ']'.\n", Buffer);
             ReportBug(BugString);
           }
           else if (!bValid)
           {
-            sprintf(BugString, "BUG: Unicode substitute '%s' truncated.  Missing ']'?\n", Buffer);
+            snprintf(BugString, sizeof(BugString),
+                     "BUG: Unicode substitute '%s' truncated.  Missing ']'?\n", Buffer);
             ReportBug(BugString);
           }
           else if (pProtocol->pVariables[eMSDP_UTF_8]->ValueInt)
@@ -976,14 +977,15 @@ const char *ProtocolOutput(descriptor_t *apDescriptor, const char *apData, int *
 
           if (!bDone || !bValid)
           {
-            sprintf(BugString, "BUG: RGB %sground colour '%s' wasn't terminated with ']'.\n",
-                    (tolower(Buffer[0]) == 'f') ? "fore" : "back", &Buffer[1]);
+            snprintf(BugString, sizeof(BugString),
+                     "BUG: RGB %sground colour '%s' wasn't terminated with ']'.\n",
+                     (tolower(Buffer[0]) == 'f') ? "fore" : "back", &Buffer[1]);
             ReportBug(BugString);
           }
           else if (!IsValidColour(Buffer))
           {
-            sprintf(
-                BugString,
+            snprintf(
+                BugString, sizeof(BugString),
                 "BUG: RGB %sground colour '%s' invalid (each digit must be in the range 0-5).\n",
                 (tolower(Buffer[0]) == 'f') ? "fore" : "back", &Buffer[1]);
             ReportBug(BugString);
@@ -1016,13 +1018,14 @@ const char *ProtocolOutput(descriptor_t *apDescriptor, const char *apData, int *
 
           if (!bDone)
           {
-            sprintf(BugString, "BUG: Required MXP version '%s' wasn't terminated with ']'.\n",
-                    Buffer);
+            snprintf(BugString, sizeof(BugString),
+                     "BUG: Required MXP version '%s' wasn't terminated with ']'.\n", Buffer);
             ReportBug(BugString);
           }
           else if (!bValid)
           {
-            sprintf(BugString, "BUG: Required MXP version '%s' too long.  Missing ']'?\n", Buffer);
+            snprintf(BugString, sizeof(BugString),
+                     "BUG: Required MXP version '%s' too long.  Missing ']'?\n", Buffer);
             ReportBug(BugString);
           }
           else if (!strcmp(pProtocol->pMXPVersion, "Unknown") ||

--- a/src/quest.c
+++ b/src/quest.c
@@ -323,8 +323,9 @@ void parse_quest(FILE *quest_f, int nr)
   /***** */
 
   /* parse value line (2nd if Dragonlance Campaign) */
-  if (!get_line(quest_f, line) || (retval = sscanf(line, " %d %d %s %d %d %d %d", t, t + 1, f1,
-                                                   t + 2, t + 3, t + 4, t + 5)) != 7)
+  if (!get_line(quest_f, line) ||
+      (retval = sscanf(line, " %d %d %127s %d %d %d %d", t, t + 1, f1, t + 2, t + 3, t + 4,
+                       t + 5)) != 7)
   {
     log("Format error in numeric line 1 (expected 7, got %d), %s\n", retval, line);
     exit(1);

--- a/src/quest.c
+++ b/src/quest.c
@@ -354,13 +354,12 @@ void parse_quest(FILE *quest_f, int nr)
   /* parse the next line of values
        re-wrote this to handle the old 3 values or new 7 values -zusuk */
   if (!get_line(quest_f, line) ||
-      (retval = sscanf(line, " %d %d %d %d %d %d %d", t, t + 1, t + 2, t + 3, t + 4, t + 5, t + 6)))
+      ((retval = sscanf(line, " %d %d %d %d %d %d %d", t, t + 1, t + 2, t + 3, t + 4, t + 5,
+                        t + 6)) != 3 &&
+       retval != 7))
   {
-    if (retval != 3 && retval != 7)
-    {
-      log("Format error in numeric line 3 (expected 3 or 7, got %d), %s\n", retval, line);
-      exit(1); /* harsh but defensive -> game won't start */
-    }
+    log("Format error in numeric line 3 (expected 3 or 7, got %d), %s\n", retval, line);
+    exit(1); /* harsh but defensive -> game won't start */
   }
 
   /* assign for 3 values */

--- a/src/race.c
+++ b/src/race.c
@@ -342,8 +342,8 @@ bool display_race_info(struct char_data *ch, const char *racename)
     if (stat_mod != 0)
     {
       found = TRUE;
-      len += snprintf(buf + len, sizeof(buf) - len, "%s %s%d ", abil_mod_names[i],
-                      (stat_mod > 0) ? "+" : "", stat_mod);
+      len = snprintf_append(buf, sizeof(buf), len, "%s %s%d ", abil_mod_names[i],
+                            (stat_mod > 0) ? "+" : "", stat_mod);
     }
   }
 

--- a/src/shop.c
+++ b/src/shop.c
@@ -111,6 +111,8 @@ static int ok_shop_room(int shop_nr, room_vnum room);
 static int add_to_shop_list(struct shop_buy_data *list, int type, int *len, int *val);
 static int end_read_list(struct shop_buy_data *list, int len, int error);
 static void read_line(FILE *shop_f, const char *string, void *data);
+static void format_shop_message(char *dest, size_t dest_size, const char *message,
+                                const char *name, int amount);
 
 /* Local file scope only variables */
 static int cmd_say;
@@ -121,6 +123,53 @@ static int cmd_shake;
 
 /* config arrays */
 static const char *operator_str[] = {"[({", "])}", "|+", "&*", "^'"};
+
+static void format_shop_message(char *dest, size_t dest_size, const char *message,
+                                const char *name, int amount)
+{
+  const char *cursor = message;
+  const char *replacement = NULL;
+  char amount_text[32] = {'\0'};
+  size_t copy_len = 0;
+  size_t used = 0;
+
+  if (!dest || dest_size == 0)
+    return;
+
+  dest[0] = '\0';
+  if (!message)
+    return;
+
+  snprintf(amount_text, sizeof(amount_text), "%d", amount);
+
+  while (*cursor && used + 1 < dest_size)
+  {
+    replacement = NULL;
+    if (*cursor == '%' && cursor[1])
+    {
+      if (cursor[1] == 's')
+        replacement = name ? name : "";
+      else if (cursor[1] == 'd')
+        replacement = amount_text;
+      else if (cursor[1] == '%')
+        replacement = "%";
+    }
+
+    if (replacement)
+    {
+      copy_len = MIN(strlen(replacement), dest_size - used - 1);
+      memcpy(dest + used, replacement, copy_len);
+      used += copy_len;
+      cursor += 2;
+    }
+    else
+    {
+      dest[used++] = *cursor++;
+    }
+  }
+
+  dest[used] = '\0';
+}
 
 static int is_ok_char(struct char_data *keeper, struct char_data *ch, int shop_nr)
 {
@@ -507,7 +556,7 @@ static struct obj_data *get_purchase_obj(struct char_data *ch, char *arg, struct
       {
         char buf[MAX_INPUT_LENGTH] = {'\0'};
 
-        snprintf(buf, sizeof(buf), shop_index[shop_nr].no_such_item1, GET_NAME(ch));
+        format_shop_message(buf, sizeof(buf), shop_index[shop_nr].no_such_item1, GET_NAME(ch), 0);
         do_tell(keeper, buf, cmd_tell, 0);
       }
       return (NULL);
@@ -631,7 +680,8 @@ static void shopping_buy(char *arg, struct char_data *ch, struct char_data *keep
     {
       char actbuf[MAX_INPUT_LENGTH] = {'\0'};
 
-      snprintf(actbuf, sizeof(actbuf), shop_index[shop_nr].missing_cash2, GET_NAME(ch));
+      format_shop_message(actbuf, sizeof(actbuf), shop_index[shop_nr].missing_cash2, GET_NAME(ch),
+                          0);
       do_tell(keeper, actbuf, cmd_tell, 0);
 
       switch (SHOP_BROKE_TEMPER(shop_nr))
@@ -851,7 +901,8 @@ static void shopping_buy(char *arg, struct char_data *ch, struct char_data *keep
     snprintf(tempbuf, sizeof(tempbuf), "%s That has cost you %d account experience.", GET_NAME(ch),
              goldamt);
   else if (shop_index[shop_nr].message_buy != NULL)
-    snprintf(tempbuf, sizeof(tempbuf), shop_index[shop_nr].message_buy, GET_NAME(ch), goldamt);
+    format_shop_message(tempbuf, sizeof(tempbuf), shop_index[shop_nr].message_buy, GET_NAME(ch),
+                        goldamt);
   else
     snprintf(tempbuf, sizeof(tempbuf), "%s That will cost you %d coins.", GET_NAME(ch), goldamt);
 
@@ -874,7 +925,7 @@ static struct obj_data *get_selling_obj(struct char_data *ch, char *name, struct
     {
       char tbuf[MAX_INPUT_LENGTH] = {'\0'};
 
-      snprintf(tbuf, sizeof(tbuf), shop_index[shop_nr].no_such_item2, GET_NAME(ch));
+      format_shop_message(tbuf, sizeof(tbuf), shop_index[shop_nr].no_such_item2, GET_NAME(ch), 0);
       do_tell(keeper, tbuf, cmd_tell, 0);
     }
     return (NULL);
@@ -892,7 +943,7 @@ static struct obj_data *get_selling_obj(struct char_data *ch, char *name, struct
              GET_NAME(ch));
     break;
   case OBJECT_NOTOK:
-    snprintf(buf, sizeof(buf), shop_index[shop_nr].do_not_buy, GET_NAME(ch));
+    format_shop_message(buf, sizeof(buf), shop_index[shop_nr].do_not_buy, GET_NAME(ch), 0);
     break;
   case OBJECT_DEAD:
     snprintf(buf, sizeof(buf), "%s %s", GET_NAME(ch), MSG_NO_USED_WANDSTAFF);
@@ -1013,7 +1064,7 @@ static void shopping_sell(char *arg, struct char_data *ch, struct char_data *kee
   {
     char buf[MAX_INPUT_LENGTH] = {'\0'};
 
-    snprintf(buf, sizeof(buf), shop_index[shop_nr].missing_cash1, GET_NAME(ch));
+    format_shop_message(buf, sizeof(buf), shop_index[shop_nr].missing_cash1, GET_NAME(ch), 0);
     do_tell(keeper, buf, cmd_tell, 0);
     return;
   }
@@ -1060,7 +1111,8 @@ static void shopping_sell(char *arg, struct char_data *ch, struct char_data *kee
   act(tempbuf, FALSE, ch, obj, 0, TO_ROOM);
 
   if (shop_index[shop_nr].message_sell != NULL)
-    snprintf(tempbuf, sizeof(tempbuf), shop_index[shop_nr].message_sell, GET_NAME(ch), goldamt);
+    format_shop_message(tempbuf, sizeof(tempbuf), shop_index[shop_nr].message_sell, GET_NAME(ch),
+                        goldamt);
   else
     snprintf(tempbuf, sizeof(tempbuf), "%s I will give you %d coins for that.", GET_NAME(ch),
              goldamt);
@@ -1437,11 +1489,20 @@ static int read_type_list(FILE *shop_f, struct shop_buy_data *list, int new_form
     ptr = buf;
     if (num == -1)
     {
-      sscanf(buf, "%d", &num);
-      while (!isdigit(*ptr))
-        ptr++;
-      while (isdigit(*ptr))
-        ptr++;
+      if (sscanf(buf, "%d", &num) != 1)
+      {
+        log("SYSERR: Invalid shop buy-type line: %s", buf);
+        error++;
+        num = -1;
+        ptr = END_OF(buf);
+      }
+      else
+      {
+        while (*ptr && !isdigit(*ptr))
+          ptr++;
+        while (isdigit(*ptr))
+          ptr++;
+      }
     }
     while (isspace(*ptr))
       ptr++;

--- a/src/shop.c
+++ b/src/shop.c
@@ -1575,7 +1575,12 @@ void boot_the_shops(FILE *shop_f, char *filename, int rec_count)
     buf = fread_string(shop_f, buf2);
     if (*buf == '#')
     { /* New shop */
-      sscanf(buf, "#%d\n", &temp);
+      if (sscanf(buf, "#%d", &temp) != 1)
+      {
+        log("SYSERR: Invalid shop header in %s: %s", filename, buf);
+        free(buf);
+        exit(1);
+      }
       snprintf(buf2, sizeof(buf2), "shop #%d in shop file %s", temp, filename);
       free(buf); /* Plug memory leak! */
       top_shop++;

--- a/src/spec_procs.c
+++ b/src/spec_procs.c
@@ -3668,7 +3668,7 @@ SPECIAL(guild)
 
 int unlinkMovingRoom(struct moving_room_data *theRoom, struct oldNextMove *ONMdata, int cibIdx)
 {
-  char errStr[100];
+  char errStr[128];
 
   if ((ONMdata->oldRoom != NOWHERE) && (ONMdata->oldRoom != ENDMOVING))
   {
@@ -3677,8 +3677,9 @@ int unlinkMovingRoom(struct moving_room_data *theRoom, struct oldNextMove *ONMda
     /*  check if rooms sync up  */
     if (theRoom->from[cibIdx] != ONMdata->oldRoom)
     {
-      sprintf(errStr, "SPEC(move_room): [%d] from[cibIdx] != oldRoom (or <= 0) (%d/%d %d)",
-              (int)ONMdata->moveRoom, theRoom->from[cibIdx], ONMdata->oldRoom, cibIdx);
+      snprintf(errStr, sizeof(errStr),
+               "SPEC(move_room): [%d] from[cibIdx] != oldRoom (or <= 0) (%d/%d %d)",
+               (int)ONMdata->moveRoom, theRoom->from[cibIdx], ONMdata->oldRoom, cibIdx);
       log("%s", errStr);
       return 0;
     }

--- a/src/spells.c
+++ b/src/spells.c
@@ -1577,7 +1577,7 @@ ASPELL(spell_arcane_mark)
   }
 
   mark = GET_ARCANE_MARK(ch);
-  if (!mark || !*mark || mark == NULL || !strcmp(mark, "(null)") || !strcmp(mark, "null"))
+  if (!mark || !*mark || !strcmp(mark, "(null)") || !strcmp(mark, "null"))
   {
     send_to_char(ch, "You have not set an arcane mark yet. Use 'arcanemark <mark>' to set it.\r\n");
     send_to_char(ch, "Your arcane mark can be anything up to 250 characters long, which includes "

--- a/src/study.c
+++ b/src/study.c
@@ -200,26 +200,23 @@ const char *familiar_names[] = {
 void init_study(struct descriptor_data *d, int class)
 {
   struct char_data *ch = d->character;
-  struct oasis_olc_data *new_olc = NULL;
-  struct level_data *new_levelup = NULL;
   int i = 0, j = 0;
-
-  CREATE(new_olc, struct oasis_olc_data, 1);
-  CREATE(new_levelup, struct level_data, 1);
 
   if (d->olc)
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_study: Player already had olc structure.");
     free(d->olc);
+    d->olc = NULL;
   }
-  d->olc = new_olc;
+  CREATE(d->olc, struct oasis_olc_data, 1);
 
   if (LEVELUP(ch))
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_study: Player already had levelup structure.");
     free(LEVELUP(ch));
+    LEVELUP(ch) = NULL;
   }
-  LEVELUP(ch) = new_levelup;
+  CREATE(LEVELUP(ch), struct level_data, 1);
 
   STATE(d) = CON_STUDY;
 

--- a/src/study.c
+++ b/src/study.c
@@ -200,7 +200,12 @@ const char *familiar_names[] = {
 void init_study(struct descriptor_data *d, int class)
 {
   struct char_data *ch = d->character;
+  struct oasis_olc_data *new_olc = NULL;
+  struct level_data *new_levelup = NULL;
   int i = 0, j = 0;
+
+  CREATE(new_olc, struct oasis_olc_data, 1);
+  CREATE(new_levelup, struct level_data, 1);
 
   if (d->olc)
   {
@@ -208,7 +213,7 @@ void init_study(struct descriptor_data *d, int class)
     free(d->olc);
     d->olc = NULL;
   }
-  CREATE(d->olc, struct oasis_olc_data, 1);
+  d->olc = new_olc;
 
   if (LEVELUP(ch))
   {
@@ -216,66 +221,66 @@ void init_study(struct descriptor_data *d, int class)
     free(LEVELUP(ch));
     LEVELUP(ch) = NULL;
   }
-  CREATE(LEVELUP(ch), struct level_data, 1);
-
-  STATE(d) = CON_STUDY;
 
   /* Now copy the player's data to the levelup structure - a scratch area
    * used during the study process. */
-  LEVELUP(ch)->class = class;
-  LEVELUP(ch)->level = CLASS_LEVEL(ch, class);
-  LEVELUP(ch)->feat_points = MAX(0, GET_FEAT_POINTS(ch));
-  LEVELUP(ch)->class_feat_points = MAX(0, GET_CLASS_FEATS(ch, class));
-  LEVELUP(ch)->epic_feat_points = MAX(0, GET_EPIC_FEAT_POINTS(ch));
-  LEVELUP(ch)->epic_class_feat_points = MAX(0, GET_EPIC_CLASS_FEATS(ch, class));
-  LEVELUP(ch)->teamwork_feat_points = MAX(0, GET_TEAMWORK_FEAT_POINTS(ch));
+  new_levelup->class = class;
+  new_levelup->level = CLASS_LEVEL(ch, class);
+  new_levelup->feat_points = MAX(0, GET_FEAT_POINTS(ch));
+  new_levelup->class_feat_points = MAX(0, GET_CLASS_FEATS(ch, class));
+  new_levelup->epic_feat_points = MAX(0, GET_EPIC_FEAT_POINTS(ch));
+  new_levelup->epic_class_feat_points = MAX(0, GET_EPIC_CLASS_FEATS(ch, class));
+  new_levelup->teamwork_feat_points = MAX(0, GET_TEAMWORK_FEAT_POINTS(ch));
 
-  LEVELUP(ch)->practices = GET_PRACTICES(ch);
-  LEVELUP(ch)->trains = GET_TRAINS(ch);
-  LEVELUP(ch)->num_boosts = GET_BOOSTS(ch);
+  new_levelup->practices = GET_PRACTICES(ch);
+  new_levelup->trains = GET_TRAINS(ch);
+  new_levelup->num_boosts = GET_BOOSTS(ch);
 
-  LEVELUP(ch)->str = GET_REAL_STR(ch);
-  LEVELUP(ch)->dex = GET_REAL_DEX(ch);
-  LEVELUP(ch)->con = GET_REAL_CON(ch);
-  LEVELUP(ch)->inte = GET_REAL_INT(ch);
-  LEVELUP(ch)->wis = GET_REAL_WIS(ch);
-  LEVELUP(ch)->cha = GET_REAL_CHA(ch);
+  new_levelup->str = GET_REAL_STR(ch);
+  new_levelup->dex = GET_REAL_DEX(ch);
+  new_levelup->con = GET_REAL_CON(ch);
+  new_levelup->inte = GET_REAL_INT(ch);
+  new_levelup->wis = GET_REAL_WIS(ch);
+  new_levelup->cha = GET_REAL_CHA(ch);
 
   /* The following data elements are used to store the player's choices during the
    * study process - Just initialize these values. */
-  LEVELUP(ch)->spell_circle = -1;
-  LEVELUP(ch)->favored_slot = -1;
-  LEVELUP(ch)->feat_type = -1;
+  new_levelup->spell_circle = -1;
+  new_levelup->favored_slot = -1;
+  new_levelup->feat_type = -1;
 
-  LEVELUP(ch)->tempFeat = 0;
+  new_levelup->tempFeat = 0;
 
   for (i = 0; i < 6; i++)
-    LEVELUP(ch)->boosts[i] = 0;
+    new_levelup->boosts[i] = 0;
   for (i = 0; i < NUM_FEATS; i++)
   {
-    LEVELUP(ch)->feats[i] = 0;
-    LEVELUP(ch)->feat_weapons[i] = 0;
-    LEVELUP(ch)->feat_skills[i] = 0;
+    new_levelup->feats[i] = 0;
+    new_levelup->feat_weapons[i] = 0;
+    new_levelup->feat_skills[i] = 0;
   }
   for (i = 0; i < NUM_CFEATS; i++)
     for (j = 0; j < FT_ARRAY_MAX; j++)
-      LEVELUP(ch)->combat_feats[i][j] = 0;
+      new_levelup->combat_feats[i][j] = 0;
   for (i = 0; i < MAX_ABILITIES; i++)
     for (j = 0; j < NUM_SKFEATS; j++)
-      LEVELUP(ch)->skill_focus[i][j] = FALSE;
+      new_levelup->skill_focus[i][j] = FALSE;
   for (i = 0; i < NUM_SFEATS; i++)
-    LEVELUP(ch)->school_feats[i] = 0;
+    new_levelup->school_feats[i] = 0;
 
-  LEVELUP(ch)->eidolon_base_form = GET_EIDOLON_BASE_FORM(ch);
+  new_levelup->eidolon_base_form = GET_EIDOLON_BASE_FORM(ch);
   for (i = 1; i < NUM_EVOLUTIONS; i++)
   {
-    LEVELUP(ch)->eidolon_evolutions[i] = KNOWS_EVOLUTION(ch, i);
-    LEVELUP(ch)->summoner_aspects[i] = HAS_REAL_EVOLUTION(ch, i);
+    new_levelup->eidolon_evolutions[i] = KNOWS_EVOLUTION(ch, i);
+    new_levelup->summoner_aspects[i] = HAS_REAL_EVOLUTION(ch, i);
   }
-  LEVELUP(ch)->necromancer_bonus_levels = NECROMANCER_CAST_TYPE(ch);
+  new_levelup->necromancer_bonus_levels = NECROMANCER_CAST_TYPE(ch);
 
-  LEVELUP(ch)->dragon_rider_dragon_type = GET_DRAGON_RIDER_DRAGON_TYPE(ch);
-  LEVELUP(ch)->dragon_rider_bond_type = GET_DRAGON_BOND_TYPE(ch);
+  new_levelup->dragon_rider_dragon_type = GET_DRAGON_RIDER_DRAGON_TYPE(ch);
+  new_levelup->dragon_rider_bond_type = GET_DRAGON_BOND_TYPE(ch);
+
+  LEVELUP(ch) = new_levelup;
+  STATE(d) = CON_STUDY;
 }
 
 void finalize_study(struct descriptor_data *d)

--- a/src/study.c
+++ b/src/study.c
@@ -200,23 +200,26 @@ const char *familiar_names[] = {
 void init_study(struct descriptor_data *d, int class)
 {
   struct char_data *ch = d->character;
+  struct oasis_olc_data *new_olc = NULL;
+  struct level_data *new_levelup = NULL;
   int i = 0, j = 0;
+
+  CREATE(new_olc, struct oasis_olc_data, 1);
+  CREATE(new_levelup, struct level_data, 1);
 
   if (d->olc)
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_study: Player already had olc structure.");
     free(d->olc);
   }
-
-  CREATE(d->olc, struct oasis_olc_data, 1);
+  d->olc = new_olc;
 
   if (LEVELUP(ch))
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_study: Player already had levelup structure.");
     free(LEVELUP(ch));
   }
-
-  CREATE(LEVELUP(ch), struct level_data, 1);
+  LEVELUP(ch) = new_levelup;
 
   STATE(d) = CON_STUDY;
 

--- a/src/sysdep.h
+++ b/src/sysdep.h
@@ -153,6 +153,10 @@ extern void abort(), exit();
 #include <crypt.h>
 #endif
 
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+
 #ifdef TIME_WITH_SYS_TIME
 #include <sys/time.h>
 #include <time.h>
@@ -571,5 +575,54 @@ ssize_t write(int fildes, const void *buf, size_t nbyte);
 #endif /* __COMM_C__ */
 
 #endif /* NO_LIBRARY_PROTOTYPES */
+
+/*
+ * Opens a writable stream without relying on the process umask to remove
+ * world-write permissions from a newly created file.
+ */
+static inline FILE *fopen_restricted(const char *path, const char *mode)
+{
+  FILE *stream;
+  int fd;
+  int flags;
+
+  if (!path || !mode)
+  {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  switch (*mode)
+  {
+  case 'w':
+    flags = O_CREAT | O_TRUNC;
+    break;
+  case 'a':
+    flags = O_CREAT | O_APPEND;
+    break;
+  default:
+    errno = EINVAL;
+    return NULL;
+  }
+
+  flags |= strchr(mode, '+') ? O_RDWR : O_WRONLY;
+#ifdef O_BINARY
+  if (strchr(mode, 'b'))
+    flags |= O_BINARY;
+#endif
+
+  fd = open(path, flags, 0640);
+  if (fd < 0)
+    return NULL;
+
+  stream = fdopen(fd, mode);
+  if (!stream)
+  {
+    close(fd);
+    return NULL;
+  }
+
+  return stream;
+}
 
 #endif /* _SYSDEP_H_ */

--- a/src/systems/pubsub/pubsub_event_handlers.c
+++ b/src/systems/pubsub/pubsub_event_handlers.c
@@ -56,7 +56,7 @@ int pubsub_handler_combat_logger(struct char_data *ch, struct pubsub_message *ms
   }
 
   /* Open combat log file - game runs from lib/ directory */
-  logfile = fopen("../log/pubsub/combat_events.log", "a");
+  logfile = fopen_restricted("../log/pubsub/combat_events.log", "a");
   if (!logfile)
   {
     pubsub_error("Cannot open combat events log at ../log/pubsub/combat_events.log - errno: %d",
@@ -66,7 +66,7 @@ int pubsub_handler_combat_logger(struct char_data *ch, struct pubsub_message *ms
 
   /* Get timestamp */
   now = time(NULL);
-  strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", localtime(&now));
+  format_time_string(now, "%Y-%m-%d %H:%M:%S", timestamp, sizeof(timestamp));
 
   /* Log the combat event with context */
   fprintf(logfile, "[%s] Player: %s | Level: %d | Class: %s | Event: %s | Room: %d\n", timestamp,

--- a/src/systems/pubsub/pubsub_spatial.c
+++ b/src/systems/pubsub/pubsub_spatial.c
@@ -555,16 +555,16 @@ static char *blend_audio_sources(struct char_data *ch __attribute__((unused)), s
       {
         if (count > 1)
         {
-          pos += snprintf(result + pos, MAX_STRING_LENGTH - pos, "%s, ", source->content);
+          pos = snprintf_append(result, MAX_STRING_LENGTH, pos, "%s, ", source->content);
         }
         else
         {
-          pos += snprintf(result + pos, MAX_STRING_LENGTH - pos, "and %s", source->content);
+          pos = snprintf_append(result, MAX_STRING_LENGTH, pos, "and %s", source->content);
         }
       }
     }
 
-    strcat(result, ".\r\n");
+    strlcat(result, ".\r\n", MAX_STRING_LENGTH);
   }
 
   return result;

--- a/src/systems/spatial/spatial_core.c
+++ b/src/systems/spatial/spatial_core.c
@@ -235,7 +235,8 @@ int spatial_process_stimulus(struct spatial_context *ctx, struct spatial_system 
         system->total_processed++;
         system->successful_transmissions++;
         system->avg_processing_time_ms =
-            (system->avg_processing_time_ms * (system->total_processed - 1) + processing_time) /
+            ((double)system->avg_processing_time_ms * (system->total_processed - 1) +
+             processing_time) /
             system->total_processed;
 
         spatial_debug("Stimulus successfully processed in %.3f ms", processing_time);

--- a/src/systems/web_client/onboarding.c
+++ b/src/systems/web_client/onboarding.c
@@ -2081,9 +2081,9 @@ static void build_account_characters(struct json_writer *w, struct descriptor_da
       if (CLASS_LEVEL(tch, class_index))
       {
         if (class_count)
-          classes_len += snprintf(classes + classes_len, sizeof(classes) - classes_len, "/");
-        classes_len += snprintf(classes + classes_len, sizeof(classes) - classes_len, "%s",
-                                CLSLIST_NAME(class_index));
+          classes_len = snprintf_append(classes, sizeof(classes), classes_len, "/");
+        classes_len = snprintf_append(classes, sizeof(classes), classes_len, "%s",
+                                      CLSLIST_NAME(class_index));
         class_count++;
       }
     }

--- a/src/tedit.c
+++ b/src/tedit.c
@@ -32,7 +32,7 @@ void tedit_string_cleanup(struct descriptor_data *d, int terminator)
   switch (terminator)
   {
   case STRINGADD_SAVE:
-    if (!(fl = fopen(storage, "w")))
+    if (!(fl = fopen_restricted(storage, "w")))
       mudlog(CMP, LVL_IMPL, TRUE, "SYSERR: Can't write file '%s'.", storage);
     else
     {
@@ -69,6 +69,7 @@ ACMD(do_tedit)
   int l, i = 0;
   char field[MAX_INPUT_LENGTH] = {'\0'};
   char *backstr = NULL;
+  struct oasis_olc_data *new_olc = NULL;
 
   const struct
   {
@@ -137,12 +138,13 @@ ACMD(do_tedit)
   send_editor_help(ch->desc);
   send_to_char(ch, "Edit file below:\r\n\r\n");
 
+  CREATE(new_olc, struct oasis_olc_data, 1);
   if (ch->desc->olc)
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_tedit: Player already had olc structure.");
     free(ch->desc->olc);
   }
-  CREATE(ch->desc->olc, struct oasis_olc_data, 1);
+  ch->desc->olc = new_olc;
 
   if (*fields[l].buffer)
   {

--- a/src/tedit.c
+++ b/src/tedit.c
@@ -69,7 +69,6 @@ ACMD(do_tedit)
   int l, i = 0;
   char field[MAX_INPUT_LENGTH] = {'\0'};
   char *backstr = NULL;
-  struct oasis_olc_data *new_olc = NULL;
 
   const struct
   {
@@ -138,13 +137,13 @@ ACMD(do_tedit)
   send_editor_help(ch->desc);
   send_to_char(ch, "Edit file below:\r\n\r\n");
 
-  CREATE(new_olc, struct oasis_olc_data, 1);
   if (ch->desc->olc)
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_tedit: Player already had olc structure.");
     free(ch->desc->olc);
+    ch->desc->olc = NULL;
   }
-  ch->desc->olc = new_olc;
+  CREATE(ch->desc->olc, struct oasis_olc_data, 1);
 
   if (*fields[l].buffer)
   {

--- a/src/tedit.c
+++ b/src/tedit.c
@@ -69,6 +69,7 @@ ACMD(do_tedit)
   int l, i = 0;
   char field[MAX_INPUT_LENGTH] = {'\0'};
   char *backstr = NULL;
+  struct oasis_olc_data *new_olc = NULL;
 
   const struct
   {
@@ -137,13 +138,14 @@ ACMD(do_tedit)
   send_editor_help(ch->desc);
   send_to_char(ch, "Edit file below:\r\n\r\n");
 
+  CREATE(new_olc, struct oasis_olc_data, 1);
   if (ch->desc->olc)
   {
     mudlog(BRF, LVL_IMMORT, TRUE, "SYSERR: do_tedit: Player already had olc structure.");
     free(ch->desc->olc);
     ch->desc->olc = NULL;
   }
-  CREATE(ch->desc->olc, struct oasis_olc_data, 1);
+  ch->desc->olc = new_olc;
 
   if (*fields[l].buffer)
   {
@@ -151,7 +153,7 @@ ACMD(do_tedit)
     backstr = strdup(*fields[l].buffer);
   }
 
-  OLC_STORAGE(ch->desc) = strdup(fields[l].filename);
+  new_olc->storage = strdup(fields[l].filename);
   string_write(ch->desc, (char **)fields[l].buffer, fields[l].size, 0, backstr);
 
   act("$n begins editing a scroll.", TRUE, ch, 0, 0, TO_ROOM);

--- a/src/treasure.c
+++ b/src/treasure.c
@@ -2173,17 +2173,17 @@ void award_magic_armor(struct char_data *ch, int grade, int wear_slot)
   /* a suit of (body), or a pair of (arm/leg), or AN() (helm) */
   if (IS_SET_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_BODY))
   {
-    strncat(desc, "a suit of", MEDIUM_STRING - strlen(desc));
+    strlcat(desc, "a suit of", sizeof(desc));
   }
   else if (IS_SET_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_HEAD) ||
            IS_SET_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_SHIELD))
   {
     armor_desc_roll = rand_number(0, NUM_A_ARMOR_SPECIAL_DESCS - 1);
-    strncat(desc, AN(armor_special_descs[armor_desc_roll]), MEDIUM_STRING - strlen(desc));
+    strlcat(desc, AN(armor_special_descs[armor_desc_roll]), sizeof(desc));
   }
   else
   {
-    strncat(desc, "a pair of", MEDIUM_STRING - strlen(desc));
+    strlcat(desc, "a pair of", sizeof(desc));
   }
 
   /* set the object material, check for upgrade */
@@ -2200,48 +2200,48 @@ void award_magic_armor(struct char_data *ch, int grade, int wear_slot)
   crest_num = rand_number(0, NUM_A_ARMOR_CRESTS - 1);
 
   /* start with keyword string */
-  strncat(keywords, " ", MEDIUM_STRING - strlen(keywords));
-  strncat(keywords, armor_list[GET_ARMOR_TYPE(obj)].name, MEDIUM_STRING - strlen(keywords));
-  strncat(keywords, " ", MEDIUM_STRING - strlen(keywords));
-  strncat(keywords, material_name[GET_OBJ_MATERIAL(obj)], MEDIUM_STRING - strlen(keywords));
+  strlcat(keywords, " ", sizeof(keywords));
+  strlcat(keywords, armor_list[GET_ARMOR_TYPE(obj)].name, sizeof(keywords));
+  strlcat(keywords, " ", sizeof(keywords));
+  strlcat(keywords, material_name[GET_OBJ_MATERIAL(obj)], sizeof(keywords));
 
   roll = dice(1, 3);
   if (roll == 3)
   { // armor spec adjective in desc?
-    strncat(desc, " ", MEDIUM_STRING - strlen(desc));
-    strncat(desc, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(desc));
-    strncat(keywords, " ", MEDIUM_STRING - strlen(keywords));
-    strncat(keywords, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(keywords));
+    strlcat(desc, " ", sizeof(desc));
+    strlcat(desc, armor_special_descs[armor_desc_roll], sizeof(desc));
+    strlcat(keywords, " ", sizeof(keywords));
+    strlcat(keywords, armor_special_descs[armor_desc_roll], sizeof(keywords));
   }
 
   roll = dice(1, 5);
   if (roll >= 4)
   { // color describe #1?
-    strncat(desc, " ", MEDIUM_STRING - strlen(desc));
-    strncat(desc, colors[color1], MEDIUM_STRING - strlen(desc));
-    strncat(keywords, " ", MEDIUM_STRING - strlen(keywords));
-    strncat(keywords, colors[color1], MEDIUM_STRING - strlen(keywords));
+    strlcat(desc, " ", sizeof(desc));
+    strlcat(desc, colors[color1], sizeof(desc));
+    strlcat(keywords, " ", sizeof(keywords));
+    strlcat(keywords, colors[color1], sizeof(keywords));
   }
   else if (roll == 3)
   { // two colors
-    strncat(desc, " ", MEDIUM_STRING - strlen(desc));
-    strncat(desc, colors[color1], MEDIUM_STRING - strlen(desc));
-    strncat(desc, " and ", MEDIUM_STRING - strlen(desc));
-    strncat(desc, colors[color2], MEDIUM_STRING - strlen(desc));
-    strncat(keywords, " ", MEDIUM_STRING - strlen(keywords));
-    strncat(keywords, colors[color1], MEDIUM_STRING - strlen(keywords));
-    strncat(keywords, " and ", MEDIUM_STRING - strlen(keywords));
-    strncat(keywords, colors[color2], MEDIUM_STRING - strlen(keywords));
+    strlcat(desc, " ", sizeof(desc));
+    strlcat(desc, colors[color1], sizeof(desc));
+    strlcat(desc, " and ", sizeof(desc));
+    strlcat(desc, colors[color2], sizeof(desc));
+    strlcat(keywords, " ", sizeof(keywords));
+    strlcat(keywords, colors[color1], sizeof(keywords));
+    strlcat(keywords, " and ", sizeof(keywords));
+    strlcat(keywords, colors[color2], sizeof(keywords));
   }
 
   // Insert the material type, then armor type
   if (GET_OBJ_MATERIAL(obj) != MATERIAL_LEATHER) // leather is redudant in description here
   {
-    strncat(desc, " ", MEDIUM_STRING - strlen(desc));
-    strncat(desc, material_name[GET_OBJ_MATERIAL(obj)], MEDIUM_STRING - strlen(desc));
+    strlcat(desc, " ", sizeof(desc));
+    strlcat(desc, material_name[GET_OBJ_MATERIAL(obj)], sizeof(desc));
   }
-  strncat(desc, " ", MEDIUM_STRING - strlen(desc));
-  strncat(desc, armor_list[GET_ARMOR_TYPE(obj)].name, MEDIUM_STRING - strlen(desc));
+  strlcat(desc, " ", sizeof(desc));
+  strlcat(desc, armor_list[GET_ARMOR_TYPE(obj)].name, sizeof(desc));
 
   roll = dice(1, 8);
   if (roll >= 7)
@@ -2249,16 +2249,16 @@ void award_magic_armor(struct char_data *ch, int grade, int wear_slot)
     char tmp[SMALL_STRING] = {'\0'};
     snprintf(tmp, SMALL_STRING, " with %s %s crest", AN(armor_crests[crest_num]),
              armor_crests[crest_num]);
-    strncat(desc, tmp, MEDIUM_STRING - strlen(desc));
-    strncat(keywords, tmp, MEDIUM_STRING - strlen(keywords));
+    strlcat(desc, tmp, sizeof(desc));
+    strlcat(keywords, tmp, sizeof(keywords));
   }
   else if (roll >= 5)
   { // or symbol?
     char tmp[SMALL_STRING] = {'\0'};
     snprintf(tmp, SMALL_STRING, " covered in symbols of %s %s", AN(armor_crests[crest_num]),
              armor_crests[crest_num]);
-    strncat(desc, tmp, MEDIUM_STRING - strlen(desc));
-    strncat(keywords, tmp, MEDIUM_STRING - strlen(keywords));
+    strlcat(desc, tmp, sizeof(desc));
+    strlcat(keywords, tmp, sizeof(keywords));
   }
 
   // keywords
@@ -2327,11 +2327,11 @@ void award_magic_armor_suit(struct char_data *ch, int grade)
 
   /* a suit of (body), or a pair of (arm/leg), or AN() (helm) */
 
-  strncat(descb, "a suit of", MEDIUM_STRING - strlen(descb));
+  strlcat(descb, "a suit of", sizeof(descb));
   armor_desc_roll = rand_number(0, NUM_A_ARMOR_SPECIAL_DESCS - 1);
-  strncat(desch, AN(armor_special_descs[armor_desc_roll]), MEDIUM_STRING - strlen(desch));
-  strncat(desca, "a pair of", MEDIUM_STRING - strlen(desca));
-  strncat(descl, "a pair of", MEDIUM_STRING - strlen(descl));
+  strlcat(desch, AN(armor_special_descs[armor_desc_roll]), sizeof(desch));
+  strlcat(desca, "a pair of", sizeof(desca));
+  strlcat(descl, "a pair of", sizeof(descl));
 
   /* set the object material, check for upgrade */
   GET_OBJ_MATERIAL(body) = possible_material_upgrade(GET_OBJ_MATERIAL(body), grade);
@@ -2350,120 +2350,120 @@ void award_magic_armor_suit(struct char_data *ch, int grade)
   crest_num = rand_number(0, NUM_A_ARMOR_CRESTS - 1);
 
   /* start with keyword string */
-  strncat(keywordsb, " ", MEDIUM_STRING - strlen(keywordsb));
-  strncat(keywordsh, " ", MEDIUM_STRING - strlen(keywordsh));
-  strncat(keywordsa, " ", MEDIUM_STRING - strlen(keywordsa));
-  strncat(keywordsl, " ", MEDIUM_STRING - strlen(keywordsl));
-  strncat(keywordsb, armor_list[GET_ARMOR_TYPE(body)].name, MEDIUM_STRING - strlen(keywordsb));
-  strncat(keywordsh, armor_list[GET_ARMOR_TYPE(head)].name, MEDIUM_STRING - strlen(keywordsh));
-  strncat(keywordsa, armor_list[GET_ARMOR_TYPE(arms)].name, MEDIUM_STRING - strlen(keywordsa));
-  strncat(keywordsl, armor_list[GET_ARMOR_TYPE(legs)].name, MEDIUM_STRING - strlen(keywordsl));
-  strncat(keywordsb, " ", MEDIUM_STRING - strlen(keywordsb));
-  strncat(keywordsh, " ", MEDIUM_STRING - strlen(keywordsh));
-  strncat(keywordsa, " ", MEDIUM_STRING - strlen(keywordsa));
-  strncat(keywordsl, " ", MEDIUM_STRING - strlen(keywordsl));
-  strncat(keywordsb, material_name[GET_OBJ_MATERIAL(body)], MEDIUM_STRING - strlen(keywordsb));
-  strncat(keywordsh, material_name[GET_OBJ_MATERIAL(head)], MEDIUM_STRING - strlen(keywordsh));
-  strncat(keywordsa, material_name[GET_OBJ_MATERIAL(arms)], MEDIUM_STRING - strlen(keywordsa));
-  strncat(keywordsl, material_name[GET_OBJ_MATERIAL(legs)], MEDIUM_STRING - strlen(keywordsl));
+  strlcat(keywordsb, " ", sizeof(keywordsb));
+  strlcat(keywordsh, " ", sizeof(keywordsh));
+  strlcat(keywordsa, " ", sizeof(keywordsa));
+  strlcat(keywordsl, " ", sizeof(keywordsl));
+  strlcat(keywordsb, armor_list[GET_ARMOR_TYPE(body)].name, sizeof(keywordsb));
+  strlcat(keywordsh, armor_list[GET_ARMOR_TYPE(head)].name, sizeof(keywordsh));
+  strlcat(keywordsa, armor_list[GET_ARMOR_TYPE(arms)].name, sizeof(keywordsa));
+  strlcat(keywordsl, armor_list[GET_ARMOR_TYPE(legs)].name, sizeof(keywordsl));
+  strlcat(keywordsb, " ", sizeof(keywordsb));
+  strlcat(keywordsh, " ", sizeof(keywordsh));
+  strlcat(keywordsa, " ", sizeof(keywordsa));
+  strlcat(keywordsl, " ", sizeof(keywordsl));
+  strlcat(keywordsb, material_name[GET_OBJ_MATERIAL(body)], sizeof(keywordsb));
+  strlcat(keywordsh, material_name[GET_OBJ_MATERIAL(head)], sizeof(keywordsh));
+  strlcat(keywordsa, material_name[GET_OBJ_MATERIAL(arms)], sizeof(keywordsa));
+  strlcat(keywordsl, material_name[GET_OBJ_MATERIAL(legs)], sizeof(keywordsl));
 
   roll = dice(1, 3);
   if (roll == 3)
   { // armor spec adjective in desc?
-    strncat(descb, " ", MEDIUM_STRING - strlen(descb));
-    strncat(desch, " ", MEDIUM_STRING - strlen(desch));
-    strncat(desca, " ", MEDIUM_STRING - strlen(desca));
-    strncat(descl, " ", MEDIUM_STRING - strlen(descl));
-    strncat(descb, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(descb));
-    strncat(desch, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(desch));
-    strncat(desca, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(desca));
-    strncat(descl, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(descl));
-    strncat(keywordsb, " ", MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, " ", MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, " ", MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, " ", MEDIUM_STRING - strlen(keywordsl));
-    strncat(keywordsb, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, armor_special_descs[armor_desc_roll], MEDIUM_STRING - strlen(keywordsl));
+    strlcat(descb, " ", sizeof(descb));
+    strlcat(desch, " ", sizeof(desch));
+    strlcat(desca, " ", sizeof(desca));
+    strlcat(descl, " ", sizeof(descl));
+    strlcat(descb, armor_special_descs[armor_desc_roll], sizeof(descb));
+    strlcat(desch, armor_special_descs[armor_desc_roll], sizeof(desch));
+    strlcat(desca, armor_special_descs[armor_desc_roll], sizeof(desca));
+    strlcat(descl, armor_special_descs[armor_desc_roll], sizeof(descl));
+    strlcat(keywordsb, " ", sizeof(keywordsb));
+    strlcat(keywordsh, " ", sizeof(keywordsh));
+    strlcat(keywordsa, " ", sizeof(keywordsa));
+    strlcat(keywordsl, " ", sizeof(keywordsl));
+    strlcat(keywordsb, armor_special_descs[armor_desc_roll], sizeof(keywordsb));
+    strlcat(keywordsh, armor_special_descs[armor_desc_roll], sizeof(keywordsh));
+    strlcat(keywordsa, armor_special_descs[armor_desc_roll], sizeof(keywordsa));
+    strlcat(keywordsl, armor_special_descs[armor_desc_roll], sizeof(keywordsl));
   }
 
   roll = dice(1, 5);
   if (roll >= 4)
   { // color describe #1?
-    strncat(descb, " ", MEDIUM_STRING - strlen(descb));
-    strncat(desch, " ", MEDIUM_STRING - strlen(desch));
-    strncat(desca, " ", MEDIUM_STRING - strlen(desca));
-    strncat(descl, " ", MEDIUM_STRING - strlen(descl));
-    strncat(descb, colors[color1], MEDIUM_STRING - strlen(descb));
-    strncat(desch, colors[color1], MEDIUM_STRING - strlen(desch));
-    strncat(desca, colors[color1], MEDIUM_STRING - strlen(desca));
-    strncat(descl, colors[color1], MEDIUM_STRING - strlen(descl));
-    strncat(keywordsb, " ", MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, " ", MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, " ", MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, " ", MEDIUM_STRING - strlen(keywordsl));
-    strncat(keywordsb, colors[color1], MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, colors[color1], MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, colors[color1], MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, colors[color1], MEDIUM_STRING - strlen(keywordsl));
+    strlcat(descb, " ", sizeof(descb));
+    strlcat(desch, " ", sizeof(desch));
+    strlcat(desca, " ", sizeof(desca));
+    strlcat(descl, " ", sizeof(descl));
+    strlcat(descb, colors[color1], sizeof(descb));
+    strlcat(desch, colors[color1], sizeof(desch));
+    strlcat(desca, colors[color1], sizeof(desca));
+    strlcat(descl, colors[color1], sizeof(descl));
+    strlcat(keywordsb, " ", sizeof(keywordsb));
+    strlcat(keywordsh, " ", sizeof(keywordsh));
+    strlcat(keywordsa, " ", sizeof(keywordsa));
+    strlcat(keywordsl, " ", sizeof(keywordsl));
+    strlcat(keywordsb, colors[color1], sizeof(keywordsb));
+    strlcat(keywordsh, colors[color1], sizeof(keywordsh));
+    strlcat(keywordsa, colors[color1], sizeof(keywordsa));
+    strlcat(keywordsl, colors[color1], sizeof(keywordsl));
   }
   else if (roll == 3)
   { // two colors
-    strncat(descb, " ", MEDIUM_STRING - strlen(descb));
-    strncat(desch, " ", MEDIUM_STRING - strlen(desch));
-    strncat(desca, " ", MEDIUM_STRING - strlen(desca));
-    strncat(descl, " ", MEDIUM_STRING - strlen(descl));
-    strncat(descb, colors[color1], MEDIUM_STRING - strlen(descb));
-    strncat(desch, colors[color1], MEDIUM_STRING - strlen(desch));
-    strncat(desca, colors[color1], MEDIUM_STRING - strlen(desca));
-    strncat(descl, colors[color1], MEDIUM_STRING - strlen(descl));
-    strncat(descb, " and ", MEDIUM_STRING - strlen(descb));
-    strncat(desch, " and ", MEDIUM_STRING - strlen(desch));
-    strncat(desca, " and ", MEDIUM_STRING - strlen(desca));
-    strncat(descl, " and ", MEDIUM_STRING - strlen(descl));
-    strncat(descb, colors[color2], MEDIUM_STRING - strlen(descb));
-    strncat(desch, colors[color2], MEDIUM_STRING - strlen(desch));
-    strncat(desca, colors[color2], MEDIUM_STRING - strlen(desca));
-    strncat(descl, colors[color2], MEDIUM_STRING - strlen(descl));
-    strncat(keywordsb, " ", MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, " ", MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, " ", MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, " ", MEDIUM_STRING - strlen(keywordsl));
-    strncat(keywordsb, colors[color1], MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, colors[color1], MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, colors[color1], MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, colors[color1], MEDIUM_STRING - strlen(keywordsl));
-    strncat(keywordsb, " and ", MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, " and ", MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, " and ", MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, " and ", MEDIUM_STRING - strlen(keywordsl));
-    strncat(keywordsb, colors[color2], MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, colors[color2], MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, colors[color2], MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, colors[color2], MEDIUM_STRING - strlen(keywordsl));
+    strlcat(descb, " ", sizeof(descb));
+    strlcat(desch, " ", sizeof(desch));
+    strlcat(desca, " ", sizeof(desca));
+    strlcat(descl, " ", sizeof(descl));
+    strlcat(descb, colors[color1], sizeof(descb));
+    strlcat(desch, colors[color1], sizeof(desch));
+    strlcat(desca, colors[color1], sizeof(desca));
+    strlcat(descl, colors[color1], sizeof(descl));
+    strlcat(descb, " and ", sizeof(descb));
+    strlcat(desch, " and ", sizeof(desch));
+    strlcat(desca, " and ", sizeof(desca));
+    strlcat(descl, " and ", sizeof(descl));
+    strlcat(descb, colors[color2], sizeof(descb));
+    strlcat(desch, colors[color2], sizeof(desch));
+    strlcat(desca, colors[color2], sizeof(desca));
+    strlcat(descl, colors[color2], sizeof(descl));
+    strlcat(keywordsb, " ", sizeof(keywordsb));
+    strlcat(keywordsh, " ", sizeof(keywordsh));
+    strlcat(keywordsa, " ", sizeof(keywordsa));
+    strlcat(keywordsl, " ", sizeof(keywordsl));
+    strlcat(keywordsb, colors[color1], sizeof(keywordsb));
+    strlcat(keywordsh, colors[color1], sizeof(keywordsh));
+    strlcat(keywordsa, colors[color1], sizeof(keywordsa));
+    strlcat(keywordsl, colors[color1], sizeof(keywordsl));
+    strlcat(keywordsb, " and ", sizeof(keywordsb));
+    strlcat(keywordsh, " and ", sizeof(keywordsh));
+    strlcat(keywordsa, " and ", sizeof(keywordsa));
+    strlcat(keywordsl, " and ", sizeof(keywordsl));
+    strlcat(keywordsb, colors[color2], sizeof(keywordsb));
+    strlcat(keywordsh, colors[color2], sizeof(keywordsh));
+    strlcat(keywordsa, colors[color2], sizeof(keywordsa));
+    strlcat(keywordsl, colors[color2], sizeof(keywordsl));
   }
 
   // Insert the material type, then armor type
   if (GET_OBJ_MATERIAL(body) != MATERIAL_LEATHER) // leather is redudant in description here
   {
-    strncat(descb, " ", MEDIUM_STRING - strlen(descb));
-    strncat(desch, " ", MEDIUM_STRING - strlen(desch));
-    strncat(desca, " ", MEDIUM_STRING - strlen(desca));
-    strncat(descl, " ", MEDIUM_STRING - strlen(descl));
-    strncat(descb, material_name[GET_OBJ_MATERIAL(body)], MEDIUM_STRING - strlen(descb));
-    strncat(desch, material_name[GET_OBJ_MATERIAL(head)], MEDIUM_STRING - strlen(desch));
-    strncat(desca, material_name[GET_OBJ_MATERIAL(arms)], MEDIUM_STRING - strlen(desca));
-    strncat(descl, material_name[GET_OBJ_MATERIAL(legs)], MEDIUM_STRING - strlen(descl));
+    strlcat(descb, " ", sizeof(descb));
+    strlcat(desch, " ", sizeof(desch));
+    strlcat(desca, " ", sizeof(desca));
+    strlcat(descl, " ", sizeof(descl));
+    strlcat(descb, material_name[GET_OBJ_MATERIAL(body)], sizeof(descb));
+    strlcat(desch, material_name[GET_OBJ_MATERIAL(head)], sizeof(desch));
+    strlcat(desca, material_name[GET_OBJ_MATERIAL(arms)], sizeof(desca));
+    strlcat(descl, material_name[GET_OBJ_MATERIAL(legs)], sizeof(descl));
   }
-  strncat(descb, " ", MEDIUM_STRING - strlen(descb));
-  strncat(desch, " ", MEDIUM_STRING - strlen(desch));
-  strncat(desca, " ", MEDIUM_STRING - strlen(desca));
-  strncat(descl, " ", MEDIUM_STRING - strlen(descl));
-  strncat(descb, armor_list[GET_ARMOR_TYPE(body)].name, MEDIUM_STRING - strlen(descb));
-  strncat(desch, armor_list[GET_ARMOR_TYPE(head)].name, MEDIUM_STRING - strlen(desch));
-  strncat(desca, armor_list[GET_ARMOR_TYPE(arms)].name, MEDIUM_STRING - strlen(desca));
-  strncat(descl, armor_list[GET_ARMOR_TYPE(legs)].name, MEDIUM_STRING - strlen(descl));
+  strlcat(descb, " ", sizeof(descb));
+  strlcat(desch, " ", sizeof(desch));
+  strlcat(desca, " ", sizeof(desca));
+  strlcat(descl, " ", sizeof(descl));
+  strlcat(descb, armor_list[GET_ARMOR_TYPE(body)].name, sizeof(descb));
+  strlcat(desch, armor_list[GET_ARMOR_TYPE(head)].name, sizeof(desch));
+  strlcat(desca, armor_list[GET_ARMOR_TYPE(arms)].name, sizeof(desca));
+  strlcat(descl, armor_list[GET_ARMOR_TYPE(legs)].name, sizeof(descl));
 
   roll = dice(1, 8);
   if (roll >= 7)
@@ -2471,28 +2471,28 @@ void award_magic_armor_suit(struct char_data *ch, int grade)
     char tmp[SMALL_STRING] = {'\0'};
     snprintf(tmp, SMALL_STRING, " with %s %s crest", AN(armor_crests[crest_num]),
              armor_crests[crest_num]);
-    strncat(descb, tmp, MEDIUM_STRING - strlen(descb));
-    strncat(desch, tmp, MEDIUM_STRING - strlen(desch));
-    strncat(desca, tmp, MEDIUM_STRING - strlen(desca));
-    strncat(descl, tmp, MEDIUM_STRING - strlen(descl));
-    strncat(keywordsb, tmp, MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, tmp, MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, tmp, MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, tmp, MEDIUM_STRING - strlen(keywordsl));
+    strlcat(descb, tmp, sizeof(descb));
+    strlcat(desch, tmp, sizeof(desch));
+    strlcat(desca, tmp, sizeof(desca));
+    strlcat(descl, tmp, sizeof(descl));
+    strlcat(keywordsb, tmp, sizeof(keywordsb));
+    strlcat(keywordsh, tmp, sizeof(keywordsh));
+    strlcat(keywordsa, tmp, sizeof(keywordsa));
+    strlcat(keywordsl, tmp, sizeof(keywordsl));
   }
   else if (roll >= 5)
   { // or symbol?
     char tmp[SMALL_STRING] = {'\0'};
     snprintf(tmp, SMALL_STRING, " covered in symbols of %s %s", AN(armor_crests[crest_num]),
              armor_crests[crest_num]);
-    strncat(descb, tmp, MEDIUM_STRING - strlen(descb));
-    strncat(desch, tmp, MEDIUM_STRING - strlen(desch));
-    strncat(desca, tmp, MEDIUM_STRING - strlen(desca));
-    strncat(descl, tmp, MEDIUM_STRING - strlen(descl));
-    strncat(keywordsb, tmp, MEDIUM_STRING - strlen(keywordsb));
-    strncat(keywordsh, tmp, MEDIUM_STRING - strlen(keywordsh));
-    strncat(keywordsa, tmp, MEDIUM_STRING - strlen(keywordsa));
-    strncat(keywordsl, tmp, MEDIUM_STRING - strlen(keywordsl));
+    strlcat(descb, tmp, sizeof(descb));
+    strlcat(desch, tmp, sizeof(desch));
+    strlcat(desca, tmp, sizeof(desca));
+    strlcat(descl, tmp, sizeof(descl));
+    strlcat(keywordsb, tmp, sizeof(keywordsb));
+    strlcat(keywordsh, tmp, sizeof(keywordsh));
+    strlcat(keywordsa, tmp, sizeof(keywordsa));
+    strlcat(keywordsl, tmp, sizeof(keywordsl));
   }
 
   // keywords

--- a/src/utils.c
+++ b/src/utils.c
@@ -2671,6 +2671,41 @@ size_t strlcat(char *buf, const char *src, size_t bufsz)
   return rtn;
 }
 
+/*
+ * Appends formatted text at a tracked buffer offset and returns the new,
+ * saturated offset.  Unlike adding snprintf()'s return value directly, the
+ * returned offset never advances past the last writable byte after truncation.
+ */
+int snprintf_append(char *buffer, size_t buffer_size, int offset, const char *format, ...)
+{
+  va_list args;
+  size_t position;
+  size_t available;
+  int written;
+
+  if (!buffer || buffer_size == 0 || !format)
+    return 0;
+
+  position = offset > 0 ? (size_t)offset : 0;
+  if (position >= buffer_size)
+  {
+    buffer[buffer_size - 1] = '\0';
+    return (int)(buffer_size - 1);
+  }
+
+  available = buffer_size - position;
+  va_start(args, format);
+  written = vsnprintf(buffer + position, available, format, args);
+  va_end(args);
+
+  if (written < 0)
+    return (int)position;
+  if ((size_t)written >= available)
+    return (int)(buffer_size - 1);
+
+  return (int)(position + (size_t)written);
+}
+
 #if !defined(HAVE_STRLCPY)
 
 /** A 'strlcpy' function in the same fashion as 'strdup' below. This copies up
@@ -2813,7 +2848,7 @@ int touch(const char *path)
 {
   FILE *fl;
 
-  if (!(fl = fopen(path, "a")))
+  if (!(fl = fopen_restricted(path, "a")))
   {
     log("SYSERR: %s: %s", path, strerror(errno));
     return (-1);
@@ -3304,7 +3339,7 @@ int get_line(FILE *fl, char *buf)
   while (sl > 0 && (temp[sl - 1] == '\n' || temp[sl - 1] == '\r'))
     temp[--sl] = '\0';
 
-  strcpy(buf, temp); /* strcpy: OK, if buf >= READ_SIZE (512) */
+  strlcpy(buf, temp, READ_SIZE);
   return (lines);
 }
 
@@ -3326,6 +3361,7 @@ int get_line(FILE *fl, char *buf)
 int get_filename(char *filename, size_t fbufsize, int mode, const char *orig_name)
 {
   const char *prefix, *middle, *suffix;
+  const char *input;
   char name[MAX_FILEPATH], *ptr;
 
   if (orig_name == NULL || *orig_name == '\0' || filename == NULL)
@@ -3333,6 +3369,15 @@ int get_filename(char *filename, size_t fbufsize, int mode, const char *orig_nam
     log("SYSERR: NULL pointer or empty string passed to get_filename(), %p or %p.", orig_name,
         filename);
     return (0);
+  }
+
+  for (input = orig_name; *input; input++)
+  {
+    if (!isalnum((unsigned char)*input) && *input != '_' && *input != '-')
+    {
+      log("SYSERR: Invalid character in player filename component.");
+      return (0);
+    }
   }
 
   switch (mode)
@@ -3406,6 +3451,20 @@ int get_filename(char *filename, size_t fbufsize, int mode, const char *orig_nam
 
   snprintf(filename, fbufsize, "%s%s" SLASH "%s.%s", prefix, middle, name, suffix);
   return (1);
+}
+
+bool is_safe_path_component(const char *name)
+{
+  const unsigned char *current;
+
+  if (!name || !*name || !strcmp(name, ".") || !strcmp(name, "..") || strstr(name, ".."))
+    return FALSE;
+
+  for (current = (const unsigned char *)name; *current; current++)
+    if (!isalnum(*current) && *current != '.' && *current != '_' && *current != '-')
+      return FALSE;
+
+  return TRUE;
 }
 
 /** Calculate the number of player characters (PCs) in the room. Any NPC (mob)
@@ -4640,7 +4699,7 @@ char *convert_from_tabs(char *string)
 {
   static char buf[MAX_STRING_LENGTH * 8];
 
-  strcpy(buf, string);
+  strlcpy(buf, string, sizeof(buf));
   parse_tab(buf);
   return (buf);
 }
@@ -5363,14 +5422,13 @@ void text_line(struct char_data *ch, const char *text, int length, char first, c
 /* Time formatting helpers */
 bool format_time_string(time_t when, const char *format, char *buf, size_t size)
 {
-  struct tm *tm_info;
+  struct tm tm_info;
 
   if (!buf || size == 0)
     return FALSE;
 
   *buf = '\0';
-  tm_info = localtime(&when);
-  if (!format || !tm_info || strftime(buf, size, format, tm_info) == 0)
+  if (!format || !localtime_r(&when, &tm_info) || strftime(buf, size, format, &tm_info) == 0)
   {
     strlcpy(buf, "Unknown", size);
     return FALSE;

--- a/src/utils.h
+++ b/src/utils.h
@@ -440,6 +440,8 @@ bool format_time_string(time_t when, const char *format, char *buf, size_t size)
 const char *format_time_ymd_hms(time_t when);
 
 /* Filesystem helpers */
+/* Validates a single filename component, excluding path separators and traversal. */
+bool is_safe_path_component(const char *name);
 /* Ensures that a directory path exists, creating intermediate directories as needed. */
 bool ensure_dir_exists(const char *path);
 
@@ -464,6 +466,8 @@ int strn_cmp(const char *arg1, const char *arg2, int n);
 #endif
 
 size_t strlcat(char *buf, const char *src, size_t bufsz);
+int snprintf_append(char *buffer, size_t buffer_size, int offset, const char *format, ...)
+    __attribute__((format(printf, 4, 5)));
 
 /* random functions in random.c */
 void circle_srandom(unsigned long initial_seed);

--- a/src/vessels_db.c
+++ b/src/vessels_db.c
@@ -63,9 +63,9 @@ void save_ship_interior(struct greyhawk_ship_data *ship)
   {
     if (i > 0)
     {
-      len += snprintf(room_vnums_str + len, sizeof(room_vnums_str) - len, ",");
+      len = snprintf_append(room_vnums_str, sizeof(room_vnums_str), len, ",");
     }
-    len += snprintf(room_vnums_str + len, sizeof(room_vnums_str) - len, "%d", ship->room_vnums[i]);
+    len = snprintf_append(room_vnums_str, sizeof(room_vnums_str), len, "%d", ship->room_vnums[i]);
   }
 
   /* Escape ship name - name is an array, not pointer, so always valid */
@@ -412,7 +412,7 @@ int serialize_room_data(struct greyhawk_ship_data *ship, char *buffer, int buffe
 {
   int i, len = 0;
 
-  if (!ship || !buffer)
+  if (!ship || !buffer || buffer_size <= 0)
   {
     return 0;
   }
@@ -422,10 +422,10 @@ int serialize_room_data(struct greyhawk_ship_data *ship, char *buffer, int buffe
 
   for (i = 0; i < ship->num_connections && i < MAX_SHIP_CONNECTIONS; i++)
   {
-    len +=
-        snprintf(buffer + len, buffer_size - len, "|%d:%d:%d:%d:%d", ship->connections[i].from_room,
-                 ship->connections[i].to_room, ship->connections[i].direction,
-                 ship->connections[i].is_hatch ? 1 : 0, ship->connections[i].is_locked ? 1 : 0);
+    len = snprintf_append(buffer, (size_t)buffer_size, len, "|%d:%d:%d:%d:%d",
+                          ship->connections[i].from_room, ship->connections[i].to_room,
+                          ship->connections[i].direction, ship->connections[i].is_hatch ? 1 : 0,
+                          ship->connections[i].is_locked ? 1 : 0);
   }
 
   return len;

--- a/src/wilderness.c
+++ b/src/wilderness.c
@@ -1825,7 +1825,7 @@ void save_map_to_file(const char *fn, int xsize, int ysize)
     }
   }
 
-  out = fopen(fn, "wb");
+  out = fopen_restricted(fn, "wb");
   gdImagePng(im, out);
   fclose(out);
   gdImageDestroy(im);
@@ -1878,7 +1878,7 @@ void save_noise_to_file(int idx, const char *fn, int xsize, int ysize, int zoom)
     }
   }
 
-  out = fopen(fn, "wb");
+  out = fopen_restricted(fn, "wb");
   gdImagePng(im, out);
   fclose(out);
   gdImageDestroy(im);

--- a/src/wilderness_kb.c
+++ b/src/wilderness_kb.c
@@ -2195,10 +2195,9 @@ void document_all_paths(FILE *fp)
 void write_header_section(FILE *fp)
 {
   time_t now = time(NULL);
-  struct tm *tm_info = localtime(&now);
   char timestamp[64];
 
-  strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", tm_info);
+  format_time_string(now, "%Y-%m-%d %H:%M:%S", timestamp, sizeof(timestamp));
 
   fprintf(fp, "# Luminari World Map Knowledge Base\n\n");
   fprintf(fp, "Generated: %s\n", timestamp);
@@ -3763,7 +3762,7 @@ void generate_wilderness_knowledge_base(const char *output_filename)
 
   /* Open output file - save to current directory */
   WILD_DEBUG("Opening output file for writing");
-  fp = fopen(output_filename, "w");
+  fp = fopen_restricted(output_filename, "w");
   if (!fp)
   {
     mudlog(CMP, LVL_IMMORT, FALSE, "ERROR: Failed to open output file %s", output_filename);

--- a/src/world/spec_artifacts.c
+++ b/src/world/spec_artifacts.c
@@ -1297,6 +1297,7 @@ void artifact_save(void)
 {
   FILE *fl = NULL;
   char temp_file[MAX_INPUT_LENGTH] = {'\0'};
+  char generated_at[32] = {'\0'};
   time_t current_time = 0;
   int i = 0, j = 0;
 
@@ -1305,7 +1306,7 @@ void artifact_save(void)
 
   snprintf(temp_file, sizeof(temp_file), "%s.tmp", ARTIFACT_FILE);
 
-  if (!(fl = fopen(temp_file, "w")))
+  if (!(fl = fopen_restricted(temp_file, "w")))
   {
     log("SYSERR: artifact_save: cannot open %s for writing", temp_file);
     return;
@@ -1318,7 +1319,9 @@ void artifact_save(void)
   fprintf(fl,
           "#         claims transfers destroys recoveries overrides discovered discovered_at\n");
   fprintf(fl, "#         last_ability last_proc effect_used[0..%d]\n", ARTIFACT_MAX_EFFECTS - 1);
-  fprintf(fl, "# Generated: %s", ctime(&current_time));
+  if (!ctime_r(&current_time, generated_at))
+    strlcpy(generated_at, "Unknown\n", sizeof(generated_at));
+  fprintf(fl, "# Generated: %s", generated_at);
   fprintf(fl, "\n");
 
   for (i = 0; i < total_artifacts; i++)
@@ -4769,6 +4772,7 @@ static void artifact_show_roster(struct char_data *ch)
 static void artifact_show_chronicle(struct char_data *ch, const char *name)
 {
   struct artifact_data *art = NULL, *match = NULL;
+  char claimed_at[32] = {'\0'};
   obj_rnum rnum = NOTHING;
   int i = 0, state = 0, stage = 0;
 
@@ -4813,12 +4817,18 @@ static void artifact_show_chronicle(struct char_data *ch, const char *name)
   artifact_show_bearer(ch, match, state);
 
   if (match->first_claimed_at > 0)
-    send_to_char(ch, "    First claimed %s", ctime(&match->first_claimed_at));
+  {
+    if (ctime_r(&match->first_claimed_at, claimed_at))
+      send_to_char(ch, "    First claimed %s", claimed_at);
+  }
   else
     send_to_char(ch, "    It has never been claimed.\r\n");
 
   if (match->last_claimed_at > 0)
-    send_to_char(ch, "    Last claimed  %s", ctime(&match->last_claimed_at));
+  {
+    if (ctime_r(&match->last_claimed_at, claimed_at))
+      send_to_char(ch, "    Last claimed  %s", claimed_at);
+  }
 
   send_to_char(ch, "    Claimed %d time%s, released %d time%s.\r\n", match->claim_count,
                match->claim_count == 1 ? "" : "s", match->transfer_count,

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -14,6 +14,8 @@
 /* protect our calloc() and free() calls from recursive redefinition: */
 #define ZMALLOC_H
 
+#include "conf.h"
+#include "sysdep.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -72,7 +74,7 @@ void zmalloc_init(void)
 
   if (!zfd)
   {
-    zfd = fopen("zmalloc.log", "w+");
+    zfd = fopen_restricted("zmalloc.log", "w+");
   }
 }
 

--- a/unittests/CuTest/test_bounds_checking.c
+++ b/unittests/CuTest/test_bounds_checking.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 /* Include the actual headers from src */
 #include "../../src/conf.h"
@@ -85,11 +86,72 @@ void Test_dr_spell_bounds_validation(CuTest *tc)
   CuAssertTrue(tc, dr.spell >= 0 && dr.spell < TOP_SPELL_DEFINE);
 }
 
+void Test_snprintf_append_saturates_offset(CuTest *tc)
+{
+  char buffer[8] = {'\0'};
+  int offset;
+
+  strlcpy(buffer, "123456789", sizeof(buffer));
+  offset = 9;
+  offset = snprintf_append(buffer, sizeof(buffer), offset, "%s", "ignored");
+
+  CuAssertIntEquals(tc, (int)sizeof(buffer) - 1, offset);
+  CuAssertStrEquals(tc, "1234567", buffer);
+
+  offset = snprintf_append(buffer, sizeof(buffer), offset, "%s", "ignored");
+  CuAssertIntEquals(tc, (int)sizeof(buffer) - 1, offset);
+  CuAssertStrEquals(tc, "1234567", buffer);
+}
+
+void Test_path_component_validation(CuTest *tc)
+{
+  char filename[MAX_FILEPATH];
+
+  CuAssertTrue(tc, is_safe_path_component("1200.wld"));
+  CuAssertTrue(tc, is_safe_path_component("zone-name_2.obj"));
+  CuAssertTrue(tc, !is_safe_path_component("../etc/passwd"));
+  CuAssertTrue(tc, !is_safe_path_component("subdir/file.wld"));
+  CuAssertTrue(tc, !is_safe_path_component("zone..obj"));
+  CuAssertTrue(tc, get_filename(filename, sizeof(filename), PLR_FILE, "taure_two"));
+  CuAssertTrue(tc, !get_filename(filename, sizeof(filename), PLR_FILE, "../../player"));
+}
+
+void Test_fopen_restricted_blocks_world_write(CuTest *tc)
+{
+  char path[] = "/tmp/luminari-fopen-test-XXXXXX";
+  struct stat file_stat;
+  FILE *file;
+  int fd;
+  int opened;
+  int stat_ok;
+  int secure_mode;
+
+  fd = mkstemp(path);
+  CuAssertTrue(tc, fd >= 0);
+  close(fd);
+  unlink(path);
+
+  file = fopen_restricted(path, "w");
+  opened = file != NULL;
+  if (file)
+    fclose(file);
+  stat_ok = stat(path, &file_stat) == 0;
+  secure_mode = stat_ok && !(file_stat.st_mode & S_IWOTH);
+  unlink(path);
+
+  CuAssertTrue(tc, opened);
+  CuAssertTrue(tc, stat_ok);
+  CuAssertTrue(tc, secure_mode);
+}
+
 /* Suite setup */
 CuSuite *BoundsCheckingSuite(void)
 {
   CuSuite *suite = CuSuiteNew();
   SUITE_ADD_TEST(suite, Test_get_wearoff_bounds_checking);
   SUITE_ADD_TEST(suite, Test_dr_spell_bounds_validation);
+  SUITE_ADD_TEST(suite, Test_snprintf_append_saturates_offset);
+  SUITE_ADD_TEST(suite, Test_path_component_validation);
+  SUITE_ADD_TEST(suite, Test_fopen_restricted_blocks_world_write);
   return suite;
 }

--- a/util/autowiz.c
+++ b/util/autowiz.c
@@ -95,7 +95,7 @@ void read_file(void)
   char name[MAX_NAME_LENGTH];
   long id = 0;
 
-  sprintf(index_name, "%s%s", LIB_PLRFILES, INDEX_FILE);
+  snprintf(index_name, sizeof(index_name), "%s%s", LIB_PLRFILES, INDEX_FILE);
   if (!(fl = fopen(index_name, "r")))
   {
     perror("Error opening playerfile");
@@ -111,7 +111,11 @@ void read_file(void)
   for (i = 0; i < recs; i++)
   {
     get_line(fl, line);
-    sscanf(line, "%ld %s %d %s %d", &id, name, &level, bits, &last);
+    if (sscanf(line, "%ld %19s %d %63s %d", &id, name, &level, bits, &last) != 5)
+    {
+      fprintf(stderr, "Invalid player index record: %s\n", line);
+      continue;
+    }
     CAP(name);
     flags = asciiflag_conv(bits);
     if (level >= MIN_LEVEL && !(IS_SET(flags, PINDEX_NOWIZLIST)) &&

--- a/util/autowiz.c
+++ b/util/autowiz.c
@@ -312,11 +312,11 @@ int main(int argc, char **argv)
   read_file();
   sort_names();
 
-  fl = fopen(argv[2], "w");
+  fl = fopen_restricted(argv[2], "w");
   write_wizlist(fl, wizlevel, LVL_IMPL);
   fclose(fl);
 
-  fl = fopen(argv[4], "w");
+  fl = fopen_restricted(argv[4], "w");
   write_wizlist(fl, immlevel, wizlevel - 1);
   fclose(fl);
 
@@ -365,7 +365,7 @@ int get_line(FILE *fl, char *buf)
   {
     temp[strlen(temp) - 1] = '\0';
   }
-  strcpy(buf, temp);
+  strlcpy(buf, temp, MEDIUM_STRING);
   return (lines);
 }
 

--- a/util/autowiz.c
+++ b/util/autowiz.c
@@ -154,7 +154,7 @@ void add_name(byte level, char *name)
     fprintf(stderr, "Error: Failed to allocate memory for name record\n");
     return;
   }
-  strcpy(tmp->name, name);
+  strlcpy(tmp->name, name, sizeof(tmp->name));
   tmp->next = 0;
 
   /* Find the appropriate level list */

--- a/util/plrtoascii.c
+++ b/util/plrtoascii.c
@@ -196,7 +196,7 @@ void convert(char *filename)
 
   sprintf(index_name, "%s%s", LIB_PLRFILES, INDEX_FILE);
 
-  if (!(index_file = fopen(index_name, "w")))
+  if (!(index_file = fopen_restricted(index_name, "w")))
   {
     perror("error opening index file");
     exit(1);
@@ -221,7 +221,7 @@ void convert(char *filename)
     fprintf(index_file, "%ld %s %d 0 %ld\n", player.char_specials_saved.idnum, bits, player.level,
             (long)player.last_logon);
 
-    if (!(outfile = fopen(outname, "w")))
+    if (!(outfile = fopen_restricted(outname, "w")))
     {
       printf("error opening output file");
       exit(1);

--- a/util/rebuildAsciiIndex.c
+++ b/util/rebuildAsciiIndex.c
@@ -11,6 +11,8 @@
 *  portability, error handling, and documentation                         *
 ************************************************************************* */
 
+#include "conf.h"
+#include "sysdep.h"
 #include <stdio.h>
 #include <dirent.h>
 #include <sys/stat.h>
@@ -60,7 +62,7 @@ int main(int argc, char **argv)
     return 0;
   }
 
-  if (!(index_file = fopen(argv[1], "w")))
+  if (!(index_file = fopen_restricted(argv[1], "w")))
   {
     perror("error opening index file");
     return 1;
@@ -199,7 +201,7 @@ void walkdir(FILE *index_file, char *dir)
   char *name;
   FILE *plr_file;
   long id, last;
-  int level, adminlevel;
+  int level, adminlevel, entry_fd, open_flags;
 
   if ((dfd = opendir(dir)) == NULL)
   {
@@ -209,18 +211,31 @@ void walkdir(FILE *index_file, char *dir)
 
   while ((dp = readdir(dfd)) != NULL)
   {
-    sprintf(filename_qfd, "%s/%s", dir, dp->d_name);
-    if (stat(filename_qfd, &stbuf) == -1)
+    if (!strcmp(".", dp->d_name) || !strcmp("..", dp->d_name))
+      continue;
+    if (snprintf(filename_qfd, sizeof(filename_qfd), "%s/%s", dir, dp->d_name) >=
+        (int)sizeof(filename_qfd))
     {
-      fprintf(stdout, "Unable to stat file: %s\n", filename_qfd);
+      fprintf(stdout, "Path is too long: %s/%s\n", dir, dp->d_name);
       continue;
     }
 
-    if ((stbuf.st_mode & S_IFMT) == S_IFDIR)
+    open_flags = O_RDONLY;
+#ifdef O_NOFOLLOW
+    open_flags |= O_NOFOLLOW;
+#endif
+    entry_fd = openat(dirfd(dfd), dp->d_name, open_flags);
+    if (entry_fd < 0 || fstat(entry_fd, &stbuf) == -1)
     {
-      if (!strcmp(".", dp->d_name) || !strcmp("..", dp->d_name))
-        continue;
+      fprintf(stdout, "Unable to open file: %s\n", filename_qfd);
+      if (entry_fd >= 0)
+        close(entry_fd);
+      continue;
+    }
 
+    if (S_ISDIR(stbuf.st_mode))
+    {
+      close(entry_fd);
       walkdir(index_file, filename_qfd);
     }
     else
@@ -229,10 +244,11 @@ void walkdir(FILE *index_file, char *dir)
 
       if (name != NULL)
       {
-        plr_file = fopen(filename_qfd, "r");
+        plr_file = fdopen(entry_fd, "r");
         if (!plr_file)
         {
           fprintf(stderr, "Warning: Could not open player file %s\n", filename_qfd);
+          close(entry_fd);
           continue;
         }
 
@@ -247,6 +263,8 @@ void walkdir(FILE *index_file, char *dir)
 
         fclose(plr_file);
       }
+      else
+        close(entry_fd);
     }
   }
   closedir(dfd);
@@ -280,6 +298,6 @@ int get_line(FILE *fl, char *buf)
   while (sl > 0 && (temp[sl - 1] == '\n' || temp[sl - 1] == '\r'))
     temp[--sl] = '\0';
 
-  strcpy(buf, temp); /* strcpy: OK, if buf >= READ_SIZE (256) */
+  strlcpy(buf, temp, READ_SIZE);
   return (lines);
 }

--- a/util/rebuildMailIndex.c
+++ b/util/rebuildMailIndex.c
@@ -199,7 +199,7 @@ int parse_mail_flags(FILE *plr_file)
   if ((txt = findLine(plr_file, "Flag:")) != NULL)
   {
     /* Read the flags */
-    if (sscanf(txt, "%s %s %s %s", f1, f2, f3, f4) == 4)
+    if (sscanf(txt, "%32s %32s %32s %32s", f1, f2, f3, f4) == 4)
     {
       fl[0] = asciiflag_conv(f1);
       fl[1] = asciiflag_conv(f2);

--- a/util/rebuildMailIndex.c
+++ b/util/rebuildMailIndex.c
@@ -12,6 +12,8 @@
 *  documentation and error handling                                       *
 ************************************************************************* */
 
+#include "conf.h"
+#include "sysdep.h"
 #include <stdio.h>
 #include <dirent.h>
 #include <sys/stat.h>
@@ -93,7 +95,7 @@ int main(int argc, char **argv)
     return 0;
   }
 
-  if (!(index_file = fopen(argv[1], "w")))
+  if (!(index_file = fopen_restricted(argv[1], "w")))
   {
     perror("error opening index file");
     return 1;
@@ -263,7 +265,7 @@ void walkdir(FILE *index_file, char *dir)
   struct dirent *dp;
   struct stat stbuf;
   long id, sender, recipient, sent_time;
-  int flags;
+  int flags, entry_fd, open_flags;
   DIR *dfd;
   FILE *mail_file;
   char *name;
@@ -276,19 +278,31 @@ void walkdir(FILE *index_file, char *dir)
 
   while ((dp = readdir(dfd)) != NULL)
   {
-    sprintf(filename_qfd, "%s/%s", dir, dp->d_name);
-
-    if (stat(filename_qfd, &stbuf) == -1)
+    if (!strcmp(".", dp->d_name) || !strcmp("..", dp->d_name))
+      continue;
+    if (snprintf(filename_qfd, sizeof(filename_qfd), "%s/%s", dir, dp->d_name) >=
+        (int)sizeof(filename_qfd))
     {
-      fprintf(stdout, "Unable to stat file: %s\n", filename_qfd);
+      fprintf(stdout, "Path is too long: %s/%s\n", dir, dp->d_name);
       continue;
     }
 
-    if ((stbuf.st_mode & S_IFMT) == S_IFDIR)
+    open_flags = O_RDONLY;
+#ifdef O_NOFOLLOW
+    open_flags |= O_NOFOLLOW;
+#endif
+    entry_fd = openat(dirfd(dfd), dp->d_name, open_flags);
+    if (entry_fd < 0 || fstat(entry_fd, &stbuf) == -1)
     {
-      if (!strcmp(".", dp->d_name) || !strcmp("..", dp->d_name))
-        continue;
+      fprintf(stdout, "Unable to open file: %s\n", filename_qfd);
+      if (entry_fd >= 0)
+        close(entry_fd);
+      continue;
+    }
 
+    if (S_ISDIR(stbuf.st_mode))
+    {
+      close(entry_fd);
       walkdir(index_file, filename_qfd);
     }
     else
@@ -298,10 +312,11 @@ void walkdir(FILE *index_file, char *dir)
       if (name != NULL)
       {
         /* Extract data from the mail file and add to index */
-        mail_file = fopen(filename_qfd, "r");
+        mail_file = fdopen(entry_fd, "r");
         if (!mail_file)
         {
           fprintf(stderr, "Warning: Could not open mail file %s\n", filename_qfd);
+          close(entry_fd);
           continue;
         }
 
@@ -319,6 +334,8 @@ void walkdir(FILE *index_file, char *dir)
 
         fclose(mail_file);
       }
+      else
+        close(entry_fd);
     }
   }
   closedir(dfd);
@@ -342,7 +359,7 @@ int get_line(FILE *fl, char *buf)
   while (sl > 0 && (temp[sl - 1] == '\n' || temp[sl - 1] == '\r'))
     temp[--sl] = '\0';
 
-  strcpy(buf, temp); /* strcpy: OK, if buf >= READ_SIZE (256) */
+  strlcpy(buf, temp, READ_SIZE);
   return (lines);
 }
 

--- a/util/shopconv.c
+++ b/util/shopconv.c
@@ -52,13 +52,13 @@ char *fread_string(FILE *fl, const char *error)
       printf("fread_string: format error at or near %s\n", error);
       exit(1);
     }
-    if (strlen(tmp) + strlen(buf) > MAX_STRING_LENGTH)
+    if (strlen(tmp) + strlen(buf) >= MAX_STRING_LENGTH)
     {
       printf("SYSERR: fread_string: string too large (shopconv.c)");
       exit(1);
     }
     else
-      strcat(buf, tmp);
+      strlcat(buf, tmp, sizeof(buf));
 
     for (point = buf + strlen(buf) - 2; point >= buf && isspace(*point); point--)
       ;
@@ -110,7 +110,7 @@ void do_list(FILE *shop_f, FILE *newshop_f, int max)
 void do_float(FILE *shop_f, FILE *newshop_f)
 {
   float f;
-  char str[20];
+  char str[512];
 
   if (fscanf(shop_f, "%f \n", &f) != 1)
   {
@@ -118,7 +118,7 @@ void do_float(FILE *shop_f, FILE *newshop_f)
     exit(1);
   }
 
-  sprintf(str, "%f", f);
+  snprintf(str, sizeof(str), "%f", f);
   while ((str[strlen(str) - 1] == '0') && (str[strlen(str) - 2] != '.'))
     str[strlen(str) - 1] = 0;
   fprintf(newshop_f, "%s \n", str);
@@ -150,15 +150,20 @@ static int boot_the_shops_conv(FILE *shop_f, FILE *newshop_f, char *filename)
   char *buf, buf2[150];
   int temp, count;
 
-  sprintf(buf2, "beginning of shop file %s", filename);
+  snprintf(buf2, sizeof(buf2), "beginning of shop file %s", filename);
   fprintf(newshop_f, "LuminariMUD %s Shop File~\n", VERSION3_TAG);
   for (;;)
   {
     buf = fread_string(shop_f, buf2);
     if (*buf == '#')
     { /* New shop */
-      sscanf(buf, "#%d\n", &temp);
-      sprintf(buf2, "shop #%d in shop file %s", temp, filename);
+      if (sscanf(buf, "#%d\n", &temp) != 1)
+      {
+        fprintf(stderr, "Invalid shop header: %s\n", buf);
+        free(buf);
+        return 0;
+      }
+      snprintf(buf2, sizeof(buf2), "shop #%d in shop file %s", temp, filename);
       fprintf(newshop_f, "#%d~\n", temp);
       free(buf); /* Plug memory leak! */
       printf("   #%d\n", temp);
@@ -262,7 +267,7 @@ int main(int argc, char *argv[])
       continue;
     }
 
-    if ((nsfp = fopen(fn, "w")) == NULL)
+    if ((nsfp = fopen_restricted(fn, "w")) == NULL)
     {
       printf("Error: Could not open %s for writing\n", fn);
       fclose(sfp);

--- a/util/shopconv.c
+++ b/util/shopconv.c
@@ -76,7 +76,7 @@ char *fread_string(FILE *fl, const char *error)
   if (strlen(buf) > 0)
   {
     CREATE(rslt, char, strlen(buf) + 1);
-    strcpy(rslt, buf);
+    memcpy(rslt, buf, strlen(buf) + 1);
   }
   else
     rslt = NULL;

--- a/util/sign.c
+++ b/util/sign.c
@@ -134,12 +134,12 @@ char *get_text(char *fname)
   {
     if (strlen(tmp) + strlen(t) < MAX_FILESIZE - 1)
     {
-      strcat(t, tmp);
+      strlcat(t, tmp, sizeof(t));
       /* Add carriage return for telnet compatibility */
       if (tmp[strlen(tmp) - 1] == '\n')
       {
         t[strlen(t) - 1] = '\0'; /* Remove \n */
-        strcat(t, "\r\n");       /* Add \r\n */
+        strlcat(t, "\r\n", sizeof(t)); /* Add \r\n */
       }
     }
     else

--- a/util/split.c
+++ b/util/split.c
@@ -42,6 +42,7 @@
 int main(void)
 {
   char line[BSZ + 1];
+  const unsigned char *filename_char;
   char *newline_pos;
   FILE *index = NULL, *outfile = NULL;
   int file_count = 0;
@@ -50,7 +51,7 @@ int main(void)
   printf("Use lines starting with '=' to specify output filenames.\n");
   printf("Example: =zone01.wld\n\n");
 
-  if (!(index = fopen(INDEX_NAME, "w")))
+  if (!(index = fopen_restricted(INDEX_NAME, "w")))
   {
     perror("error opening index file for write");
     exit(1);
@@ -67,6 +68,25 @@ int main(void)
         *newline_pos = '\0';
       }
 
+      filename_char = (const unsigned char *)(line + 1);
+      if (!*filename_char || !strcmp((const char *)filename_char, ".") ||
+          !strcmp((const char *)filename_char, "..") ||
+          strstr((const char *)filename_char, ".."))
+      {
+        fprintf(stderr, "Invalid output filename: %s\n", line + 1);
+        fclose(index);
+        exit(1);
+      }
+      while (*filename_char && (isalnum(*filename_char) || *filename_char == '.' ||
+                                *filename_char == '_' || *filename_char == '-'))
+        filename_char++;
+      if (*filename_char)
+      {
+        fprintf(stderr, "Invalid output filename: %s\n", line + 1);
+        fclose(index);
+        exit(1);
+      }
+
       /* Close previous output file if open */
       if (outfile)
       {
@@ -75,7 +95,7 @@ int main(void)
       }
 
       /* Open new output file */
-      if (!(outfile = fopen((line + 1), "w")))
+      if (!(outfile = fopen_restricted((line + 1), "w")))
       {
         fprintf(stderr, "Error opening output file: %s\n", line + 1);
         fclose(index);

--- a/util/wld2html.c
+++ b/util/wld2html.c
@@ -418,7 +418,7 @@ static void write_output(void)
       fatal_file_error("output filename is too long", NULL);
 
     fprintf(stderr, "Writing %s\n", filename);
-    fl = fopen(filename, "w");
+    fl = fopen_restricted(filename, "w");
     if (!fl)
       fatal_file_error("cannot open output file", filename);
 


### PR DESCRIPTION
## Summary

- replace unsafe string assembly with bounded copy/append helpers and truncation-safe offset handling
- validate parser results, path components, allocations, time conversions, and replacement lifetimes
- restrict newly created files to mode 0640 and harden sensitive file reads against symlink/TOCTOU races
- remove tainted format-string flows and constrain legacy shop-format expansion to supported conversions
- add focused regression coverage for bounded appends, path validation, and restricted file creation

## Why

The existing CodeQL findings trace primarily to legacy C APIs, unchecked parse/size contracts, and file operations that relied on process defaults. These changes make those contracts explicit while preserving gameplay and data formats.

## Impact

This is a security-hardening change across core server, OLC, persistence, protocol, and maintenance utilities. No source files were added or removed, no customized local headers or credential files were changed, and no gameplay behavior is intentionally changed.

## Verification

- `make test` - PASS (`OK (210 tests)` plus autorun supervision checks)
- `make install` - PASS
- targeted Clang static-analysis core pass - completed successfully
- `git diff --check` - PASS
- pre-commit hygiene hooks - PASS
- remediation-branch CodeQL push and pull-request analyses - PASS
- exact branch Code Scanning API query - **0 open alerts**

All 481 originally reported alerts were reviewed. Thirty tagged-pointer or constrained/trusted-path false positives were dismissed with recorded justifications; the remaining findings were remediated in code. Findings newly surfaced by the updated analysis were also fixed.

## Final outcome

Merged into `master` as `f8713d96bb2dd08cc3b7da5a705cc9062892c561`.

- master Security workflow `30426041201` - PASS
- master CodeQL analysis `1541766479` - PASS with no analysis error
- exact `refs/heads/master` open-alert query - **0**
- repository-wide open-alert query - **0**
- live alert states - **590 fixed, 30 dismissed, 0 open**
- merged master tree hash exactly matches the locally tested branch tree

## Other CI context

The unrelated red checks were verified as pre-existing or repository-configuration issues:

- the remediation changes no `.github`, SQL/schema, or deployment-script files
- the last comparable `master` Build & Test run failed the same production-linked test location (`.github:1630`, exit code 2)
- the last comparable `master` Code Quality run already failed the same file-wide formatting gate
- database validation fails because existing component SQL files are not classified exactly once
- dependency review reports that Dependency Graph is disabled for the repository