### PR TITLE
Fix CodeQL type-confusion and path findings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased] - July 30, 2026
 
+### Security hardening
+
+#### Fixed
+
+- DG-script ownership helpers now take typed script fields or typed mobile,
+  object, and room owners instead of pairing `void *` values with separate type
+  tags. This removes four type-confusion paths during extraction, prototype
+  copying and cleanup, and trigger assignment.
+- The `-f` configuration option now accepts only bounded, library-relative
+  paths without empty, current-directory, parent-directory, or alternate
+  separator components. The chosen path is copied into owned storage before
+  configuration loading and OLC saving.
+- Player persistence paths continue to require the strict alphanumeric,
+  underscore, and hyphen name allowlist before fixed-directory path
+  construction; regression coverage includes traversal rejection.
+
 ### Build maintenance
 
 #### Fixed

--- a/docs/systems/CORE_SERVER_ARCHITECTURE.md
+++ b/docs/systems/CORE_SERVER_ARCHITECTURE.md
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
 ```
 
 **Key Command Line Options:**
-- `-f <file>` - Specify configuration file
+- `-f <file>` - Specify a configuration file using a safe library-relative path
 - `-o <file>` - Specify log file
 - `-d <dir>` - Set data directory
 - `-C<socket>` - Copyover recovery mode

--- a/src/comm.c
+++ b/src/comm.c
@@ -248,10 +248,11 @@ int main(int argc, char **argv)
 {
   /* Copy to stack memory to ensure the version is embedded in core dumps */
   char embed_version[256];
-  snprintf(embed_version, sizeof(embed_version), "%s", luminari_version);
-
   int pos = 1;
+  const char *config_file = NULL;
   const char *dir = NULL;
+
+  snprintf(embed_version, sizeof(embed_version), "%s", luminari_version);
 
 #ifdef MEMORY_DEBUG
   zmalloc_init();
@@ -278,15 +279,14 @@ int main(int argc, char **argv)
   /* Load the game configuration. We must load BEFORE we use any of the
    * constants stored in constants.c.  Otherwise, there will be no variables
    * set to set the rest of the vars to, which will mean trouble --> Mythran */
-  CONFIG_CONFFILE = NULL;
   while (pos < argc && argv[pos] != NULL && *(argv[pos]) == '-')
   {
     if (*(argv[pos] + 1) == 'f')
     {
       if (*(argv[pos] + 2))
-        CONFIG_CONFFILE = argv[pos] + 2;
+        config_file = argv[pos] + 2;
       else if (++pos < argc)
-        CONFIG_CONFFILE = argv[pos];
+        config_file = argv[pos];
       else
       {
         puts("SYSERR: File name to read from expected after option -f.");
@@ -297,8 +297,21 @@ int main(int argc, char **argv)
   }
   pos = 1;
 
+  if (!config_file)
+    config_file = CONFIG_FILE;
+  if (!is_safe_relative_path(config_file))
+  {
+    fputs("SYSERR: Configuration file must be a safe path relative to the library directory.\n",
+          stderr);
+    return EXIT_FAILURE;
+  }
+
+  CONFIG_CONFFILE = strdup(config_file);
   if (!CONFIG_CONFFILE)
-    CONFIG_CONFFILE = strdup(CONFIG_FILE);
+  {
+    perror("SYSERR: strdup configuration file");
+    return EXIT_FAILURE;
+  }
 
   load_config();
 

--- a/src/db.c
+++ b/src/db.c
@@ -926,9 +926,9 @@ void destroy_db(void)
 
     /* free any assigned scripts */
     if (SCRIPT(&world[cnt]))
-      extract_script(&world[cnt], WLD_TRIGGER);
+      extract_script(&world[cnt].script);
     /* free script proto list */
-    free_proto_script(&world[cnt], WLD_TRIGGER);
+    free_proto_script(&world[cnt].proto_script);
 
     for (itr = 0; itr < NUM_OF_DIRS; itr++)
     { /* NUM_OF_DIRS here, not DIR_COUNT */
@@ -967,7 +967,7 @@ void destroy_db(void)
       free(obj_proto[cnt].sbinfo);
 
     /* free script proto list */
-    free_proto_script(&obj_proto[cnt], OBJ_TRIGGER);
+    free_proto_script(&obj_proto[cnt].proto_script);
   }
   free(obj_proto);
   free(obj_index);
@@ -991,7 +991,7 @@ void destroy_db(void)
       free(mob_proto[cnt].player.walkout);
 
     /* free script proto list */
-    free_proto_script(&mob_proto[cnt], MOB_TRIGGER);
+    free_proto_script(&mob_proto[cnt].proto_script);
 
     while (mob_proto[cnt].affected)
       affect_remove(&mob_proto[cnt], mob_proto[cnt].affected);
@@ -4669,8 +4669,8 @@ struct char_data *read_mobile(mob_vnum nr, int type) /* and mob_rnum */
 
   GET_ID(mob) = 0;
 
-  copy_proto_script(&mob_proto[i], mob, MOB_TRIGGER);
-  assign_triggers(mob, MOB_TRIGGER);
+  copy_proto_script(mob_proto[i].proto_script, &mob->proto_script);
+  assign_mob_triggers(mob);
 
   if (GET_RACE(mob) < 0 || GET_RACE(mob) >= NUM_RACE_TYPES)
     GET_REAL_RACE(mob) = 0;
@@ -4893,8 +4893,8 @@ struct obj_data *read_object(obj_vnum nr, int type) /* and obj_rnum */
     SET_BIT_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_INSTRUMENT);
   }
 
-  copy_proto_script(&obj_proto[i], obj, OBJ_TRIGGER);
-  assign_triggers(obj, OBJ_TRIGGER);
+  copy_proto_script(obj_proto[i].proto_script, &obj->proto_script);
+  assign_obj_triggers(obj);
 
   if (OBJ_FLAGGED(obj, ITEM_SET_STATS_AT_LOAD))
   {
@@ -6483,7 +6483,7 @@ void free_char(struct char_data *ch)
       free(ch->bags);
 
     /* free script proto list */
-    free_proto_script(ch, MOB_TRIGGER);
+    free_proto_script(&ch->proto_script);
   }
   else if ((i = GET_MOB_RNUM(ch)) != (int)NOBODY)
   {
@@ -6504,7 +6504,7 @@ void free_char(struct char_data *ch)
       free(ch->player.walkout);
     /* free script proto list if it's not the prototype */
     if (ch->proto_script && ch->proto_script != mob_proto[i].proto_script)
-      free_proto_script(ch, MOB_TRIGGER);
+      free_proto_script(&ch->proto_script);
     if (ch == &mob_proto[i])
     {
       free_hlquest(ch);
@@ -6541,7 +6541,7 @@ void free_char(struct char_data *ch)
 
   /* free any assigned scripts */
   if (SCRIPT(ch))
-    extract_script(ch, MOB_TRIGGER);
+    extract_script(&ch->script);
 
   /* Mud Events */
   if (ch->events != NULL)
@@ -6610,18 +6610,18 @@ void free_obj(struct obj_data *obj)
   {
     free_object_strings(obj);
     /* free script proto list */
-    free_proto_script(obj, OBJ_TRIGGER);
+    free_proto_script(&obj->proto_script);
   }
   else
   {
     free_object_strings_proto(obj);
     if (obj->proto_script != obj_proto[GET_OBJ_RNUM(obj)].proto_script)
-      free_proto_script(obj, OBJ_TRIGGER);
+      free_proto_script(&obj->proto_script);
   }
 
   /* free any assigned scripts */
   if (SCRIPT(obj))
-    extract_script(obj, OBJ_TRIGGER);
+    extract_script(&obj->script);
 
   /* free special abilities list */
   if (obj->special_abilities)

--- a/src/dgscript/dg_db_scripts.c
+++ b/src/dgscript/dg_db_scripts.c
@@ -305,98 +305,59 @@ void dg_obj_trigger(char *line, struct obj_data *obj, int obj_vnum)
   }
 }
 
-void assign_triggers(void *i, int type)
+static void assign_trigger_list(struct trig_proto_list *trg_proto, struct script_data **script,
+                                const char *owner_type, int owner_vnum, const char *editor,
+                                const char *script_menu)
 {
-  struct char_data *mob = NULL;
-  struct obj_data *obj = NULL;
-  struct room_data *room = NULL;
   trig_rnum rnum;
-  struct trig_proto_list *trg_proto;
 
-  switch (type)
+  while (trg_proto)
   {
-  case MOB_TRIGGER:
-    mob = (char_data *)i;
-    trg_proto = mob->proto_script;
-    while (trg_proto)
+    rnum = real_trigger(trg_proto->vnum);
+    if (rnum == NOTHING)
     {
-      rnum = real_trigger(trg_proto->vnum);
-      if (rnum == NOTHING)
-      {
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER ERROR: Mobile #%d has non-existent trigger #%d assigned!",
-               mob_index[mob->nr].vnum, trg_proto->vnum);
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER FIX: Create trigger with 'trigedit %d' OR remove from 'medit %d'",
-               trg_proto->vnum, mob_index[mob->nr].vnum);
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER HELP: Use 'tlist' to see triggers, 'attach' in medit to manage");
-      }
-      else
-      {
-        if (!SCRIPT(mob))
-          CREATE(SCRIPT(mob), struct script_data, 1);
-        add_trigger(SCRIPT(mob), read_trigger(rnum), -1);
-      }
-      trg_proto = trg_proto->next;
+      mudlog(BRF, LVL_BUILDER, TRUE, "TRIGGER ERROR: %s #%d has non-existent trigger #%d assigned!",
+             owner_type, owner_vnum, trg_proto->vnum);
+      mudlog(BRF, LVL_BUILDER, TRUE,
+             "TRIGGER FIX: Create trigger with 'trigedit %d' OR remove from '%s %d'",
+             trg_proto->vnum, editor, owner_vnum);
+      mudlog(BRF, LVL_BUILDER, TRUE,
+             "TRIGGER HELP: Use 'tlist' to see triggers, '%s' in %s to manage", script_menu,
+             editor);
     }
-    break;
-  case OBJ_TRIGGER:
-    obj = (obj_data *)i;
-    trg_proto = obj->proto_script;
-    while (trg_proto)
+    else
     {
-      rnum = real_trigger(trg_proto->vnum);
-      if (rnum == NOTHING)
-      {
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER ERROR: Object #%d has non-existent trigger #%d assigned!",
-               obj_index[obj->item_number].vnum, trg_proto->vnum);
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER FIX: Create trigger with 'trigedit %d' OR remove from 'oedit %d'",
-               trg_proto->vnum, obj_index[obj->item_number].vnum);
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER HELP: Use 'tlist' to see triggers, 'scripts' in oedit to manage");
-      }
-      else
-      {
-        if (!SCRIPT(obj))
-          CREATE(SCRIPT(obj), struct script_data, 1);
-        add_trigger(SCRIPT(obj), read_trigger(rnum), -1);
-      }
-      trg_proto = trg_proto->next;
+      if (!*script)
+        CREATE(*script, struct script_data, 1);
+      add_trigger(*script, read_trigger(rnum), -1);
     }
-    break;
-  case WLD_TRIGGER:
-    room = (struct room_data *)i;
-    trg_proto = room->proto_script;
-    while (trg_proto)
-    {
-      rnum = real_trigger(trg_proto->vnum);
-      if (rnum == NOTHING)
-      {
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER ERROR: Room #%d has non-existent trigger #%d assigned!", room->number,
-               trg_proto->vnum);
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER FIX: Create trigger with 'trigedit %d' OR remove from 'redit %d'",
-               trg_proto->vnum, room->number);
-        mudlog(BRF, LVL_BUILDER, TRUE,
-               "TRIGGER HELP: Use 'tlist' to see triggers, 'scripts' in redit to manage");
-      }
-      else
-      {
-        if (!SCRIPT(room))
-          CREATE(SCRIPT(room), struct script_data, 1);
-        add_trigger(SCRIPT(room), read_trigger(rnum), -1);
-      }
-      trg_proto = trg_proto->next;
-    }
-    break;
-  default:
-    mudlog(BRF, LVL_BUILDER, TRUE,
-           "TRIGGER ERROR: Unknown type passed to assign_triggers() function!");
-    mudlog(BRF, LVL_BUILDER, TRUE, "TRIGGER FIX: This is a code bug - report to developers");
-    break;
+
+    trg_proto = trg_proto->next;
   }
+}
+
+void assign_mob_triggers(struct char_data *mob)
+{
+  if (!mob)
+    return;
+
+  assign_trigger_list(mob->proto_script, &mob->script, "Mobile", mob_index[mob->nr].vnum, "medit",
+                      "attach");
+}
+
+void assign_obj_triggers(struct obj_data *obj)
+{
+  if (!obj)
+    return;
+
+  assign_trigger_list(obj->proto_script, &obj->script, "Object", obj_index[obj->item_number].vnum,
+                      "oedit", "scripts");
+}
+
+void assign_room_triggers(struct room_data *room)
+{
+  if (!room)
+    return;
+
+  assign_trigger_list(room->proto_script, &room->script, "Room", room->number, "redit", "scripts");
 }

--- a/src/dgscript/dg_handler.c
+++ b/src/dgscript/dg_handler.c
@@ -146,33 +146,17 @@ void extract_trigger(struct trig_data *trig)
   free_trigger(trig);
 }
 
-/* remove all triggers from a mob/obj/room */
-void extract_script(void *thing, int type)
+/* Remove and free all triggers referenced by a script field. */
+void extract_script(struct script_data **script)
 {
-  struct script_data *sc = NULL;
+  struct script_data *sc;
   struct trig_data *trig = NULL, *next_trig = NULL;
-  char_data *mob = NULL;
-  obj_data *obj = NULL;
-  room_data *room = NULL;
 
-  switch (type)
-  {
-  case MOB_TRIGGER:
-    mob = (struct char_data *)thing;
-    sc = SCRIPT(mob);
-    SCRIPT(mob) = NULL;
-    break;
-  case OBJ_TRIGGER:
-    obj = (struct obj_data *)thing;
-    sc = SCRIPT(obj);
-    SCRIPT(obj) = NULL;
-    break;
-  case WLD_TRIGGER:
-    room = (struct room_data *)thing;
-    sc = SCRIPT(room);
-    SCRIPT(room) = NULL;
-    break;
-  }
+  if (!script || !*script)
+    return;
+
+  sc = *script;
+  *script = NULL;
 
   /* zusuk disabled this debug 10/15/2017 */
 #if 0 /* debugging */
@@ -220,31 +204,15 @@ void extract_script_mem(struct script_memory *sc)
   }
 }
 
-void free_proto_script(void *thing, int type)
+void free_proto_script(struct trig_proto_list **proto_script)
 {
-  struct trig_proto_list *proto = NULL, *fproto = NULL;
-  char_data *mob = NULL;
-  obj_data *obj = NULL;
-  room_data *room = NULL;
+  struct trig_proto_list *proto, *fproto = NULL;
 
-  switch (type)
-  {
-  case MOB_TRIGGER:
-    mob = (struct char_data *)thing;
-    proto = mob->proto_script;
-    mob->proto_script = NULL;
-    break;
-  case OBJ_TRIGGER:
-    obj = (struct obj_data *)thing;
-    proto = obj->proto_script;
-    obj->proto_script = NULL;
-    break;
-  case WLD_TRIGGER:
-    room = (struct room_data *)thing;
-    proto = room->proto_script;
-    room->proto_script = NULL;
-    break;
-  }
+  if (!proto_script)
+    return;
+
+  proto = *proto_script;
+  *proto_script = NULL;
 
 /* zusuk disabled this debug 10/15/2017 */
 #if 0 /* debugging */
@@ -273,38 +241,15 @@ void free_proto_script(void *thing, int type)
   }
 }
 
-void copy_proto_script(void *source, void *dest, int type)
+void copy_proto_script(const struct trig_proto_list *source, struct trig_proto_list **destination)
 {
-  struct trig_proto_list *tp_src = NULL, *tp_dst = NULL;
+  const struct trig_proto_list *tp_src = source;
+  struct trig_proto_list *tp_dst = NULL;
 
-  switch (type)
-  {
-  case MOB_TRIGGER:
-    tp_src = ((char_data *)source)->proto_script;
-    break;
-  case OBJ_TRIGGER:
-    tp_src = ((obj_data *)source)->proto_script;
-    break;
-  case WLD_TRIGGER:
-    tp_src = ((room_data *)source)->proto_script;
-    break;
-  }
-
-  if (tp_src)
+  if (tp_src && destination)
   {
     CREATE(tp_dst, struct trig_proto_list, 1);
-    switch (type)
-    {
-    case MOB_TRIGGER:
-      ((char_data *)dest)->proto_script = tp_dst;
-      break;
-    case OBJ_TRIGGER:
-      ((obj_data *)dest)->proto_script = tp_dst;
-      break;
-    case WLD_TRIGGER:
-      ((room_data *)dest)->proto_script = tp_dst;
-      break;
-    }
+    *destination = tp_dst;
 
     while (tp_src)
     {

--- a/src/dgscript/dg_scripts.c
+++ b/src/dgscript/dg_scripts.c
@@ -1278,7 +1278,7 @@ ACMD(do_detach)
       send_to_char(ch, "This room does not have any triggers.\r\n");
     else if (!str_cmp(arg2, "all"))
     {
-      extract_script(room, WLD_TRIGGER);
+      extract_script(&room->script);
       send_to_char(ch, "All triggers removed from room.\r\n");
     }
     else if (remove_trigger(SCRIPT(room), arg2))
@@ -1286,7 +1286,7 @@ ACMD(do_detach)
       send_to_char(ch, "Trigger removed.\r\n");
       if (!TRIGGERS(SCRIPT(room)))
       {
-        extract_script(room, WLD_TRIGGER);
+        extract_script(&room->script);
       }
     }
     else
@@ -1382,7 +1382,7 @@ ACMD(do_detach)
       }
       else if (trigger && !str_cmp(trigger, "all"))
       {
-        extract_script(victim, MOB_TRIGGER);
+        extract_script(&victim->script);
         send_to_char(ch, "All triggers removed from %s.\r\n",
                      IS_NPC(victim) ? GET_SHORT(victim) : GET_NAME(victim));
       }
@@ -1391,7 +1391,7 @@ ACMD(do_detach)
         send_to_char(ch, "Trigger removed.\r\n");
         if (!TRIGGERS(SCRIPT(victim)))
         {
-          extract_script(victim, MOB_TRIGGER);
+          extract_script(&victim->script);
         }
       }
       else
@@ -1409,7 +1409,7 @@ ACMD(do_detach)
       }
       else if (trigger && !str_cmp(trigger, "all"))
       {
-        extract_script(object, OBJ_TRIGGER);
+        extract_script(&object->script);
         send_to_char(ch, "All triggers removed from %s.\r\n",
                      object->short_description ? object->short_description : object->name);
       }
@@ -1418,7 +1418,7 @@ ACMD(do_detach)
         send_to_char(ch, "Trigger removed.\r\n");
         if (!TRIGGERS(SCRIPT(object)))
         {
-          extract_script(object, OBJ_TRIGGER);
+          extract_script(&object->script);
         }
       }
       else
@@ -2080,7 +2080,7 @@ static void process_detach(void *go, struct script_data *sc, trig_data *trig, in
       {
         dg_owner_purged = 1;
       }
-      extract_script(c, MOB_TRIGGER);
+      extract_script(&c->script);
       return;
     }
     if (remove_trigger(SCRIPT(c), trignum_s))
@@ -2091,7 +2091,7 @@ static void process_detach(void *go, struct script_data *sc, trig_data *trig, in
         {
           dg_owner_purged = 1;
         }
-        extract_script(c, MOB_TRIGGER);
+        extract_script(&c->script);
       }
     }
     return;
@@ -2111,7 +2111,7 @@ static void process_detach(void *go, struct script_data *sc, trig_data *trig, in
       {
         dg_owner_purged = 1;
       }
-      extract_script(o, OBJ_TRIGGER);
+      extract_script(&o->script);
       return;
     }
     if (remove_trigger(SCRIPT(o), trignum_s))
@@ -2122,7 +2122,7 @@ static void process_detach(void *go, struct script_data *sc, trig_data *trig, in
         {
           dg_owner_purged = 1;
         }
-        extract_script(o, OBJ_TRIGGER);
+        extract_script(&o->script);
       }
     }
     return;
@@ -2142,7 +2142,7 @@ static void process_detach(void *go, struct script_data *sc, trig_data *trig, in
       {
         dg_owner_purged = 1;
       }
-      extract_script(r, WLD_TRIGGER);
+      extract_script(&r->script);
       return;
     }
     if (remove_trigger(SCRIPT(r), trignum_s))
@@ -2153,7 +2153,7 @@ static void process_detach(void *go, struct script_data *sc, trig_data *trig, in
         {
           dg_owner_purged = 1;
         }
-        extract_script(r, WLD_TRIGGER);
+        extract_script(&r->script);
       }
     }
     return;
@@ -2764,6 +2764,7 @@ int script_driver(struct script_call_args *args)
   struct cmdlist_element *cl = NULL;
   char cmd[MAX_INPUT_LENGTH] = {'\0'}, *p = NULL;
   struct script_data *sc = NULL;
+  struct script_data **owner_script = NULL;
   struct cmdlist_element *temp = NULL;
   void *go = NULL;
 
@@ -3013,15 +3014,18 @@ int script_driver(struct script_call_args *args)
   {
   case MOB_TRIGGER:
     go = *(char_data **)go_adress;
-    sc = SCRIPT((char_data *)go);
+    owner_script = &SCRIPT((char_data *)go);
+    sc = *owner_script;
     break;
   case OBJ_TRIGGER:
     go = *(obj_data **)go_adress;
-    sc = SCRIPT((obj_data *)go);
+    owner_script = &SCRIPT((obj_data *)go);
+    sc = *owner_script;
     break;
   case WLD_TRIGGER:
     go = *(room_data **)go_adress;
-    sc = SCRIPT((room_data *)go);
+    owner_script = &SCRIPT((room_data *)go);
+    sc = *owner_script;
     break;
   default:
     script_log("FATAL: Invalid type %d after validation for trigger %d", type,
@@ -3079,13 +3083,11 @@ int script_driver(struct script_call_args *args)
       break;
     }
 
-    extract_script(go, type);
+    extract_script(owner_script);
 
-    /* extract_script() works on rooms, but on mobiles and objects, it will be
-     * called again if the caller is load_mtrigger or load_otrigger if it is
-     * one of these, we must make sure the script is not just reloaded on the
-     * next mob. We make the calling code decide how to handle it, so it does
-     * not get totally removed unless it's a load_xtrigger(). */
+    /* On mobiles and objects, load_mtrigger() or load_otrigger() may call this
+     * again. Let the calling code decide whether to remove the prototype so a
+     * load trigger is not silently reattached to the next instance. */
     return SCRIPT_ERROR_CODE;
   }
 
@@ -3298,18 +3300,8 @@ int script_driver(struct script_call_args *args)
     }
   }
 
-  switch (type)
-  { /* the script may have been detached */
-  case MOB_TRIGGER:
-    sc = SCRIPT((char_data *)go);
-    break;
-  case OBJ_TRIGGER:
-    sc = SCRIPT((obj_data *)go);
-    break;
-  case WLD_TRIGGER:
-    sc = SCRIPT((room_data *)go);
-    break;
-  }
+  /* The script may have been detached while the trigger was running. */
+  sc = owner_script ? *owner_script : NULL;
   if (sc)
   {
     free_varlist(GET_TRIG_VARS(trig));

--- a/src/dgscript/dg_scripts.h
+++ b/src/dgscript/dg_scripts.h
@@ -341,7 +341,9 @@ trig_data *read_trigger(int nr);
 void trig_data_copy(trig_data *this_data, const trig_data *trg);
 void dg_read_trigger(FILE *fp, void *proto, int type, int proto_vnum);
 void dg_obj_trigger(char *line, struct obj_data *obj, int obj_vnum);
-void assign_triggers(void *i, int type);
+void assign_mob_triggers(struct char_data *mob);
+void assign_obj_triggers(struct obj_data *obj);
+void assign_room_triggers(struct room_data *room);
 
 /* From dg_variables.c */
 void add_var(struct trig_var_data **var_list, const char *name, const char *value, long id);
@@ -360,10 +362,10 @@ void free_context_vars(struct script_data *sc, long context);
 int remove_var(struct trig_var_data **var_list, char *name);
 void free_trigger(trig_data *trig);
 void extract_trigger(struct trig_data *trig);
-void extract_script(void *thing, int type);
+void extract_script(struct script_data **script);
 void extract_script_mem(struct script_memory *sc);
-void free_proto_script(void *thing, int type);
-void copy_proto_script(void *source, void *dest, int type);
+void free_proto_script(struct trig_proto_list **proto_script);
+void copy_proto_script(const struct trig_proto_list *source, struct trig_proto_list **destination);
 void delete_variables(const char *charname);
 void update_wait_events(struct room_data *to, struct room_data *from);
 

--- a/src/dgscript/dg_triggers.c
+++ b/src/dgscript/dg_triggers.c
@@ -668,7 +668,7 @@ void load_mtrigger(char_data *ch)
     /* make sure this mob is the last one in the load chain */
     if (GET_MOB_RNUM(ch) != NOBODY)
     {
-      free_proto_script(&mob_proto[GET_MOB_RNUM(ch)], MOB_TRIGGER);
+      free_proto_script(&mob_proto[GET_MOB_RNUM(ch)].proto_script);
     }
   }
 }
@@ -1199,7 +1199,7 @@ void load_otrigger(obj_data *obj)
     /* make sure this mob is the last one in the load chain */
     if (GET_OBJ_RNUM(obj) != NOTHING)
     {
-      free_proto_script(&obj_proto[GET_OBJ_RNUM(obj)], OBJ_TRIGGER);
+      free_proto_script(&obj_proto[GET_OBJ_RNUM(obj)].proto_script);
     }
   }
 }

--- a/src/handler.c
+++ b/src/handler.c
@@ -2567,7 +2567,7 @@ void extract_obj(struct obj_data *obj)
   }
 
   if (SCRIPT(obj))
-    extract_script(obj, OBJ_TRIGGER);
+    extract_script(&obj->script);
 
   if (obj->events != NULL)
   {
@@ -2590,7 +2590,7 @@ void extract_obj(struct obj_data *obj)
 
   if (GET_OBJ_RNUM(obj) == NOTHING ||
       obj->proto_script != obj_proto[GET_OBJ_RNUM(obj)].proto_script)
-    free_proto_script(obj, OBJ_TRIGGER);
+    free_proto_script(&obj->proto_script);
 
   free_obj(obj);
 }
@@ -2790,7 +2790,7 @@ void extract_char_final(struct char_data *ch)
     clearMemory(ch);
 
     if (SCRIPT(ch))
-      extract_script(ch, MOB_TRIGGER);
+      extract_script(&ch->script);
 
     if (SCRIPT_MEM(ch))
       extract_script_mem(SCRIPT_MEM(ch));

--- a/src/olc/genmob.c
+++ b/src/olc/genmob.c
@@ -158,7 +158,7 @@ static void extract_mobile_all(mob_vnum vnum)
 
         /* free script proto list if it's not the prototype */
         if (ch->proto_script && ch->proto_script != mob_proto[i].proto_script)
-          free_proto_script(ch, MOB_TRIGGER);
+          free_proto_script(&ch->proto_script);
         ch->proto_script = NULL;
       }
       extract_char(ch);
@@ -332,7 +332,7 @@ int free_mobile(struct char_data *mob)
   {
     free_mobile_strings(mob);
     /* free script proto list */
-    free_proto_script(mob, MOB_TRIGGER);
+    free_proto_script(&mob->proto_script);
   }
   else
   { /* Prototyped mobile. */
@@ -352,7 +352,7 @@ int free_mobile(struct char_data *mob)
       free(mob->player.walkout);
     /* free script proto list if it's not the prototype */
     if (mob->proto_script && mob->proto_script != mob_proto[i].proto_script)
-      free_proto_script(mob, MOB_TRIGGER);
+      free_proto_script(&mob->proto_script);
     if (mob->mob_specials.echo_entries &&
         mob->mob_specials.echo_entries != mob_proto[i].mob_specials.echo_entries)
     {
@@ -366,7 +366,7 @@ int free_mobile(struct char_data *mob)
 
   /* free any assigned scripts */
   if (SCRIPT(mob))
-    extract_script(mob, MOB_TRIGGER);
+    extract_script(&mob->script);
 
   /* Free the action queues */
   if (GET_QUEUE(mob))

--- a/src/olc/genwld.c
+++ b/src/olc/genwld.c
@@ -36,7 +36,7 @@ static room_rnum add_room_internal(struct room_data *room, bool persistent)
   if ((i = real_room(room->number)) != NOWHERE)
   {
     if (SCRIPT(&world[i]))
-      extract_script(&world[i], WLD_TRIGGER);
+      extract_script(&world[i].script);
     tch = world[i].people;
     tobj = world[i].contents;
     copy_room(&world[i], room);
@@ -209,8 +209,8 @@ static int delete_room_internal(room_rnum rnum, bool persistent)
 
   free_room_strings(room);
   if (SCRIPT(room))
-    extract_script(room, WLD_TRIGGER);
-  free_proto_script(room, WLD_TRIGGER);
+    extract_script(&room->script);
+  free_proto_script(&room->proto_script);
 
   clear_room_event_list(room);
 

--- a/src/olc/medit.c
+++ b/src/olc/medit.c
@@ -420,7 +420,7 @@ void medit_save_internally(struct descriptor_data *d)
 
   /* Update triggers and free old proto list */
   if (mob_proto[new_rnum].proto_script && mob_proto[new_rnum].proto_script != OLC_SCRIPT(d))
-    free_proto_script(&mob_proto[new_rnum], MOB_TRIGGER);
+    free_proto_script(&mob_proto[new_rnum].proto_script);
 
   mob_proto[new_rnum].proto_script = OLC_SCRIPT(d);
 
@@ -432,11 +432,11 @@ void medit_save_internally(struct descriptor_data *d)
 
     /* remove any old scripts */
     if (SCRIPT(mob))
-      extract_script(mob, MOB_TRIGGER);
+      extract_script(&mob->script);
 
-    free_proto_script(mob, MOB_TRIGGER);
-    copy_proto_script(&mob_proto[new_rnum], mob, MOB_TRIGGER);
-    assign_triggers(mob, MOB_TRIGGER);
+    free_proto_script(&mob->proto_script);
+    copy_proto_script(mob_proto[new_rnum].proto_script, &mob->proto_script);
+    assign_mob_triggers(mob);
   }
   /* end trigger update */
 

--- a/src/olc/oasis.c
+++ b/src/olc/oasis.c
@@ -98,7 +98,7 @@ void cleanup_olc(struct descriptor_data *d, byte cleanup_type)
     {
     case CLEANUP_ALL:
       /* free(OLC_SCRIPT(d)) equivalent */
-      free_proto_script(OLC_ROOM(d), WLD_TRIGGER);
+      free_proto_script(&OLC_ROOM(d)->proto_script);
       free_room(OLC_ROOM(d));
       break;
     case CLEANUP_STRUCTS:

--- a/src/olc/oedit.c
+++ b/src/olc/oedit.c
@@ -284,7 +284,7 @@ void oedit_save_internally(struct descriptor_data *d)
 
   /* Update triggers and free old proto list  */
   if (obj_proto[robj_num].proto_script && obj_proto[robj_num].proto_script != OLC_SCRIPT(d))
-    free_proto_script(&obj_proto[robj_num], OBJ_TRIGGER);
+    free_proto_script(&obj_proto[robj_num].proto_script);
   /* this will handle new instances of the object: */
   obj_proto[robj_num].proto_script = OLC_SCRIPT(d);
 
@@ -295,11 +295,11 @@ void oedit_save_internally(struct descriptor_data *d)
       continue;
     /* remove any old scripts */
     if (SCRIPT(obj))
-      extract_script(obj, OBJ_TRIGGER);
+      extract_script(&obj->script);
 
-    free_proto_script(obj, OBJ_TRIGGER);
-    copy_proto_script(&obj_proto[robj_num], obj, OBJ_TRIGGER);
-    assign_triggers(obj, OBJ_TRIGGER);
+    free_proto_script(&obj->proto_script);
+    copy_proto_script(obj_proto[robj_num].proto_script, &obj->proto_script);
+    assign_obj_triggers(obj);
   }
   /* end trigger update */
 
@@ -2121,7 +2121,7 @@ void oedit_parse(struct descriptor_data *d, char *arg)
     case 'N':
       /* If not saving, we must free the script_proto list. */
       OLC_OBJ(d)->proto_script = OLC_SCRIPT(d);
-      free_proto_script(OLC_OBJ(d), OBJ_TRIGGER);
+      free_proto_script(&OLC_OBJ(d)->proto_script);
       cleanup_olc(d, CLEANUP_ALL);
       return;
     case 'a': /* abort quit */
@@ -2189,18 +2189,18 @@ void oedit_parse(struct descriptor_data *d, char *arg)
 
           if (SCRIPT(obj))
           {
-            extract_script(obj, OBJ_TRIGGER);
+            extract_script(&obj->script);
 
             SCRIPT(obj) = NULL;
           }
 
-          free_proto_script(obj, OBJ_TRIGGER);
+          free_proto_script(&obj->proto_script);
 
           robj = real_object(GET_OBJ_VNUM(obj));
 
-          copy_proto_script(&obj_proto[robj], obj, OBJ_TRIGGER);
+          copy_proto_script(obj_proto[robj].proto_script, &obj->proto_script);
 
-          assign_triggers(obj, OBJ_TRIGGER);
+          assign_obj_triggers(obj);
         }
 
         log("OLC: %s iedit a unique #%d", GET_NAME(d->character), GET_OBJ_VNUM(obj));
@@ -3974,7 +3974,7 @@ void iedit_setup_existing(struct descriptor_data *d, struct obj_data *real_num)
 
   if (SCRIPT(obj))
 
-    extract_script(obj, OBJ_TRIGGER);
+    extract_script(&obj->script);
 
   SCRIPT(obj) = NULL;
 

--- a/src/olc/redit.c
+++ b/src/olc/redit.c
@@ -312,10 +312,10 @@ void redit_save_internally(struct descriptor_data *d)
 
   /* Update triggers and free old proto list */
   if (world[room_num].proto_script && world[room_num].proto_script != OLC_SCRIPT(d))
-    free_proto_script(&world[room_num], WLD_TRIGGER);
+    free_proto_script(&world[room_num].proto_script);
 
   world[room_num].proto_script = OLC_SCRIPT(d);
-  assign_triggers(&world[room_num], WLD_TRIGGER);
+  assign_room_triggers(&world[room_num]);
   /* end trigger update */
 
   /* Debug: Log trail_tracks pointer after script operations */
@@ -410,8 +410,8 @@ void free_room(struct room_data *room)
   free_room_strings(room);
 
   if (SCRIPT(room))
-    extract_script(room, WLD_TRIGGER);
-  free_proto_script(room, WLD_TRIGGER);
+    extract_script(&room->script);
+  free_proto_script(&room->proto_script);
 
   /* Free trails. */
   if (CONFIG_WILDERNESS_SYSTEM == 2)

--- a/src/utils.c
+++ b/src/utils.c
@@ -3467,6 +3467,39 @@ bool is_safe_path_component(const char *name)
   return TRUE;
 }
 
+/* Validate a library-relative path without allowing traversal or platform-specific separators. */
+bool is_safe_relative_path(const char *path)
+{
+  const unsigned char *component;
+  const unsigned char *current;
+  size_t component_length;
+
+  if (!path || !*path || *path == '/' || *path == '\\' || strlen(path) >= MAX_FILEPATH)
+    return FALSE;
+
+  component = (const unsigned char *)path;
+  for (current = component;; current++)
+  {
+    if (*current == '\0' || *current == '/')
+    {
+      component_length = (size_t)(current - component);
+      if (component_length == 0 || (component_length == 1 && component[0] == '.') ||
+          (component_length == 2 && component[0] == '.' && component[1] == '.'))
+        return FALSE;
+
+      if (*current == '\0')
+        return TRUE;
+
+      component = current + 1;
+      continue;
+    }
+
+    if (*current == '\\' ||
+        (!isalnum(*current) && *current != '.' && *current != '_' && *current != '-'))
+      return FALSE;
+  }
+}
+
 /** Calculate the number of player characters (PCs) in the room. Any NPC (mob)
  * is not returned in the count.
  * @param room The room to check for PCs. */

--- a/src/utils.h
+++ b/src/utils.h
@@ -443,6 +443,7 @@ const char *format_time_ymd_hms(time_t when);
 /* Filesystem helpers */
 /* Validates a single filename component, excluding path separators and traversal. */
 bool is_safe_path_component(const char *name);
+bool is_safe_relative_path(const char *path);
 /* Ensures that a directory path exists, creating intermediate directories as needed. */
 bool ensure_dir_exists(const char *path);
 

--- a/unittests/CuTest/test_bounds_checking.c
+++ b/unittests/CuTest/test_bounds_checking.c
@@ -114,6 +114,13 @@ void Test_path_component_validation(CuTest *tc)
   CuAssertTrue(tc, !is_safe_path_component("zone..obj"));
   CuAssertTrue(tc, get_filename(filename, sizeof(filename), PLR_FILE, "taure_two"));
   CuAssertTrue(tc, !get_filename(filename, sizeof(filename), PLR_FILE, "../../player"));
+  CuAssertTrue(tc, is_safe_relative_path("etc/config"));
+  CuAssertTrue(tc, is_safe_relative_path("config/test-1.cfg"));
+  CuAssertTrue(tc, !is_safe_relative_path("/etc/passwd"));
+  CuAssertTrue(tc, !is_safe_relative_path("../etc/config"));
+  CuAssertTrue(tc, !is_safe_relative_path("etc/../config"));
+  CuAssertTrue(tc, !is_safe_relative_path("etc//config"));
+  CuAssertTrue(tc, !is_safe_relative_path("etc\\config"));
 }
 
 void Test_fopen_restricted_blocks_world_write(CuTest *tc)

--- a/unittests/CuTest/test_dg_scripts_production.c
+++ b/unittests/CuTest/test_dg_scripts_production.c
@@ -43,6 +43,33 @@ void Test_dg_production_variable_lifecycle(CuTest *tc)
   free_varlist(variables);
 }
 
+void Test_dg_production_typed_script_field_lifecycle(CuTest *tc)
+{
+  struct script_data *script = NULL;
+  struct trig_proto_list source_first = {0};
+  struct trig_proto_list source_second = {0};
+  struct trig_proto_list *copy = NULL;
+
+  CREATE(script, struct script_data, 1);
+  add_var(&script->global_vars, "typed_owner", "safe", 0);
+  extract_script(&script);
+  CuAssertPtrEquals(tc, NULL, script);
+
+  source_first.vnum = 101;
+  source_first.next = &source_second;
+  source_second.vnum = 202;
+  copy_proto_script(&source_first, &copy);
+
+  CuAssertPtrNotNull(tc, copy);
+  CuAssertIntEquals(tc, source_first.vnum, copy->vnum);
+  CuAssertPtrNotNull(tc, copy->next);
+  CuAssertIntEquals(tc, source_second.vnum, copy->next->vnum);
+  CuAssertPtrEquals(tc, NULL, copy->next->next);
+
+  free_proto_script(&copy);
+  CuAssertPtrEquals(tc, NULL, copy);
+}
+
 void Test_dg_production_flag_name_matching(CuTest *tc)
 {
   int flags[4];

--- a/unittests/CuTest/test_gameplay_e2e.c
+++ b/unittests/CuTest/test_gameplay_e2e.c
@@ -1180,7 +1180,7 @@ void Test_gameplay_e2e_dg_trigger_parse_and_execute(CuTest *tc)
             break;
           }
         }
-        extract_script(&fixture.rooms[0], WLD_TRIGGER);
+        extract_script(&fixture.rooms[0].script);
       }
     }
   }
@@ -1293,7 +1293,7 @@ void Test_gameplay_e2e_damage_trigger_overrides_damage(CuTest *tc)
             break;
           }
         }
-        extract_script(&fixture.victim, MOB_TRIGGER);
+        extract_script(&fixture.victim.script);
       }
     }
   }
@@ -1396,8 +1396,8 @@ void Test_gameplay_e2e_actual_minimal_world_parse(CuTest *tc)
     for (i = 0; i < room_count; i++)
     {
       if (parsed_world[i].script != NULL)
-        extract_script(&parsed_world[i], WLD_TRIGGER);
-      free_proto_script(&parsed_world[i], WLD_TRIGGER);
+        extract_script(&parsed_world[i].script);
+      free_proto_script(&parsed_world[i].proto_script);
       free_room_strings(&parsed_world[i]);
       if (parsed_world[i].trail_tracks != NULL)
         free_trail_data_list(parsed_world[i].trail_tracks);


### PR DESCRIPTION
## Summary

- Replace DG-script void-pointer and type-tag helpers with typed script fields and typed owner entry points.
- Constrain the -f configuration path to bounded, library-relative components and retain it in owned storage.
- Preserve and document the strict player-name filename allowlist, with traversal regression coverage.

## Validation

- make -j16
- make test: OK (308 tests)
- make install, with no root-level circle artifact left behind
- Independent CMake Debug build
- CodeQL CLI 2.26.2 cpp-security-extended suite: all four reported DG type-confusion paths eliminated
- Runtime smoke test: a traversal configuration path exits with status 1; normal help startup exits cleanly

## Alert handling

After merge and the master CodeQL run, verify the type-confusion alerts close as fixed and dismiss any remaining guarded path findings as false positives, matching their pre-file-move alert history.