### PR TITLE
Complete RoL canonical conversion through Phase 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,6 +945,8 @@ set(WORLD_TOOL_SOURCES
     scripts/world/wtool_lib/rol_persistence_audit.py
     scripts/world/wtool_lib/rol_planner.py
     scripts/world/wtool_lib/rol_rebase.py
+    scripts/world/wtool_lib/rol_phase7.py
+    scripts/world/wtool_lib/rol_phase8.py
     scripts/world/wtool_lib/rol_pilot.py
     scripts/world/wtool_lib/rol_pilot_build.py
     scripts/world/wtool_lib/rol_periodic_profiles.py
@@ -983,6 +985,8 @@ set(WORLD_TOOL_SOURCES
     scripts/world/tests/test_rol_persistence_audit.py
     scripts/world/tests/test_rol_planner.py
     scripts/world/tests/test_rol_rebase.py
+    scripts/world/tests/test_rol_phase7.py
+    scripts/world/tests/test_rol_phase8.py
     scripts/world/tests/test_rol_pilot.py
     scripts/world/tests/test_rol_pilot_build.py
     scripts/world/tests/test_rol_periodic_profiles.py

--- a/Makefile.am
+++ b/Makefile.am
@@ -490,6 +490,8 @@ world_tool_sources = \
 	scripts/world/wtool_lib/rol_persistence_audit.py \
 	scripts/world/wtool_lib/rol_planner.py \
 	scripts/world/wtool_lib/rol_rebase.py \
+	scripts/world/wtool_lib/rol_phase7.py \
+	scripts/world/wtool_lib/rol_phase8.py \
 	scripts/world/wtool_lib/rol_pilot.py \
 	scripts/world/wtool_lib/rol_pilot_build.py \
 	scripts/world/wtool_lib/rol_periodic_profiles.py \
@@ -528,6 +530,8 @@ world_tool_sources = \
 	scripts/world/tests/test_rol_persistence_audit.py \
 	scripts/world/tests/test_rol_planner.py \
 	scripts/world/tests/test_rol_rebase.py \
+	scripts/world/tests/test_rol_phase7.py \
+	scripts/world/tests/test_rol_phase8.py \
 	scripts/world/tests/test_rol_pilot.py \
 	scripts/world/tests/test_rol_pilot_build.py \
 	scripts/world/tests/test_rol_periodic_profiles.py \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## [Unreleased] - August 11, 2026
+## [Unreleased] - August 14, 2026
+
+### Realms of Luminari Phases 7 and 8 completion
+
+#### Added
+
+- Added deterministic 12-batch canonical corpus compilation and sealed milestone,
+  repeat-generation, release, apply, and post-apply completion evidence.
+- Added full-corpus behavior evidence for rooms, mobiles, objects, shops, HLQs, SOC,
+  triggers, resets, attachments, traps, paths, keyed exits, containers, and specials.
+- Added typed composite runtime bindings for all 14 source multi-binding special
+  profiles, plus parser and transform coverage for source-object irregularities.
+
+#### Changed
+
+- Converted all 258 active packages and 71,680 selected records, then applied the
+  1,201-path hash-guarded Phase 8 release to the development world.
+- Fixed failed object-reset dependency propagation so a failed `O` command correctly
+  prevents dependent reset commands from executing.
+- Marked the canonical RoL conversion complete through Phase 8 after 409 world-tool
+  tests, 699 production-linked CuTests, install, syntax boot, bounded database runtime
+  boot, zero converted-zone diagnostic, and zero-write repeat application all passed.
 
 ### Realms of Luminari Phase 6 completion
 

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -449,6 +449,33 @@ The focused protocol harness also has a convenience target:
 make -C unittests/CuTest valgrind-protocol
 ```
 
+## Realms of Luminari Release Validation
+
+The final RoL conversion gate uses the normal full suites plus an isolated copy of the
+complete candidate world:
+
+```sh
+make test-world-tools
+make test
+make install
+python3 scripts/world/wtool.py \
+  --world-root <isolated-lib>/world validate --all --strict
+bin/circle -c -d <isolated-lib>
+timeout --signal=INT 30 bin/circle -d <isolated-lib> <test-port>
+```
+
+The isolated lib root must use a loopback-only test MariaDB database. Never point these
+commands at production. The syntax and bounded runtime logs must show a complete boot;
+the runtime log must enter the game loop, reset the converted corpus, terminate
+normally, and contain no converted-VNUM `SYSERR`, zone error, invalid-reference, or
+missing-reference diagnostic.
+
+`rol-phase8` records the suite, install, syntax, and runtime logs with the static
+structure, reference, reset, quest, shop, SOC, trap, special, path, persistence,
+preservation, and determinism audits. After the accepted overlay is applied to
+development, `rol-phase8-completion` requires an identical validator result and a
+hash-preconditioned repeat-apply no-op.
+
 ## Adding Tests
 
 1. Put the test in `unittests/CuTest/test_*.c`.

--- a/docs/ongoing-projects/README_ongoing-projects.md
+++ b/docs/ongoing-projects/README_ongoing-projects.md
@@ -18,8 +18,8 @@ Statuses below were re-verified against the source tree on 2026-08-14.
 
 | Document | Status | What remains |
 |----------|--------|--------------|
-| [REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md](RoL/REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md) | Phase 6.5 complete; Phase 7 ready | Deliver Phase 7 canonical corpus batches, then Phase 8 integration. |
-| [RoL-Changelog.md](RoL/RoL-Changelog.md) | Current milestone record | Record completed Phase 7 and later milestones; entries through Phase 6 remain in the linked archive. |
+| [REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md](RoL/REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md) | Complete through Phase 8 | No conversion work remains; retain the sealed run identities and acceptance contract until the working plan is archived. |
+| [RoL-Changelog.md](RoL/RoL-Changelog.md) | Complete through Phase 8 | Preserve the Phase 6.5, Phase 7, and Phase 8 evidence; entries through Phase 6 remain in the linked archive. |
 | [REALMS_OF_LUMINARI_WORKNOTES.md](RoL/plan-archive/REALMS_OF_LUMINARI_WORKNOTES.md) | Archived Phase 6.5 handoff | Preserve the completed Phase 6-6.5 run identities, validation state, and Phase 7 continuation notes. |
 | [PHASE4_MANUAL_TESTING.md](RoL/plan-archive/PHASE4_MANUAL_TESTING.md) | Archived Phase 4-6.5 test matrix | Preserve the staged pilot and canonical rebase walkthrough/reset evidence for historical reference. |
 | [PET_SYSTEM_COMPARISON_LUMINARI_CHRONICLES_OF_KRYNN.md](PET_SYSTEM_COMPARISON_LUMINARI_CHRONICLES_OF_KRYNN.md) | Comparison complete; P0 persistence repaired | Luminari now has fail-closed migrations and atomic snapshots. Admission policy, temporary lifetime, stable ownership, and full schema-source unification remain design work; the Chronicles sample is still reference-only. |

--- a/docs/ongoing-projects/RoL/REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md
+++ b/docs/ongoing-projects/RoL/REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md
@@ -1,9 +1,11 @@
 # Realms of Luminari Canonical Conversion Plan
 
-- Status: Phase 6.5 complete; Phase 7 ready to begin
+- Status: Complete through Phase 8
 - Consolidated: 2026-08-13
 - Phase 6.5 completed: 2026-08-14
 - Phase 7 plan streamlined: 2026-08-14
+- Phase 7 completed: 2026-08-14
+- Phase 8 completed: 2026-08-14
 - Source: `EXAMPLE/RealmsOfLuminari/`
 - Target: this development checkout and its current `lib/world/`
 - Production changes: prohibited
@@ -652,7 +654,19 @@ no-clobber, and idempotency gates.
 **Exit:** Section 9.1 passes on the authoritative development target; only then may
 Phase 7 begin.
 
-### 7.3 Phase 7: Lean canonical corpus conversion
+### 7.3 Phase 7: Complete - lean canonical corpus conversion
+
+Phase 7 completed in 12 dependency-complete batches on 2026-08-14. The final sealed
+checkpoint is `lib/rol-conversion/runs/phase7-final-20260814`, run
+`rol-phase7-b12-a20bbc98e3513f98`; the independently generated
+`phase7-final-repeat-20260814` tree is byte-identical. The cumulative ledger accounts
+for all 258 active packages and all 71,680 selected records with terminal actions,
+including 1,228 SOC triggers, 14 multi-binding special profiles, and 160 patched
+records. Source parsing, runtime contracts, reference closure, preservation, and all
+selected-record gates pass with zero staged new active error and zero live target
+write. Milestone checkpoints were sealed after batches 4 and 8 before final closeout.
+
+The execution rules below are retained as the completed Phase 7 record.
 
 Convert all remaining active packages against the applied canonical baseline. A legacy
 identity, canonical collision, or formula exception is a failed Phase 6.5 invariant;
@@ -696,7 +710,25 @@ milestone checks, and Phase 7 closeout, but not Phase 8. Reforecast after three
 representative batches covering straightforward data, cross-package references, and a
 runtime-heavy package. This is a working envelope, not a calendar promise.
 
-### 7.4 Phase 8: Final integration and release evidence
+### 7.4 Phase 8: Complete - final integration and release evidence
+
+Phase 8 completed on the authoritative development target on 2026-08-14. The sealed
+release bundle is `lib/rol-conversion/runs/phase8-release-20260814`, run
+`rol-phase8-release-5992b9c59dd3055e`, with candidate tree
+`39c05c7427b941e715491d129d83b17b73f89c332219ec577ea5bf2dc4662b20`.
+Its hash-guarded plan applied all 1,201 paths and the repeat apply is a zero-write
+no-op. The release reconciles 258 packages and 71,680 records with zero new active
+error, a clean namespace audit, byte-identical repeat generation, and passing
+preservation and runtime contracts.
+
+Full-corpus behavior evidence covers 761 zones, 90,722 rooms, 26,427 mobiles, 22,273
+objects, 1,148 shops, 6,296 HLQs, 3,216 triggers, 115,074 reset commands, 3,432 trigger
+attachments, 77 object traps, and 34 exit traps. The production binary passes 409
+world-tool tests, 699 CuTests, install, syntax boot, and bounded private-MariaDB runtime
+boot with zero converted-zone diagnostic. The post-apply completion audit is
+`lib/rol-conversion/runs/phase8-completion-20260814`.
+
+The integration steps below are retained as the completed Phase 8 record.
 
 Integrate the accepted cumulative Phase 7 output without repeating the namespace rebase
 or legacy persistent-state migration. Split the following work into 6-10 sessions if
@@ -880,13 +912,12 @@ Out of scope:
 Current handoff:
 
 ```text
-consume the sealed Phase 6.5 canonical baseline
--> execute lean Phase 7 dependency batches and milestone checks
--> integrate and apply the accepted cumulative output in Phase 8
--> pass the project Definition of Done
+sealed Phase 6.5 canonical baseline
+-> sealed and byte-identical Phase 7 cumulative corpus
+-> applied Phase 8 development release
+-> reproducible completion evidence and a zero-write repeat apply
 ```
 
-Phase 7 consumes only the canonical Phase 6.5 policy, identity manifest, generated
-profiles, and validated development baseline. Phase 8 preserves that baseline while
-integrating accepted corpus bundles; neither phase may restore legacy identity
-precedence.
+The conversion through Phase 8 is complete. Future maintenance must preserve the
+canonical identity contract, regenerate from the recorded inputs and policy, and may
+not restore legacy identity precedence.

--- a/docs/ongoing-projects/RoL/RoL-Changelog.md
+++ b/docs/ongoing-projects/RoL/RoL-Changelog.md
@@ -9,6 +9,37 @@ requirements and acceptance gates in
 
 ## Unreleased
 
+### 2026-08-14 - Phase 8 final integration complete
+
+- Applied release run `rol-phase8-release-5992b9c59dd3055e` to the development world.
+  Its hash-guarded plan changed all 1,201 expected paths and produced tree
+  `39c05c7427b941e715491d129d83b17b73f89c332219ec577ea5bf2dc4662b20`.
+- Reconciled all 258 active packages and 71,680 records with zero new active error,
+  zero converted-zone runtime diagnostic, clean namespace and action audits, passing
+  preservation/runtime contracts, and byte-identical repeat generation.
+- Added complete behavior evidence for 761 zones, 90,722 rooms, 26,427 mobiles,
+  22,273 objects, 1,148 shops, 6,296 HLQs, 3,216 triggers, 115,074 resets, trigger
+  attachments, traps, paths, containers, keyed exits, specials, and shops.
+- Added typed composite special-procedure bindings for the 14 source multi-binding
+  profiles and removed their conflicting hardwired assignments.
+- Hardened source-object normalization for omitted action descriptions and misplaced
+  extra descriptions, supplied runtime-safe object descriptions, repaired invalid
+  charge maxima, and fixed failed object-reset dependency propagation.
+- Passed 409 world-tool tests, all 699 production-linked CuTests, install, syntax boot,
+  and bounded private-MariaDB runtime boot. Repeat application performs zero writes.
+
+### 2026-08-14 - Phase 7 canonical corpus conversion complete
+
+- Converted the active corpus in 12 dependency-complete batches, with sealed milestone
+  checkpoints after batches 4 and 8.
+- Sealed final run `rol-phase7-b12-a20bbc98e3513f98` for all 258 packages and 71,680
+  records, including 1,228 SOC triggers, 14 composite profiles, and 160 patched
+  records, with terminal actions and resolved required references throughout.
+- Regenerated the final cumulative output independently in
+  `phase7-final-repeat-20260814`; the complete trees are byte-identical.
+- Closed Phase 7 with zero staged new active error, no live target writes, and passing
+  source-parse, runtime-contract, preservation, special-binding, and SOC gates.
+
 ### 2026-08-14 - Phase 6.5 canonical VNUM rebase complete
 
 - Enforced the universal zone `+20000` and entity `+2000000` resolver, including the

--- a/docs/utilities/WORLD_VALIDATOR_CLI.md
+++ b/docs/utilities/WORLD_VALIDATOR_CLI.md
@@ -28,7 +28,7 @@ python3 scripts/world/wtool.py --help
 python3 scripts/world/wtool.py --version
 ```
 
-The current release reports `wtool 0.6.0`.
+The current release reports `wtool 0.8.0`.
 
 The default world root is `lib/world`. Override it for a staging tree or
 fixture with the global `--world-root` option. Global options precede the
@@ -399,6 +399,68 @@ package incoming/outgoing reference reports, classified non-world numeric matche
 runtime structural evidence, a documentation audit, parsed final gates, and a matrix
 covering every archived deliverable, session task, exit gate, and canonical acceptance
 criterion.
+
+## Realms of Luminari Phase 7 and Phase 8
+
+Generate cumulative Phase 7 milestones after batches 4, 8, and 12. Each invocation
+regenerates from the sealed Phase 6.5 development baseline; it does not modify that
+baseline.
+
+```sh
+python3 scripts/world/wtool.py --world-root lib/world rol-phase7 \
+  --discovery-dir <phase1-directory> \
+  --plan-dir <phase2-directory> \
+  --capability-audit-dir <phase5-directory> \
+  --phase6-dir <phase6-directory> \
+  --completion-dir <phase6.5-completion-directory> \
+  --through-batch 12 \
+  --prior-milestone-dir <batch4-directory> \
+  --prior-milestone-dir <batch8-directory> \
+  --output-dir <phase7-final-directory>
+```
+
+The command freezes the input trees, derives dependency-complete package batches,
+converts every selected record, compiles SOC and special behavior, patches preserved
+canonical records, validates the full assembled world, and records preservation and
+runtime-contract evidence. The final milestone requires 258 packages, 71,680 record
+actions, no new normalized active error, and a byte-identical independent repeat.
+
+After the code suites, install, isolated syntax boot, and bounded runtime boot pass,
+assemble the Phase 8 release candidate:
+
+```sh
+python3 scripts/world/wtool.py --world-root lib/world rol-phase8 \
+  --phase7-dir <phase7-final-directory> \
+  --repeat-phase7-dir <phase7-repeat-directory> \
+  --completion-dir <phase6.5-completion-directory> \
+  --world-tools-log <world-tools-log> \
+  --cutest-log <cutest-log> \
+  --install-log <install-log> \
+  --syntax-log <syntax-log> \
+  --runtime-log <runtime-log> \
+  --output-dir <phase8-release-directory>
+```
+
+`rol-phase8` reproduces the complete candidate from the frozen baseline and Phase 7
+overlay, reconciles counts and actions, audits selected records, exercises static
+behavior coverage, verifies the namespace and persistence handoff, and emits a
+hash-preconditioned apply plan. Apply and seal it only in development:
+
+```sh
+python3 scripts/world/wtool.py --json rol-phase8-apply \
+  --bundle-dir <phase8-release-directory> \
+  --lib-root lib
+
+python3 scripts/world/wtool.py --json rol-phase8-completion \
+  --bundle-dir <phase8-release-directory> \
+  --lib-root lib \
+  --output-dir <phase8-completion-directory>
+```
+
+The apply command rejects production, changed inputs, changed runtime binaries, and
+modified bundle artifacts. Reapplication is a verified no-op. The completion command
+requires the development tree and post-apply diagnostics to match the accepted
+candidate, rechecks documentation, and records the no-op reapplication.
 
 ## Validation Modes
 

--- a/scripts/world/tests/test_constants.py
+++ b/scripts/world/tests/test_constants.py
@@ -212,7 +212,7 @@ class ConstantsTests(unittest.TestCase):
 class SpecRegistryTests(unittest.TestCase):
   def test_current_registry_exposes_canonical_and_alias_names(self) -> None:
     names = extract_spec_names(default_repo_root())
-    self.assertEqual(118, len(names))
+    self.assertEqual(120, len(names))
     self.assertIn("bank", names)
     self.assertIn("guild", names)
     self.assertIn("guildmaster", names)
@@ -223,6 +223,8 @@ class SpecRegistryTests(unittest.TestCase):
     self.assertIn("rol darkhold object", names)
     self.assertIn("rol death's head", names)
     self.assertIn("rol drow equipment", names)
+    self.assertIn("rol composite mobile", names)
+    self.assertIn("rol composite object", names)
     self.assertIn("rol travel portal", names)
     self.assertIn("rol monster combat", names)
     self.assertIn("rol lich rite", names)

--- a/scripts/world/tests/test_rol_phase7.py
+++ b/scripts/world/tests/test_rol_phase7.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from wtool_lib.rol_phase7 import (
+    _bound_trigger_text,
+    _ensure_index_entry,
+    _filter_zone_door_resets,
+    _merge_hlquest_blocks,
+    _patch_record_block,
+    _validation_delta,
+)
+
+
+class RolPhase7Tests(unittest.TestCase):
+  def test_hlquest_merge_keeps_one_host_and_deduplicates_exact_bodies(self) -> None:
+    first = "#2000100\nA!\nhello~\nworld~\n"
+    second = "#2000100\nQ!\ndone~\nS\n"
+
+    merged = _merge_hlquest_blocks(
+        [
+            (2_000_100, first, "first"),
+            (2_000_100, first, "duplicate"),
+            (2_000_100, second, "second"),
+        ]
+    )
+
+    self.assertEqual(1, merged.count("#2000100\n"))
+    self.assertEqual(1, merged.count("A!\n"))
+    self.assertEqual(1, merged.count("Q!\n"))
+
+  def test_mobile_patch_places_spec_proc_inside_enhanced_section(self) -> None:
+    source = (
+        "#2000100\nmobile~\na mobile~\nA mobile is here.~\nA mobile.~\n"
+        "0 0 0 0 0 0 0 0 0 E\n1 0 0 1d1+0 1d1+0\n0 0\n9 9 0\n"
+        "Class: 0\nRace: 0\nE\n"
+    )
+
+    patched = _patch_record_block(
+        "mob", 2_000_100, source, "RoL Composite Mobile", (2_026_167,), (), ()
+    )
+
+    self.assertLess(patched.index("SpecProc:"), patched.rindex("\nE\n"))
+    self.assertGreater(patched.index("T 2026167"), patched.rindex("\nE\n"))
+
+  def test_door_filter_excludes_only_known_absent_directions(self) -> None:
+    source = "D 0 2000100 1 1\nD 0 2000100 2 1\nD 0 2999999 4 1\n"
+
+    filtered, diagnostics = _filter_zone_door_resets(source, {2_000_100: {1}})
+
+    self.assertIn("2000100 1", filtered)
+    self.assertNotIn("2000100 2", filtered)
+    self.assertIn("2999999 4", filtered)
+    self.assertEqual(1, len(diagnostics))
+
+  def test_trigger_echo_lines_are_bounded_without_dropping_text(self) -> None:
+    payload = "word " * 180
+    source = f"  mecho {payload}\n"
+
+    bounded, diagnostics = _bound_trigger_text(2_026_167, source)
+
+    self.assertTrue(all(len(line.encode("ascii")) <= 480 for line in bounded.splitlines()))
+    self.assertGreater(bounded.count("mecho "), 1)
+    self.assertEqual(1, len(diagnostics))
+
+  def test_validation_delta_treats_same_record_reclassification_as_inherited(self) -> None:
+    baseline = {
+        "findings": [
+            {
+                "severity": "error",
+                "code": "REF022",
+                "message": "missing object",
+                "path": "wld/1.wld",
+                "record_type": "room",
+                "vnum": 100,
+            }
+        ]
+    }
+    staged = {
+        "findings": [
+            {
+                "severity": "error",
+                "code": "REF023",
+                "message": "wrong typed object",
+                "path": "wld/1.wld",
+                "record_type": "room",
+                "vnum": 100,
+            }
+        ]
+    }
+
+    delta = _validation_delta(baseline, staged)
+
+    self.assertEqual(0, delta["new_active_errors"])
+    self.assertEqual([], delta["new_findings"])
+
+  def test_index_updates_are_numeric_and_idempotent(self) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+      path = Path(temporary) / "index"
+      path.write_text("12157521.wld\n10.wld\n$\n", encoding="ascii")
+
+      self.assertTrue(_ensure_index_entry(path, "20000.wld"))
+      self.assertFalse(_ensure_index_entry(path, "20000.wld"))
+      self.assertEqual(
+          ["10.wld", "20000.wld", "12157521.wld", "$"],
+          path.read_text(encoding="ascii").splitlines(),
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/world/tests/test_rol_phase8.py
+++ b/scripts/world/tests/test_rol_phase8.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+import unittest
+
+from wtool_lib.rol_phase8 import _action_audit, _line_format_audit
+
+
+class RolPhase8Tests(unittest.TestCase):
+  def test_action_audit_accepts_clean_canonical_targets(self) -> None:
+    actions = [
+        {
+            "source_record_id": f"room:{index}",
+            "source_kind": "wld",
+            "destination_vnum": 2_000_000 + index,
+            "final_action": "ADD",
+        }
+        for index in range(71_680)
+    ]
+
+    audit = _action_audit(actions, {"findings": []})
+
+    self.assertTrue(audit["pass"])
+    self.assertEqual(71_680, audit["rows"])
+    self.assertEqual(71_680, audit["selected_target_records"])
+
+  def test_action_audit_rejects_blocking_selected_record_error(self) -> None:
+    actions = [
+        {
+            "source_record_id": f"room:{index}",
+            "source_kind": "wld",
+            "destination_vnum": 2_000_000 + index,
+            "final_action": "ADD",
+        }
+        for index in range(71_680)
+    ]
+    validation = {
+        "findings": [
+            {
+                "severity": "error",
+                "suppressed": False,
+                "record_type": "room",
+                "vnum": 2_000_001,
+            }
+        ]
+    }
+
+    audit = _action_audit(actions, validation)
+
+    self.assertFalse(audit["pass"])
+    self.assertEqual(1, len(audit["blocking_selected_record_findings"]))
+
+  def test_line_format_audit_requires_ascii_lf(self) -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+      root = Path(temporary)
+      (root / "good").write_bytes(b"good\n")
+      (root / "crlf").write_bytes(b"bad\r\n")
+      (root / "nonascii").write_bytes(b"bad\xff\n")
+
+      audit = _line_format_audit(root, ("good", "crlf", "nonascii"))
+
+    self.assertFalse(audit["pass"])
+    by_path = {row["path"]: row for row in audit["files"]}
+    self.assertTrue(by_path["good"]["ascii"])
+    self.assertFalse(by_path["crlf"]["lf_only"])
+    self.assertFalse(by_path["nonascii"]["ascii"])
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/world/tests/test_rol_transform.py
+++ b/scripts/world/tests/test_rol_transform.py
@@ -1053,6 +1053,64 @@ class RolTransformTests(unittest.TestCase):
     self.assertIn("approximated source race-factor apply 41", diagnostics)
     self.assertNotIn("unknown source item type", diagnostics)
 
+  def test_emitted_object_synthesizes_runtime_safe_identity_strings(self) -> None:
+    source = self._source_record(
+        "obj",
+        b"#2\ncorpse~\n~\n~\n~\n24 0 0\n0 0 0 0\n200 0 0\n",
+    )
+
+    emitted = emit_object(source, 2_000_002, _resolver)
+    path = self._target_path("obj", emitted.text)
+    result = parse_object_file(path, "obj/20000.obj", self.manifest, set())
+
+    self.assertTrue(result.complete)
+    obj = result.records[0]
+    self.assertEqual("corpse", obj.aliases)
+    self.assertEqual("corpse", obj.short_description)
+    self.assertEqual("corpse is here.", obj.description)
+    diagnostics = " ".join(emitted.diagnostics)
+    self.assertIn("synthesized missing object short description", diagnostics)
+    self.assertIn("synthesized missing object room description", diagnostics)
+
+  def test_source_object_recovers_missing_action_description(self) -> None:
+    temporary = tempfile.TemporaryDirectory()
+    self.addCleanup(temporary.cleanup)
+    source_path = Path(temporary.name) / "sample.obj"
+    source_path.write_bytes(
+        b"#7\nmanual~\na manual~\nA manual lies here.~\n"
+        b"23 0 1\n0 0 0 0\n1 1000 0\n"
+    )
+
+    records, corpus = parse_rol_source_file(
+        source_path, "areas/obj/sample.obj", "obj", "sample"
+    )
+
+    self.assertTrue(corpus.complete)
+    self.assertEqual(23, records[0].values["item_type"])
+    self.assertEqual("", records[0].values["strings"]["action_description"])
+    self.assertTrue(any(item.code == "ROLOBJ005" for item in corpus.diagnostics))
+
+  def test_source_object_recovers_pre_header_extra_description(self) -> None:
+    temporary = tempfile.TemporaryDirectory()
+    self.addCleanup(temporary.cleanup)
+    source_path = Path(temporary.name) / "sample.obj"
+    source_path.write_bytes(
+        b"#1034\nkey~\na translucent key~\nA translucent key lies here.~\n~\n"
+        b"E\nkey~\nA nearly transparent skeleton key.~\n"
+        b"18 0 1\n0 0 0 0\n1 1 1\n"
+    )
+
+    records, corpus = parse_rol_source_file(
+        source_path, "areas/obj/sample.obj", "obj", "sample"
+    )
+
+    self.assertTrue(corpus.complete)
+    self.assertEqual(18, records[0].values["item_type"])
+    extras = [row for row in records[0].directives if row["token"] == "E"]
+    self.assertEqual(1, len(extras))
+    self.assertEqual("key", extras[0]["keyword"])
+    self.assertTrue(any(item.code == "ROLOBJ006" for item in corpus.diagnostics))
+
   def test_emitted_room_repairs_missing_mountain_sector(self) -> None:
     source = self._source_record(
         "wld",
@@ -1208,6 +1266,23 @@ class RolTransformTests(unittest.TestCase):
     self.assertTrue(result.complete)
     self.assertEqual(120, result.records[0].values[1])
     self.assertIn("source spell 41 (haste)", " ".join(emitted.diagnostics))
+
+  def test_emitted_staff_repairs_current_charges_above_maximum(self) -> None:
+    source = self._source_record(
+        "obj",
+        b"#8013\nstaff magi~\nthe staff of the magi~\n"
+        b"The staff of the magi lies here.~\n~\n"
+        b"4 0 1\n50 1 6 75\n4 10000 6000\n",
+    )
+
+    emitted = emit_object(source, 2_008_013, _resolver)
+    path = self._target_path("obj", emitted.text)
+    result = parse_object_file(path, "obj/20080.obj", self.manifest, set())
+
+    self.assertTrue(result.complete)
+    self.assertEqual(6, result.records[0].values[1])
+    self.assertEqual(6, result.records[0].values[2])
+    self.assertIn("raised source wand/staff maximum charges", " ".join(emitted.diagnostics))
 
   def test_emitted_magic_item_disables_spell_without_target_equivalent(self) -> None:
     source = self._source_record(

--- a/scripts/world/wtool_lib/cli.py
+++ b/scripts/world/wtool_lib/cli.py
@@ -51,6 +51,13 @@ from .rol_rebase import (
 )
 from .rol_pilot import render_rol_pilot_selection_human, write_pilot_selection_bundle
 from .rol_pilot_build import render_rol_pilot_build_human, write_pilot_build_bundle
+from .rol_phase7 import render_rol_phase7_human, write_phase7_bundle
+from .rol_phase8 import (
+    apply_phase8_bundle,
+    render_rol_phase8_human,
+    write_phase8_bundle,
+    write_phase8_completion,
+)
 from .rol_persistence_audit import (
     apply_persistence_migration_bundle,
     render_persistence_apply_human,
@@ -298,6 +305,58 @@ def _parser() -> argparse.ArgumentParser:
   rol_completion_audit.add_argument("--runtime-log", type=Path, required=True)
   rol_completion_audit.add_argument("--output-dir", type=Path, required=True)
   rol_completion_audit.add_argument("--created-at")
+
+  rol_phase7 = commands.add_parser(
+      "rol-phase7",
+      help="build a cumulative Realms of Luminari Phase 7 conversion milestone",
+  )
+  rol_phase7.add_argument("--discovery-dir", type=Path, required=True)
+  rol_phase7.add_argument("--plan-dir", type=Path, required=True)
+  rol_phase7.add_argument("--capability-audit-dir", type=Path, required=True)
+  rol_phase7.add_argument("--phase6-dir", type=Path, required=True)
+  rol_phase7.add_argument("--completion-dir", type=Path, required=True)
+  rol_phase7.add_argument(
+      "--source-root", type=Path, default=_default_rol_source_root()
+  )
+  rol_phase7.add_argument("--output-dir", type=Path, required=True)
+  rol_phase7.add_argument("--through-batch", type=int, required=True)
+  rol_phase7.add_argument("--prior-milestone-dir", type=Path, action="append", default=[])
+  rol_phase7.add_argument("--created-at")
+
+  rol_phase8 = commands.add_parser(
+      "rol-phase8",
+      help="assemble and seal the final Realms of Luminari release candidate",
+  )
+  rol_phase8.add_argument("--phase7-dir", type=Path, required=True)
+  rol_phase8.add_argument("--repeat-phase7-dir", type=Path, required=True)
+  rol_phase8.add_argument("--completion-dir", type=Path, required=True)
+  rol_phase8.add_argument("--world-tools-log", type=Path, required=True)
+  rol_phase8.add_argument("--cutest-log", type=Path, required=True)
+  rol_phase8.add_argument("--install-log", type=Path, required=True)
+  rol_phase8.add_argument("--syntax-log", type=Path, required=True)
+  rol_phase8.add_argument("--runtime-log", type=Path, required=True)
+  rol_phase8.add_argument("--output-dir", type=Path, required=True)
+  rol_phase8.add_argument("--created-at")
+
+  rol_phase8_apply = commands.add_parser(
+      "rol-phase8-apply",
+      help="apply an accepted Phase 8 release candidate to development",
+  )
+  rol_phase8_apply.add_argument("--bundle-dir", type=Path, required=True)
+  rol_phase8_apply.add_argument(
+      "--lib-root", type=Path, default=default_repo_root() / "lib"
+  )
+
+  rol_phase8_completion = commands.add_parser(
+      "rol-phase8-completion",
+      help="seal post-apply Phase 8 completion and idempotency evidence",
+  )
+  rol_phase8_completion.add_argument("--bundle-dir", type=Path, required=True)
+  rol_phase8_completion.add_argument(
+      "--lib-root", type=Path, default=default_repo_root() / "lib"
+  )
+  rol_phase8_completion.add_argument("--output-dir", type=Path, required=True)
+  rol_phase8_completion.add_argument("--created-at")
   return parser
 
 
@@ -716,6 +775,83 @@ def _run_rol_persistence_bundle(args: argparse.Namespace) -> int:
   return 0
 
 
+def _run_rol_phase7(args: argparse.Namespace) -> int:
+  summary = write_phase7_bundle(
+      args.discovery_dir,
+      args.plan_dir,
+      args.capability_audit_dir,
+      args.phase6_dir,
+      args.completion_dir,
+      args.source_root,
+      args.world_root,
+      args.output_dir,
+      args.through_batch,
+      prior_milestone_dirs=args.prior_milestone_dir,
+      created_at=args.created_at,
+  )
+  if args.json_output:
+    _print_json(summary)
+  else:
+    sys.stdout.write(render_rol_phase7_human(summary))
+  return 0
+
+
+def _run_rol_phase8(args: argparse.Namespace) -> int:
+  summary = write_phase8_bundle(
+      args.phase7_dir,
+      args.repeat_phase7_dir,
+      args.completion_dir,
+      args.world_root,
+      args.output_dir,
+      {
+          "world-tools": args.world_tools_log,
+          "cutest": args.cutest_log,
+          "install": args.install_log,
+          "syntax": args.syntax_log,
+          "runtime": args.runtime_log,
+      },
+      created_at=args.created_at,
+  )
+  if args.json_output:
+    _print_json(summary)
+  else:
+    sys.stdout.write(render_rol_phase8_human(summary))
+  return 0
+
+
+def _run_rol_phase8_apply(args: argparse.Namespace) -> int:
+  summary = apply_phase8_bundle(args.bundle_dir, args.lib_root)
+  if args.json_output:
+    _print_json(summary)
+  else:
+    sys.stdout.write(
+        f"RoL Phase 8 apply: {summary['run_id']}\n"
+        f"Changed paths: {summary['changed_paths']}\n"
+        f"Already current paths: {summary['already_current_paths']}\n"
+        f"Idempotent no-op: {str(summary['idempotent_no_op']).lower()}\n"
+    )
+  return 0
+
+
+def _run_rol_phase8_completion(args: argparse.Namespace) -> int:
+  summary = write_phase8_completion(
+      args.bundle_dir,
+      args.lib_root,
+      args.output_dir,
+      created_at=args.created_at,
+  )
+  if args.json_output:
+    _print_json(summary)
+  else:
+    sys.stdout.write(
+        f"RoL Phase 8 completion: {summary['run_id']}\n"
+        f"Output: {summary['output_dir']}\n"
+        f"Repeat apply no-op: {str(summary['repeat_apply_no_op']).lower()}\n"
+        f"Complete: {str(summary['complete']).lower()}\n"
+    )
+  return 0
+
+
 def _run_rol_persistence_apply(args: argparse.Namespace) -> int:
   summary = apply_persistence_migration_bundle(
       args.bundle_dir,
@@ -802,6 +938,14 @@ def main(argv: Sequence[str] | None = None) -> int:
       return _run_rol_persistence_apply(args)
     if args.command == "rol-completion-audit":
       return _run_rol_completion_audit(args)
+    if args.command == "rol-phase7":
+      return _run_rol_phase7(args)
+    if args.command == "rol-phase8":
+      return _run_rol_phase8(args)
+    if args.command == "rol-phase8-apply":
+      return _run_rol_phase8_apply(args)
+    if args.command == "rol-phase8-completion":
+      return _run_rol_phase8_completion(args)
   except (ConfigError, DocumentationError, ExtractionError, OSError, ValueError) as error:
     sys.stderr.write(f"wtool: error: {error}\n")
     return 2

--- a/scripts/world/wtool_lib/rol_phase7.py
+++ b/scripts/world/wtool_lib/rol_phase7.py
@@ -1,0 +1,1696 @@
+"""Build deterministic Phase 7 Realms of Luminari corpus milestones."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import replace
+import hashlib
+import json
+from pathlib import Path
+import re
+import shutil
+import textwrap
+from typing import Any, Iterable
+
+from .config import resolve_config
+from .constants import default_repo_root, load_manifest
+from .flags import decode_tokens, encode_bits
+from .models import TOOL_VERSION
+from .reporting import result_payload
+from .rol_discovery import extract_source_commands
+from .rol_pilot_build import (
+    _artifact,
+    _canonical_json,
+    _canonical_line,
+    _created_at,
+    _load_json,
+    _load_jsonl,
+    _reset_references,
+    _source_records,
+    _verify_bundle,
+)
+from .rol_skeleton import tree_manifest
+from .rol_soc import SocCompilation, compile_soc_records
+from .rol_source import RolRecord
+from .rol_special import NativeSpecialBinding, SpecialCompilation, compile_special_bindings
+from .rol_transform import (
+    TransformResult,
+    emit_hlquest,
+    emit_mobile,
+    emit_object,
+    emit_room,
+    emit_shop,
+    emit_zone,
+    mobile_automatic_race_flags,
+)
+from .world import load_indexed_world_data, validate_indexed_world
+
+
+ROL_PHASE7_SCHEMA_VERSION = 1
+_SOURCE_ROOT_PREFIX = "EXAMPLE/RealmsOfLuminari"
+_KIND_OWNER = {"mob": "mob", "obj": "obj", "wld": "wld"}
+_KIND_DIRECTORY = {
+    "mob": ("mob", "mob"),
+    "obj": ("obj", "obj"),
+    "qst": ("hlq", "hlq"),
+    "shp": ("shp", "shp"),
+    "wld": ("wld", "wld"),
+    "zon": ("zon", "zon"),
+}
+_TYPE_KIND = {"mobile": "mob", "object": "obj", "room": "wld"}
+_PRECONVERTED_BASENAMES = frozenset({"hulburg", "trail", "jotun"})
+_SOC_OWNER_EXCLUSIONS = frozenset(
+    {
+        "soc:22496:areas/soc/bs3.soc:1",
+        "soc:22496:areas/soc/bs3.soc:72",
+        "soc:89128:areas/soc/bandits.soc:1",
+    }
+)
+_SPECIAL_TRIGGER_START = 2_026_167
+_COMPOSITE_SPECIALS = {
+    ("mob", 2007110): ("RoL Bloodstone Critter", "RoL Corpse Devourer"),
+    ("mob", 2007111): ("RoL Bloodstone Critter", "RoL Corpse Devourer"),
+    ("mob", 2007112): ("RoL Bloodstone Critter", "RoL Corpse Devourer"),
+    ("mob", 2007141): ("RoL Bloodstone Critter", "RoL Corpse Devourer"),
+    ("mob", 2007154): ("RoL Corpse Devourer", "RoL Source Periodic"),
+    ("mob", 2007177): ("Receptionist", "RoL Source Periodic"),
+    ("mob", 2007180): ("RoL Monster Combat", "RoL Source Periodic"),
+    ("mob", 2007190): ("RoL Source Periodic", "money_changer"),
+    ("mob", 2019701): (
+        "RoL Lich Energy Drain",
+        "RoL Monster Combat",
+        "breath_weapon_acid",
+    ),
+    ("mob", 2019750): ("RoL Guild Guard", "RoL Monster Combat"),
+    ("mob", 2025400): ("RoL Guild Guard", "breath_weapon_gas"),
+    ("mob", 2080220): ("RoL Monster Combat", "RoL Poison Bite"),
+    ("mob", 2093202): ("RoL Monster Combat", "RoL Source Periodic"),
+    ("obj", 2003088): ("RoL Travel Portal", "RoL Utility Object"),
+}
+
+
+class RolPhase7Error(ValueError):
+  """Raised when a Phase 7 milestone violates a frozen conversion invariant."""
+
+
+class _UnionFind:
+  def __init__(self, values: Iterable[str]):
+    self.parent = {value: value for value in values}
+
+  def find(self, value: str) -> str:
+    parent = self.parent[value]
+    if parent != value:
+      self.parent[value] = self.find(parent)
+    return self.parent[value]
+
+  def union(self, left: str, right: str) -> None:
+    left_root = self.find(left)
+    right_root = self.find(right)
+    if left_root != right_root:
+      self.parent[max(left_root, right_root)] = min(left_root, right_root)
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+  count = 0
+  path.parent.mkdir(parents=True, exist_ok=True)
+  with path.open("wb") as output:
+    for row in rows:
+      output.write(_canonical_line(row))
+      count += 1
+  return count
+
+
+def _augment_actions(
+    discovery_dir: Path, plan_dir: Path
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+  metadata = {
+      str(row["record_id"]): row
+      for row in _load_jsonl(discovery_dir / "source-records.jsonl")
+  }
+  actions: list[dict[str, Any]] = []
+  for planned in _load_jsonl(plan_dir / "change-plan.jsonl"):
+    record_id = str(planned["source_record_id"])
+    try:
+      source = metadata[record_id]
+    except KeyError as error:
+      raise RolPhase7Error(f"plan record is absent from discovery: {record_id}") from error
+    actions.append(
+        {
+            **planned,
+            "basename": str(source["basename"]),
+            "source_kind": str(source["kind"]),
+            "source_path": str(source["path"]),
+            "source_vnum": int(source["vnum"]),
+        }
+    )
+  if len(actions) != len(metadata):
+    raise RolPhase7Error("Phase 7 requires one planned action for every discovered record")
+  return actions, metadata
+
+
+def _package_batches(
+    inventory: dict[str, Any],
+    metadata: dict[str, dict[str, Any]],
+    actions: Iterable[dict[str, Any]],
+    references: Iterable[dict[str, Any]],
+) -> list[list[str]]:
+  packages = sorted(
+      str(row["basename"])
+      for row in inventory["packages"]
+      if row.get("included") is True
+  )
+  union = _UnionFind(packages)
+  owners: defaultdict[tuple[str, int], set[str]] = defaultdict(set)
+  for row in metadata.values():
+    owners[(str(row["kind"]), int(row["vnum"]))].add(str(row["basename"]))
+  target_kind = {"mobile": "mob", "object": "obj", "room": "wld"}
+  for reference in references:
+    if reference.get("resolution") != "active_source":
+      continue
+    source = metadata.get(str(reference.get("source_record_id")))
+    kind = target_kind.get(str(reference.get("target_type")))
+    if source is None or kind is None:
+      continue
+    destinations = owners.get((kind, int(reference["target_vnum"])), set())
+    for destination in destinations:
+      union.union(str(source["basename"]), destination)
+
+  zones: defaultdict[int, set[str]] = defaultdict(set)
+  for action in actions:
+    if action["source_kind"] == "zon" and action["destination_vnum"] is not None:
+      zones[int(action["destination_vnum"])].add(str(action["basename"]))
+  for basenames in zones.values():
+    first = min(basenames)
+    for basename in basenames:
+      union.union(first, basename)
+
+  for alias, owner in (
+      ("foggy_woods2", "foggy_woods"),
+      ("northern_highroad2", "northern_highroad"),
+      ("northern_highroad3", "northern_highroad"),
+  ):
+    if alias in union.parent and owner in union.parent:
+      union.union(alias, owner)
+
+  components: defaultdict[str, list[str]] = defaultdict(list)
+  for package in packages:
+    components[union.find(package)].append(package)
+  result = sorted(
+      (sorted(component) for component in components.values()),
+      key=lambda component: (-len(component), component[0]),
+  )
+  if len(result) != 12 or sum(len(component) for component in result) != 258:
+    raise RolPhase7Error(
+        f"frozen dependency graph expected 12 batches and 258 packages, got "
+        f"{len(result)} batches and {sum(len(component) for component in result)} packages"
+    )
+  return result
+
+
+def _typed_resolver(
+    plan_dir: Path, references: Iterable[dict[str, Any]]
+):
+  identities = {
+      (str(row["source_kind"]), int(row["source_vnum"])): row["destination_vnum"]
+      for row in _load_jsonl(plan_dir / "identity-map.jsonl")
+  }
+  identities[("wld", 96003)] = 2_096_003
+  exact: set[tuple[str, int]] = set()
+  kind_for_type = {"mobile": "mob", "object": "obj", "room": "wld"}
+  for row in references:
+    if row.get("resolution") != "target_exact":
+      continue
+    kind = kind_for_type.get(str(row.get("target_type")))
+    if kind is not None:
+      exact.add((kind, int(row["target_vnum"])))
+
+  def resolve(kind: str, vnum: int) -> int:
+    key = (kind, vnum)
+    if key in identities:
+      destination = identities[key]
+      if destination is None:
+        raise RolPhase7Error(f"required identity {kind} {vnum} is excluded")
+      return int(destination)
+    if key in exact or vnum <= 0:
+      return vnum
+    raise RolPhase7Error(f"no typed identity for {kind} {vnum}")
+
+  return resolve
+
+
+def _zone_intervals(
+    actions: Iterable[dict[str, Any]], records: dict[str, RolRecord]
+) -> dict[str, list[tuple[int, int, int]]]:
+  result: defaultdict[str, list[tuple[int, int, int]]] = defaultdict(list)
+  for action in actions:
+    if action["source_kind"] != "zon" or action["destination_vnum"] is None:
+      continue
+    record = records[str(action["source_record_id"])]
+    header = list(record.values.get("header", []))
+    if not header:
+      raise RolPhase7Error(f"zone {record.record_id} lacks a top VNUM")
+    bottom = 81700 if record.basename == "mytheast" else record.vnum * 100
+    result[record.basename].append((bottom, int(header[0]), int(action["destination_vnum"])))
+  normalized: dict[str, list[tuple[int, int, int]]] = {}
+  for basename, source_rows in result.items():
+    rows = sorted(source_rows)
+    output: list[tuple[int, int, int]] = []
+    for index, (bottom, top, destination_zone) in enumerate(rows):
+      if index + 1 < len(rows):
+        top = min(top, rows[index + 1][0] - 1)
+      if top < bottom:
+        top = bottom + 99
+        if index + 1 < len(rows):
+          top = min(top, rows[index + 1][0] - 1)
+      output.append((bottom, top, destination_zone))
+    normalized[basename] = output
+  return normalized
+
+
+def _record_zone(
+    basename: str,
+    source_vnum: int,
+    destination_vnum: int,
+    intervals: dict[str, list[tuple[int, int, int]]],
+) -> int:
+  rows = intervals.get(basename, [])
+  for bottom, top, destination_zone in rows:
+    if bottom <= source_vnum <= top:
+      return destination_zone
+  if len(rows) == 1:
+    return rows[0][2]
+  return destination_vnum // 100
+
+
+def _source_zone_flags(
+    basename: str,
+    source_vnum: int,
+    intervals: dict[str, list[tuple[int, int, int]]],
+    zone_records: dict[tuple[str, int], RolRecord],
+) -> int:
+  rows = intervals.get(basename, [])
+  selected: RolRecord | None = None
+  for bottom, top, destination_zone in rows:
+    del destination_zone
+    if bottom <= source_vnum <= top:
+      selected = zone_records.get((basename, bottom))
+      break
+  if selected is None and len(rows) == 1:
+    selected = zone_records.get((basename, rows[0][0]))
+  if selected is None:
+    return 0
+  header = list(selected.values.get("header", []))
+  return int(header[3]) if len(header) > 3 else 0
+
+
+def _target_zone_ranges(
+    actions: Iterable[dict[str, Any]],
+    records: dict[str, RolRecord],
+    intervals: dict[str, list[tuple[int, int, int]]],
+) -> dict[int, tuple[int, int]]:
+  selected = [
+      action
+      for action in actions
+      if action["action"] != "EXCLUDE" and action["destination_vnum"] is not None
+  ]
+  rooms: defaultdict[int, list[int]] = defaultdict(list)
+  for action in selected:
+    if action["source_kind"] != "wld":
+      continue
+    owner = _record_zone(
+        str(action["basename"]),
+        int(action["source_vnum"]),
+        int(action["destination_vnum"]),
+        intervals,
+    )
+    rooms[owner].append(int(action["destination_vnum"]))
+
+  provisional: defaultdict[int, list[tuple[int, int]]] = defaultdict(list)
+  for action in selected:
+    if action["source_kind"] != "zon":
+      continue
+    record = records[str(action["source_record_id"])]
+    destination = int(action["destination_vnum"])
+    source_bottom = 81700 if record.basename == "mytheast" else record.vnum * 100
+    interval = next(
+        (
+            (bottom, top)
+            for bottom, top, zone in intervals[record.basename]
+            if bottom == source_bottom and zone == destination
+        ),
+        None,
+    )
+    if interval is None:
+      raise RolPhase7Error(f"cannot recover target range for {record.record_id}")
+    owned = rooms.get(destination, [])
+    bottom = min(owned) if owned else destination * 100
+    top = destination * 100 + (interval[1] - interval[0])
+    if owned:
+      top = max(top, max(owned))
+    provisional[destination].append((bottom, top))
+
+  combined = {
+      destination: (
+          min(bottom for bottom, _ in rows),
+          max(top for _, top in rows),
+      )
+      for destination, rows in provisional.items()
+  }
+  ordered = sorted(
+      ((bottom, top, destination) for destination, (bottom, top) in combined.items()),
+      key=lambda row: (row[0], row[2]),
+  )
+  result: dict[int, tuple[int, int]] = {}
+  for index, (bottom, top, destination) in enumerate(ordered):
+    if index + 1 < len(ordered):
+      next_bottom = ordered[index + 1][0]
+      if next_bottom <= bottom:
+        raise RolPhase7Error(
+            f"target zones {destination} and {ordered[index + 1][2]} share bottom {bottom}"
+        )
+      top = min(top, next_bottom - 1)
+    result[destination] = (bottom, max(bottom, top))
+  return result
+
+
+def _target_room_zone(
+    destination_vnum: int,
+    fallback: int,
+    ranges: dict[int, tuple[int, int]],
+) -> int:
+  owners = [
+      zone for zone, (bottom, top) in ranges.items() if bottom <= destination_vnum <= top
+  ]
+  if len(owners) == 1:
+    return owners[0]
+  return fallback
+
+
+def _binding_rows(phase6_dir: Path) -> list[dict[str, Any]]:
+  rows: list[dict[str, Any]] = []
+  for source in _load_jsonl(phase6_dir / "binding-ledger.jsonl"):
+    consumers = source.get("consumers", [])
+    if source.get("status") != "resolved" or not consumers:
+      continue
+    row = dict(source)
+    row["basename"] = str(consumers[0]["basename"])
+    rows.append(row)
+  return rows
+
+
+def _aggregate_native_bindings(
+    compilation: SpecialCompilation,
+) -> dict[tuple[str, int], NativeSpecialBinding]:
+  grouped: defaultdict[tuple[str, int], list[NativeSpecialBinding]] = defaultdict(list)
+  for binding in compilation.native_bindings:
+    grouped[(binding.target_kind, binding.target_vnum)].append(binding)
+
+  result: dict[tuple[str, int], NativeSpecialBinding] = {}
+  measured_conflicts: set[tuple[str, int]] = set()
+  for key, bindings in sorted(grouped.items()):
+    persisted: list[str] = []
+    for binding in bindings:
+      if binding.persisted_name is not None and binding.persisted_name not in persisted:
+        persisted.append(binding.persisted_name)
+    if len(persisted) > 1:
+      expected = _COMPOSITE_SPECIALS.get(key)
+      if expected is None or tuple(persisted) != expected:
+        raise RolPhase7Error(
+            f"unmeasured composite special profile {key}: {persisted!r}"
+        )
+      persisted_name = "RoL Composite Mobile" if key[0] == "mob" else "RoL Composite Object"
+      measured_conflicts.add(key)
+    else:
+      persisted_name = persisted[0] if persisted else None
+    first = bindings[0]
+    result[key] = replace(
+        first,
+        persisted_name=persisted_name,
+        required_flag_bits=tuple(
+            sorted({bit for binding in bindings for bit in binding.required_flag_bits})
+        ),
+        required_affect_bits=tuple(
+            sorted({bit for binding in bindings for bit in binding.required_affect_bits})
+        ),
+        value_reference_slots=tuple(
+            sorted(
+                {
+                    slot
+                    for binding in bindings
+                    for slot in binding.value_reference_slots
+                }
+            )
+        ),
+    )
+  if measured_conflicts != set(_COMPOSITE_SPECIALS):
+    missing = sorted(set(_COMPOSITE_SPECIALS) - measured_conflicts)
+    raise RolPhase7Error(f"measured composite profiles were not reproduced: {missing}")
+  return result
+
+
+def _trigger_vnums(path: Path) -> set[int]:
+  result: set[int] = set()
+  if not path.is_dir():
+    return result
+  for source in sorted(path.glob("*.trg")):
+    text = source.read_text(encoding="utf-8")
+    result.update(int(value) for value in re.findall(r"(?m)^#(\d+)\s*$", text))
+  return result
+
+
+def _compile_soc_corpus(
+    records: Iterable[RolRecord],
+    resolve,
+    source_commands: dict[int, str],
+    intervals: dict[str, list[tuple[int, int, int]]],
+    occupied: set[int],
+) -> SocCompilation:
+  by_basename: defaultdict[str, list[RolRecord]] = defaultdict(list)
+  for record in records:
+    if record.record_id not in _SOC_OWNER_EXCLUSIONS:
+      by_basename[record.basename].append(record)
+
+  fixed: dict[str, tuple[int, ...]] = {
+      "hulburg": tuple(range(2_026_100, 2_026_150)),
+      "theswamp": tuple(range(2_040_900, 2_041_000)),
+      "cemetery": tuple(range(2_055_300, 2_055_400)),
+      "muspel": (*range(2_058_600, 2_058_700), *range(2_026_150, 2_026_167)),
+  }
+  reserved = set(occupied)
+  reserved.update(range(_SPECIAL_TRIGGER_START, _SPECIAL_TRIGGER_START + 14))
+  compilations: list[SocCompilation] = []
+  for basename in sorted(by_basename):
+    source_records = by_basename[basename]
+    if basename in fixed:
+      candidates = [value for value in fixed[basename] if value not in occupied]
+    else:
+      sample = source_records[0]
+      destination = resolve("mob", sample.vnum)
+      package_intervals = intervals.get(basename, [])
+      zone = (
+          package_intervals[0][2]
+          if len(package_intervals) == 1
+          else _record_zone(basename, sample.vnum, destination, intervals)
+      )
+      candidates = [value for value in range(zone * 100, zone * 100 + 100) if value not in reserved]
+    try:
+      compilation = compile_soc_records(
+          source_records,
+          0,
+          resolve,
+          source_commands,
+          trigger_vnums=candidates,
+      )
+    except (IndexError, StopIteration, ValueError) as error:
+      raise RolPhase7Error(f"SOC trigger range exhausted for {basename}: {error}") from error
+    used = {trigger.vnum for trigger in compilation.triggers}
+    if used & reserved:
+      raise RolPhase7Error(f"SOC trigger collision for {basename}: {sorted(used & reserved)[0]}")
+    reserved.update(used)
+    compilations.append(compilation)
+
+  triggers = sorted(
+      (trigger for compilation in compilations for trigger in compilation.triggers),
+      key=lambda trigger: trigger.vnum,
+  )
+  if len({trigger.vnum for trigger in triggers}) != len(triggers):
+    raise RolPhase7Error("full-corpus SOC compilation emitted duplicate trigger VNUMs")
+  attachments: defaultdict[int, list[int]] = defaultdict(list)
+  for compilation in compilations:
+    for owner, trigger_ids in compilation.attachments.items():
+      attachments[owner].extend(trigger_ids)
+  return SocCompilation(
+      triggers=triggers,
+      attachments={owner: sorted(ids) for owner, ids in sorted(attachments.items())},
+      diagnostics=[item for compilation in compilations for item in compilation.diagnostics],
+      source_records=sum(item.source_records for item in compilations),
+      source_actions=sum(item.source_actions for item in compilations),
+  )
+
+
+def _merge_zone_blocks(blocks: list[tuple[int, str, str]]) -> str:
+  if not blocks:
+    raise RolPhase7Error("cannot merge an empty zone group")
+  parsed: list[tuple[list[str], list[str]]] = []
+  for destination, text, record_id in blocks:
+    del record_id
+    lines = text.splitlines(keepends=True)
+    if len(lines) < 6 or not lines[0].startswith(f"#{destination}"):
+      raise RolPhase7Error(f"malformed emitted zone {destination}")
+    parsed.append((lines[:4], lines[4:-2]))
+  header = list(parsed[0][0])
+  tokens = [item[0][3].split() for item in parsed]
+  for item in tokens:
+    if len(item) < 4:
+      raise RolPhase7Error("emitted zone header is missing required fields")
+    if len(item) < 8:
+      item.extend(["0", "0", "0", "0", "-1", "-1", "1", "0", "0", "0"])
+  base = list(tokens[0])
+  base[0] = str(min(int(item[0]) for item in tokens))
+  base[1] = str(max(int(item[1]) for item in tokens))
+  base[2] = str(max(int(item[2]) for item in tokens))
+  base[3] = str(max(int(item[3]) for item in tokens))
+  flag_bits: set[int] = set()
+  for item in tokens:
+    decoded = decode_tokens(item[4:8])
+    if decoded.issues:
+      raise RolPhase7Error("cannot decode emitted zone flags during MERGE")
+    flag_bits.update(decoded.bits)
+  base[4:8] = list(encode_bits(flag_bits))
+  header[3] = " ".join(base) + "\n"
+  commands = [line for _, rows in parsed for line in rows]
+  return "".join([*header, *commands, "S\n", "$\n"])
+
+
+def _merge_hlquest_blocks(blocks: list[tuple[int, str, str]]) -> str:
+  if not blocks:
+    raise RolPhase7Error("cannot merge an empty hlquest group")
+  destination = blocks[0][0]
+  bodies: list[str] = []
+  seen: set[str] = set()
+  for block_destination, block, record_id in blocks:
+    lines = block.splitlines(keepends=True)
+    if block_destination != destination or not lines or lines[0].strip() != f"#{destination}":
+      raise RolPhase7Error(f"malformed emitted hlquest {record_id}")
+    body = "".join(lines[1:])
+    if body not in seen:
+      seen.add(body)
+      bodies.append(body)
+  return f"#{destination}\n" + "".join(bodies)
+
+
+def _filter_zone_door_resets(
+    text: str,
+    valid_exit_directions: dict[int, set[int]],
+) -> tuple[str, list[str]]:
+  output: list[str] = []
+  diagnostics: list[str] = []
+  for line in text.splitlines(keepends=True):
+    tokens = line.split()
+    if len(tokens) >= 4 and tokens[0] in {"D", "K"}:
+      room = int(tokens[2])
+      direction = int(tokens[3])
+      if room in valid_exit_directions and direction not in valid_exit_directions[room]:
+        diagnostics.append(
+            f"excluded {tokens[0]} reset for absent exit {room} direction {direction}"
+        )
+        continue
+    output.append(line)
+  return "".join(output), diagnostics
+
+
+def _bound_trigger_text(vnum: int, source: str) -> tuple[str, list[str]]:
+  output: list[str] = []
+  diagnostics: list[str] = []
+  for line_number, line in enumerate(source.splitlines(keepends=True), start=1):
+    body = line.rstrip("\n")
+    if len(body.encode("ascii")) <= 480:
+      output.append(line)
+      continue
+    indentation = body[: len(body) - len(body.lstrip())]
+    stripped = body.lstrip()
+    if stripped.startswith("mecho "):
+      prefix = indentation + "mecho "
+      payload = stripped[len("mecho "):]
+    elif stripped.startswith("mrolzoneecho "):
+      words = stripped.split(maxsplit=3)
+      if len(words) != 4:
+        raise RolPhase7Error(f"cannot safely bound trigger {vnum} line {line_number}")
+      prefix = indentation + " ".join(words[:3]) + " "
+      payload = words[3]
+    else:
+      raise RolPhase7Error(
+          f"trigger {vnum} line {line_number} exceeds 480 bytes in an unsupported command"
+      )
+    chunks = textwrap.wrap(
+        payload,
+        width=480 - len(prefix),
+        break_long_words=True,
+        break_on_hyphens=False,
+        replace_whitespace=True,
+        drop_whitespace=True,
+    )
+    output.extend(prefix + chunk + "\n" for chunk in chunks)
+    diagnostics.append(
+        f"split overlong echo at generated trigger line {line_number} into {len(chunks)} echoes"
+    )
+  return "".join(output), diagnostics
+
+
+def _split_world_file(path: Path, kind: str) -> tuple[str, list[tuple[int, str]]]:
+  text = path.read_text(encoding="utf-8")
+  matches = list(re.finditer(r"(?m)^#(\d+)~?\s*$", text))
+  if not matches:
+    prefix = text
+    if kind == "shp" and "$~" in prefix:
+      prefix = prefix[: prefix.rfind("$~")]
+    return prefix, []
+  prefix = text[: matches[0].start()]
+  blocks: list[tuple[int, str]] = []
+  for index, match in enumerate(matches):
+    end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+    block = text[match.start():end]
+    if index + 1 == len(matches):
+      lines = block.splitlines(keepends=True)
+      while lines and not lines[-1].strip():
+        lines.pop()
+      if lines and lines[-1].strip() == "$~":
+        lines.pop()
+      elif kind != "zon" and lines and lines[-1].strip() == "$":
+        lines.pop()
+      block = "".join(lines)
+    blocks.append((int(match.group(1)), block))
+  return prefix, blocks
+
+
+def _render_world_file(kind: str, prefix: str, blocks: Iterable[tuple[int, str]]) -> str:
+  body = "".join(text if text.endswith("\n") else text + "\n" for _, text in blocks)
+  if kind == "shp":
+    if not prefix.strip():
+      prefix = "CircleMUD v3.0 Shop File~\n"
+    elif not prefix.endswith("\n"):
+      prefix += "\n"
+    return prefix + body + "$~\n"
+  if kind == "zon":
+    return body
+  return body + "$~\n"
+
+
+def _merge_world_records(
+    path: Path,
+    kind: str,
+    additions: list[tuple[int, str, str]],
+    replacements: set[int] = frozenset(),
+) -> None:
+  if path.exists():
+    prefix, existing = _split_world_file(path, kind)
+  else:
+    prefix, existing = ("CircleMUD v3.0 Shop File~\n" if kind == "shp" else ""), []
+  existing_counts = Counter(vnum for vnum, _ in existing)
+  replacement_text: defaultdict[int, list[tuple[str, str]]] = defaultdict(list)
+  appended: list[tuple[int, str, str]] = []
+  for vnum, text, record_id in additions:
+    if vnum in replacements:
+      replacement_text[vnum].append((text, record_id))
+    else:
+      if existing_counts[vnum] and kind != "hlq":
+        raise RolPhase7Error(f"ADD {record_id} collides with existing {kind} {vnum}")
+      appended.append((vnum, text, record_id))
+  rendered: list[tuple[int, str]] = []
+  replaced: set[int] = set()
+  for vnum, text in existing:
+    if vnum not in replacement_text:
+      rendered.append((vnum, text))
+      continue
+    if vnum in replaced:
+      continue
+    rows = replacement_text[vnum]
+    if len(rows) != 1:
+      raise RolPhase7Error(f"replacement {kind} {vnum} is not unique")
+    rendered.append((vnum, rows[0][0]))
+    replaced.add(vnum)
+  missing_replacements = set(replacement_text) - replaced
+  if missing_replacements:
+    missing = min(missing_replacements)
+    raise RolPhase7Error(f"replacement target {kind} {missing} is absent from {path}")
+  rendered.extend((vnum, text) for vnum, text, _ in sorted(appended))
+  rendered.sort(key=lambda row: row[0])
+  path.parent.mkdir(parents=True, exist_ok=True)
+  path.write_text(_render_world_file(kind, prefix, rendered), encoding="utf-8", newline="\n")
+
+
+def _block_flag_row(lines: list[str], kind: str, vnum: int) -> int:
+  if kind == "mob":
+    for index, line in enumerate(lines):
+      tokens = line.strip().split()
+      if len(tokens) >= 10 and tokens[-1] == "E":
+        return index
+    raise RolPhase7Error(f"mobile {vnum} lacks an enhanced flag row")
+  required_tildes = 4 if kind == "obj" else 2
+  terminators = 0
+  for index, line in enumerate(lines):
+    if line.rstrip().endswith("~"):
+      terminators += 1
+      if terminators == required_tildes:
+        if index + 1 >= len(lines):
+          break
+        return index + 1
+  raise RolPhase7Error(f"{kind} {vnum} lacks a canonical flag row")
+
+
+def _merge_flag_chunks(tokens: list[str], start: int, required: Iterable[int]) -> None:
+  required_bits = set(required)
+  if not required_bits:
+    return
+  decoded = decode_tokens(tokens[start:start + 4])
+  if decoded.issues:
+    raise RolPhase7Error(f"cannot decode persisted flags {tokens[start:start + 4]!r}")
+  tokens[start:start + 4] = encode_bits(set(decoded.bits) | required_bits)
+
+
+def _patch_record_block(
+    kind: str,
+    vnum: int,
+    text: str,
+    special_proc: str | None,
+    attachments: Iterable[int],
+    required_flags: Iterable[int],
+    required_affects: Iterable[int],
+) -> str:
+  lines = text.splitlines(keepends=True)
+  flag_index = _block_flag_row(lines, kind, vnum)
+  tokens = lines[flag_index].strip().split()
+  if kind == "mob":
+    action_bits = set(required_flags)
+    if special_proc is not None:
+      action_bits.add(0)
+    _merge_flag_chunks(tokens, 0, action_bits)
+    _merge_flag_chunks(tokens, 4, required_affects)
+  elif kind == "obj":
+    _merge_flag_chunks(tokens, 1, required_flags)
+  else:
+    _merge_flag_chunks(tokens, 1, required_flags)
+  lines[flag_index] = " ".join(tokens) + "\n"
+
+  if kind == "mob":
+    lines = [line for line in lines if not line.startswith("SpecProc:")]
+    if special_proc is not None:
+      enhanced_end = max(
+          (index for index, line in enumerate(lines) if line.strip() == "E"),
+          default=-1,
+      )
+      if enhanced_end < 0:
+        raise RolPhase7Error(f"mobile {vnum} lacks an enhanced E terminator")
+      lines.insert(enhanced_end, f"SpecProc: {special_proc}\n")
+  else:
+    stripped: list[str] = []
+    index = 0
+    while index < len(lines):
+      if lines[index].strip() == "Z" and index + 1 < len(lines):
+        index += 2
+        continue
+      stripped.append(lines[index])
+      index += 1
+    lines = stripped
+    if special_proc is not None:
+      if kind == "wld":
+        room_end = max(
+            (index for index, line in enumerate(lines) if line.strip() == "S"),
+            default=-1,
+        )
+        if room_end < 0:
+          raise RolPhase7Error(f"room {vnum} lacks an S terminator")
+        lines[room_end:room_end] = ["Z\n", f"{special_proc}\n"]
+      else:
+        lines.extend(["Z\n", f"{special_proc}\n"])
+
+  existing_attachments = {
+      int(match.group(1))
+      for line in lines
+      if (match := re.fullmatch(r"T\s+(\d+)\s*\n?", line)) is not None
+  }
+  lines.extend(
+      f"T {trigger_vnum}\n"
+      for trigger_vnum in sorted(set(attachments) - existing_attachments)
+  )
+  return "".join(lines)
+
+
+def _record_file_index(world_root: Path, kind: str, requested: set[int]) -> dict[int, Path]:
+  result: dict[int, Path] = {}
+  extension = kind
+  for path in sorted((world_root / kind).glob(f"*.{extension}")):
+    headers = {
+        int(value)
+        for value in re.findall(rb"(?m)^#(\d+)~?\s*$", path.read_bytes())
+    }
+    for vnum in headers:
+      if vnum not in requested:
+        continue
+      if vnum in result:
+        raise RolPhase7Error(f"preserved {kind} {vnum} is defined in multiple files")
+      result[vnum] = path
+  return result
+
+
+def _patch_preserved_records(
+    staging_world: Path,
+    patches: dict[
+        tuple[str, int],
+        tuple[str | None, tuple[int, ...], tuple[int, ...], tuple[int, ...]],
+    ],
+) -> set[str]:
+  by_file: defaultdict[tuple[str, Path], dict[int, tuple[Any, ...]]] = defaultdict(dict)
+  requested = {
+      kind: {vnum for patch_kind, vnum in patches if patch_kind == kind}
+      for kind in ("mob", "obj", "wld")
+  }
+  indexes = {
+      kind: _record_file_index(staging_world, kind, requested[kind])
+      for kind in ("mob", "obj", "wld")
+  }
+  for (kind, vnum), patch in sorted(patches.items()):
+    try:
+      path = indexes[kind][vnum]
+    except KeyError as error:
+      raise RolPhase7Error(f"preserved patch target {kind} {vnum} is absent") from error
+    by_file[(kind, path)][vnum] = patch
+
+  touched: set[str] = set()
+  for (kind, path), file_patches in sorted(by_file.items(), key=lambda item: item[0][1].as_posix()):
+    prefix, blocks = _split_world_file(path, kind)
+    output: list[tuple[int, str]] = []
+    seen: set[int] = set()
+    for vnum, text in blocks:
+      patch = file_patches.get(vnum)
+      if patch is not None:
+        text = _patch_record_block(kind, vnum, text, *patch)
+        seen.add(vnum)
+      output.append((vnum, text))
+    if seen != set(file_patches):
+      raise RolPhase7Error(f"not every preserved patch was applied in {path}")
+    path.write_text(_render_world_file(kind, prefix, output), encoding="utf-8", newline="\n")
+    touched.add(path.relative_to(staging_world).as_posix())
+  return touched
+
+
+def _normalized_finding(row: dict[str, Any]) -> str:
+  return json.dumps(
+      {
+          "severity": row.get("severity"),
+          "path": row.get("path"),
+          "record_type": row.get("record_type"),
+          "vnum": row.get("vnum"),
+          "suppressed": row.get("suppressed", False),
+      },
+      ensure_ascii=True,
+      sort_keys=True,
+      separators=(",", ":"),
+  )
+
+
+def _validation_delta(
+    baseline: dict[str, Any], staged: dict[str, Any]
+) -> dict[str, Any]:
+  before = Counter(_normalized_finding(row) for row in baseline["findings"])
+  after = Counter(_normalized_finding(row) for row in staged["findings"])
+  new = [json.loads(value) for value in (after - before).elements()]
+  resolved = [json.loads(value) for value in (before - after).elements()]
+  return {
+      "normalization": (
+          "severity, path, record type, vnum, suppression; source line, code, and message excluded"
+      ),
+      "new_findings": sorted(
+          new,
+          key=lambda row: (
+              row["severity"],
+              row.get("path") or "",
+              row.get("record_type") or "",
+              row.get("vnum") if row.get("vnum") is not None else -1,
+          ),
+      ),
+      "resolved_findings": sorted(
+          resolved,
+          key=lambda row: (
+              row["severity"],
+              row.get("path") or "",
+              row.get("record_type") or "",
+              row.get("vnum") if row.get("vnum") is not None else -1,
+          ),
+      ),
+      "new_active_errors": sum(
+          row["severity"] == "error" and not row.get("suppressed", False) for row in new
+      ),
+  }
+
+
+def _runtime_contract(world, zone_vnums: Iterable[int]) -> dict[str, Any]:
+  definitions = {
+      "mob": {record.vnum for record in world.mobiles},
+      "obj": {record.vnum for record in world.objects},
+      "wld": {record.vnum for record in world.rooms},
+  }
+  zones = {record.vnum: record for record in world.zones}
+  rooms = {record.vnum: record for record in world.rooms}
+  evidence: list[dict[str, Any]] = []
+  for vnum in sorted(set(zone_vnums)):
+    zone = zones.get(vnum)
+    unresolved: list[dict[str, Any]] = []
+    commands: Counter[str] = Counter()
+    if zone is not None:
+      for ordinal, command in enumerate(zone.commands, start=1):
+        commands[command.command] += 1
+        for kind, target in _reset_references(command):
+          if target > 0 and target not in definitions[kind]:
+            unresolved.append(
+                {
+                    "ordinal": ordinal,
+                    "command": command.command,
+                    "kind": kind,
+                    "vnum": target,
+                }
+            )
+    owned_rooms = [room for room in rooms.values() if room.file_zone == vnum]
+    missing_exits = sorted(
+        {
+            exit_record.destination_vnum
+            for room in owned_rooms
+            for exit_record in room.exits
+            if exit_record.destination_vnum > 0
+            and exit_record.destination_vnum not in definitions["wld"]
+        }
+    )
+    evidence.append(
+        {
+            "zone_vnum": vnum,
+            "zone_present": zone is not None,
+            "room_count": len(owned_rooms),
+            "reset_counts": dict(sorted(commands.items())),
+            "unresolved_resets": unresolved,
+            "missing_exit_targets": missing_exits,
+            "pass": zone is not None and not unresolved and not missing_exits,
+        }
+    )
+  return {
+      "zones": evidence,
+      "all_pass": all(row["pass"] for row in evidence),
+      "zone_count": len(evidence),
+      "unresolved_reset_count": sum(len(row["unresolved_resets"]) for row in evidence),
+      "missing_exit_count": sum(len(row["missing_exit_targets"]) for row in evidence),
+  }
+
+
+def _preservation_check(
+    baseline: dict[str, Any], staged: dict[str, Any], touched: set[str]
+) -> dict[str, Any]:
+  before = {str(row["path"]): str(row["sha256"]) for row in baseline["files"]}
+  after = {str(row["path"]): str(row["sha256"]) for row in staged["files"]}
+  changed = sorted(path for path in before.keys() & after.keys() if before[path] != after[path])
+  removed = sorted(before.keys() - after.keys())
+  undeclared = sorted(set(changed) - touched)
+  return {
+      "baseline_files": len(before),
+      "staged_files": len(after),
+      "changed_paths": changed,
+      "removed_paths": removed,
+      "declared_touched_paths": sorted(touched),
+      "undeclared_changed_paths": undeclared,
+      "pass": not removed and not undeclared,
+  }
+
+
+def _selected_reference_exceptions(
+    references: Iterable[dict[str, Any]], selected_record_ids: set[str]
+) -> list[dict[str, Any]]:
+  result: list[dict[str, Any]] = []
+  for row in references:
+    if str(row.get("source_record_id")) not in selected_record_ids:
+      continue
+    resolution = str(row.get("resolution"))
+    if resolution not in {"excluded_source", "unresolved", "target_lineage_candidate"}:
+      continue
+    disposition = (
+        "EXCLUDE_DEPENDENT_INSTRUCTION"
+        if resolution in {"excluded_source", "unresolved"}
+        else "EXCLUDE_AMBIGUOUS_LINEAGE_INSTRUCTION"
+    )
+    result.append({**row, "phase7_disposition": disposition, "final": True})
+  return result
+
+
+def _ensure_index_entry(path: Path, filename: str) -> bool:
+  lines = path.read_text(encoding="utf-8").splitlines()
+  entries = [line.strip() for line in lines if line.strip() and line.strip() != "$"]
+  if filename not in entries:
+    entries.append(filename)
+
+  def index_key(entry: str) -> tuple[int, int | str, str]:
+    stem = entry.split(".", 1)[0]
+    return (0, int(stem), entry) if stem.isdigit() else (1, stem, entry)
+
+  rendered = "".join(f"{entry}\n" for entry in sorted(set(entries), key=index_key)) + "$\n"
+  previous = path.read_text(encoding="utf-8")
+  if rendered == previous:
+    return False
+  path.write_text(rendered, encoding="utf-8", newline="\n")
+  return True
+
+
+def write_phase7_bundle(
+    discovery_dir: Path,
+    plan_dir: Path,
+    capability_audit_dir: Path,
+    phase6_dir: Path,
+    completion_dir: Path,
+    source_root: Path,
+    target_world: Path,
+    output_dir: Path,
+    through_batch: int,
+    prior_milestone_dirs: Iterable[Path] = (),
+    created_at: str | None = None,
+) -> dict[str, Any]:
+  """Regenerate one cumulative Phase 7 milestone from the sealed Phase 6.5 baseline."""
+
+  repo_root = default_repo_root()
+  discovery_dir = discovery_dir.resolve()
+  plan_dir = plan_dir.resolve()
+  capability_audit_dir = capability_audit_dir.resolve()
+  phase6_dir = phase6_dir.resolve()
+  completion_dir = completion_dir.resolve()
+  source_root = source_root.resolve()
+  target_world = target_world.resolve()
+  output_dir = output_dir.resolve()
+  prior_milestone_dirs = [path.resolve() for path in prior_milestone_dirs]
+  if output_dir.exists():
+    raise RolPhase7Error(f"Phase 7 output directory already exists: {output_dir}")
+  if source_root != (repo_root / _SOURCE_ROOT_PREFIX).resolve():
+    raise RolPhase7Error("Phase 7 requires the inventoried repository RoL source root")
+  if not target_world.is_dir():
+    raise RolPhase7Error(f"Phase 6.5 target world is inaccessible: {target_world}")
+  if through_batch < 1 or through_batch > 12:
+    raise RolPhase7Error("--through-batch must be in the frozen range 1..12")
+
+  discovery_manifest = _verify_bundle(discovery_dir, 1)
+  plan_manifest = _verify_bundle(plan_dir, 2)
+  capability_manifest = _verify_bundle(
+      capability_audit_dir, 5, "full-corpus-capability-audit"
+  )
+  phase6_manifest = _verify_bundle(phase6_dir, 6, "special-procedure-reconciliation")
+  completion_manifest = _verify_bundle(completion_dir, "6.5-completion-audit")
+  if not completion_manifest.get("acceptance", {}).get("complete"):
+    raise RolPhase7Error("Phase 7 requires the accepted Phase 6.5 completion bundle")
+  if plan_manifest.get("discovery_run_id") != discovery_manifest["run_id"]:
+    raise RolPhase7Error("Phase 1 and Phase 2 inputs do not share a run lineage")
+  if phase6_manifest.get("discovery_run_id") != discovery_manifest["run_id"]:
+    raise RolPhase7Error("Phase 6 input does not share the Phase 1 run lineage")
+
+  actions, metadata = _augment_actions(discovery_dir, plan_dir)
+  records, source_diagnostics = _source_records(repo_root, actions)
+  references = _load_jsonl(discovery_dir / "reference-report.jsonl")
+  inventory = _load_json(discovery_dir / "source-inventory.json")
+  batches = _package_batches(inventory, metadata, actions, references)
+  selected_packages = {
+      package for batch in batches[:through_batch] for package in batch
+  }
+  selected_actions = [
+      action for action in actions if str(action["basename"]) in selected_packages
+  ]
+  selected_record_ids = {str(action["source_record_id"]) for action in selected_actions}
+  selected_records = [records[record_id] for record_id in sorted(selected_record_ids)]
+  resolve = _typed_resolver(plan_dir, references)
+  intervals = _zone_intervals(actions, records)
+  target_ranges = _target_zone_ranges(selected_actions, records, intervals)
+  zone_records: dict[tuple[str, int], RolRecord] = {}
+  for record in records.values():
+    if record.kind != "zon":
+      continue
+    bottom = 81700 if record.basename == "mytheast" else record.vnum * 100
+    zone_records[(record.basename, bottom)] = record
+
+  rehomed_record_ids = {
+      str(row["source_record_id"])
+      for row in _load_jsonl(completion_dir / "record-rehome-ledger.jsonl")
+  }
+
+  room_records = [record for record in records.values() if record.kind == "wld"]
+  valid_exit_directions: defaultdict[int, set[int]] = defaultdict(set)
+  for room_record in room_records:
+    try:
+      target_room = resolve("wld", room_record.vnum)
+    except RolPhase7Error:
+      continue
+    valid_exit_directions[target_room]
+    for directive in room_record.directives:
+      arguments = list(directive.get("arguments", []))
+      if (
+          directive.get("token") != "D"
+          or len(arguments) < 3
+          or directive.get("source_defaulted_destination")
+      ):
+        continue
+      try:
+        if int(arguments[2]) > 0:
+          resolve("wld", int(arguments[2]))
+      except RolPhase7Error:
+        continue
+      valid_exit_directions[target_room].add(int(directive["direction"]))
+  special_compilation = compile_special_bindings(
+      _binding_rows(phase6_dir),
+      _SPECIAL_TRIGGER_START,
+      resolve,
+      room_records,
+  )
+  if (
+      special_compilation.source_bindings != 1721
+      or len(special_compilation.native_bindings) != 1562
+      or len(special_compilation.triggers) != 14
+  ):
+    raise RolPhase7Error("full special compilation drifted from the sealed Phase 6 measurements")
+  native = _aggregate_native_bindings(special_compilation)
+
+  command_evidence = extract_source_commands(source_root)
+  source_commands = {
+      int(row["action_code"]): str(row["command"])
+      for row in command_evidence["commands"]
+  }
+  soc_records = [record for record in selected_records if record.kind == "soc"]
+  soc = _compile_soc_corpus(
+      soc_records,
+      resolve,
+      source_commands,
+      intervals,
+      _trigger_vnums(target_world / "trg"),
+  )
+
+  attachments: defaultdict[tuple[str, int], list[int]] = defaultdict(list)
+  for owner, trigger_ids in soc.attachments.items():
+    attachments[("mob", owner)].extend(trigger_ids)
+  for owner, trigger_ids in special_compilation.attachments.items():
+    attachments[owner].extend(trigger_ids)
+  for owner in list(attachments):
+    attachments[owner] = sorted(set(attachments[owner]))
+
+  inert_special_sources = {
+      (str(row["source_record_type"]), int(row["source_vnum"]))
+      for row in special_compilation.dispositions
+      if row["strategy"] in {"SOURCE_INERT_EXCLUDED", "MINIMAL_DEPENDENCY_EXCLUSION"}
+  }
+  generated: defaultdict[str, list[tuple[int, str, str]]] = defaultdict(list)
+  quest_fragments: defaultdict[int, list[tuple[str, str, str]]] = defaultdict(list)
+  zone_outputs: defaultdict[int, list[tuple[int, str, str]]] = defaultdict(list)
+  transform_diagnostics: list[dict[str, Any]] = []
+  generated_targets: set[tuple[str, int]] = set()
+  record_outputs: dict[str, str] = {}
+
+  def preconverted(action: dict[str, Any]) -> bool:
+    if action["source_kind"] == "zon" and action["basename"] == "mytheast":
+      return False
+    return (
+        str(action["source_record_id"]) in rehomed_record_ids
+        or str(action["basename"]) in _PRECONVERTED_BASENAMES
+    )
+
+  for action in selected_actions:
+    kind = str(action["source_kind"])
+    record_id = str(action["source_record_id"])
+    if kind in {"soc", "zon"} or action["action"] == "EXCLUDE" or preconverted(action):
+      continue
+    if action["destination_vnum"] is None:
+      continue
+    destination = int(action["destination_vnum"])
+    record = records[record_id]
+    target_kind = _KIND_OWNER.get(kind, kind)
+    binding = native.get((target_kind, destination))
+    owner_attachments = tuple(attachments.get((target_kind, destination), ()))
+    emitted: TransformResult
+    if kind == "mob":
+      emitted = emit_mobile(
+          record,
+          destination,
+          special_proc=binding.persisted_name if binding is not None else None,
+          special_resolved=("mobile", record.vnum) in inert_special_sources
+          or binding is not None,
+          attachments=owner_attachments,
+          required_action_bits=binding.required_flag_bits if binding is not None else (),
+          required_affect_bits=binding.required_affect_bits if binding is not None else (),
+      )
+    elif kind == "obj":
+      emitted = emit_object(
+          record,
+          destination,
+          resolve,
+          special_proc=binding.persisted_name if binding is not None else None,
+          attachments=owner_attachments,
+          required_extra_bits=binding.required_flag_bits if binding is not None else (),
+          required_value_references=(
+              binding.value_reference_slots if binding is not None else ()
+          ),
+      )
+    elif kind == "wld":
+      source_zone = _record_zone(record.basename, record.vnum, destination, intervals)
+      zone = _target_room_zone(destination, source_zone, target_ranges)
+      emitted = emit_room(
+          record,
+          destination,
+          zone,
+          resolve,
+          special_proc=binding.persisted_name if binding is not None else None,
+          attachments=owner_attachments,
+          source_zone_flags=_source_zone_flags(
+              record.basename, record.vnum, intervals, zone_records
+          ),
+          required_flag_bits=binding.required_flag_bits if binding is not None else (),
+      )
+    elif kind == "qst":
+      emitted = emit_hlquest(record, destination, resolve)
+    elif kind == "shp":
+      emitted = emit_shop(record, destination, resolve)
+    else:
+      raise RolPhase7Error(f"no Phase 7 emitter for {kind}")
+    zone = _record_zone(record.basename, record.vnum, destination, intervals)
+    directory, extension = _KIND_DIRECTORY[kind]
+    relative = f"{directory}/{zone}.{extension}"
+    if kind == "qst":
+      quest_fragments[destination].append((relative, emitted.text, record_id))
+    else:
+      generated[relative].append((destination, emitted.text, record_id))
+      record_outputs[record_id] = relative
+    if kind in _KIND_OWNER:
+      generated_targets.add((_KIND_OWNER[kind], destination))
+    transform_diagnostics.extend(
+        {
+            "source_record_id": record_id,
+            "target": relative,
+            "message": message,
+        }
+        for message in emitted.diagnostics
+    )
+
+  for destination, fragments in sorted(quest_fragments.items()):
+    ordered = sorted(fragments, key=lambda row: (row[0], row[2]))
+    relative = ordered[0][0]
+    blocks = [(destination, text, record_id) for _, text, record_id in ordered]
+    generated[relative].append(
+        (
+            destination,
+            _merge_hlquest_blocks(blocks),
+            "+".join(record_id for _, _, record_id in blocks),
+        )
+    )
+    for _, _, record_id in ordered:
+      record_outputs[record_id] = relative
+
+  for action in selected_actions:
+    if (
+        action["source_kind"] != "zon"
+        or action["action"] == "EXCLUDE"
+        or preconverted(action)
+        or action["destination_vnum"] is None
+    ):
+      continue
+    record_id = str(action["source_record_id"])
+    record = records[record_id]
+    destination = int(action["destination_vnum"])
+    interval = next(
+        (
+            (bottom, top)
+            for bottom, top, zone in intervals[record.basename]
+            if zone == destination
+            and (bottom == (81700 if record.basename == "mytheast" else record.vnum * 100))
+        ),
+        None,
+    )
+    if interval is None:
+      raise RolPhase7Error(f"cannot recover source interval for {record_id}")
+    source_top = int(list(record.values.get("header", []))[0])
+    destination_bottom, destination_top = target_ranges[destination]
+
+    def zone_resolve(kind: str, source_vnum: int) -> int:
+      if kind == "wld" and source_vnum == source_top:
+        return destination_top
+      return resolve(kind, source_vnum)
+
+    emitted = emit_zone(
+        record,
+        destination,
+        destination_bottom,
+        zone_resolve,
+    )
+    filtered_text, filter_diagnostics = _filter_zone_door_resets(
+        emitted.text, valid_exit_directions
+    )
+    emitted = TransformResult(filtered_text, [*emitted.diagnostics, *filter_diagnostics])
+    zone_outputs[destination].append((destination, emitted.text, record_id))
+    transform_diagnostics.extend(
+        {
+            "source_record_id": record_id,
+            "target": f"zon/{destination}.zon",
+            "message": message,
+        }
+        for message in emitted.diagnostics
+    )
+  for destination, blocks in sorted(zone_outputs.items()):
+    relative = f"zon/{destination}.zon"
+    generated[relative].append(
+        (
+            destination,
+            _merge_zone_blocks(blocks),
+            "+".join(record_id for _, _, record_id in blocks),
+        )
+    )
+    for _, _, record_id in blocks:
+      record_outputs[record_id] = relative
+
+  for trigger in [*soc.triggers, *special_compilation.triggers]:
+    relative = f"trg/{trigger.vnum // 100}.trg"
+    trigger_text, trigger_diagnostics = _bound_trigger_text(trigger.vnum, trigger.text)
+    generated[relative].append(
+        (trigger.vnum, trigger_text, f"trigger:{trigger.vnum}")
+    )
+    transform_diagnostics.extend(
+        {
+            "source_record_id": f"trigger:{trigger.vnum}",
+            "target": relative,
+            "message": message,
+        }
+        for message in trigger_diagnostics
+    )
+
+  output_dir.mkdir(parents=True)
+  staging_world = output_dir / "staging/world"
+  shutil.copytree(target_world, staging_world, copy_function=shutil.copy2)
+  existing_trigger_ids = _trigger_vnums(staging_world / "trg")
+  touched: set[str] = set()
+  for relative, rows in sorted(generated.items()):
+    kind = relative.split("/", 1)[0]
+    replacements: set[int] = (
+        {vnum for vnum, _, _ in rows if vnum in existing_trigger_ids}
+        if kind == "trg"
+        else set()
+    )
+    target_path = staging_world / relative
+    if kind == "zon" and target_path.exists():
+      _, baseline_blocks = _split_world_file(target_path, kind)
+      baseline_by_vnum: defaultdict[int, list[str]] = defaultdict(list)
+      for vnum, text in baseline_blocks:
+        baseline_by_vnum[vnum].append(text)
+      merged_rows: list[tuple[int, str, str]] = []
+      for vnum, text, record_id in rows:
+        if vnum in baseline_by_vnum:
+          if len(baseline_by_vnum[vnum]) != 1:
+            raise RolPhase7Error(f"baseline zone {vnum} is not unique in {target_path}")
+          text = _merge_zone_blocks(
+              [(vnum, baseline_by_vnum[vnum][0], "phase6.5-baseline"),
+               (vnum, text, record_id)]
+          )
+          replacements.add(vnum)
+        merged_rows.append((vnum, text, record_id))
+      rows = merged_rows
+    _merge_world_records(target_path, kind, rows, replacements)
+    touched.add(relative)
+    filename = relative.split("/", 1)[1]
+    index_path = staging_world / kind / "index"
+    if _ensure_index_entry(index_path, filename):
+      touched.add(f"{kind}/index")
+
+  action_by_target: defaultdict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+  for action in selected_actions:
+    kind = _KIND_OWNER.get(str(action["source_kind"]))
+    if kind is not None and action["destination_vnum"] is not None:
+      action_by_target[(kind, int(action["destination_vnum"]))].append(action)
+
+  patches: dict[
+      tuple[str, int],
+      tuple[str | None, tuple[int, ...], tuple[int, ...], tuple[int, ...]],
+  ] = {}
+  patch_candidates = set(attachments) | set(native)
+  for key, owner_actions in sorted(action_by_target.items()):
+    if key in generated_targets or not any(preconverted(action) for action in owner_actions):
+      continue
+    kind, destination = key
+    binding = native.get(key)
+    required_flags: set[int] = set(binding.required_flag_bits if binding is not None else ())
+    required_affects: set[int] = set(
+        binding.required_affect_bits if binding is not None else ()
+    )
+    if kind == "mob":
+      for action in owner_actions:
+        automatic_actions, automatic_affects = mobile_automatic_race_flags(
+            records[str(action["source_record_id"])]
+        )
+        required_flags.update(automatic_actions)
+        required_affects.update(automatic_affects)
+    if key not in patch_candidates and not required_flags and not required_affects:
+      continue
+    if kind == "obj" and binding is not None and binding.value_reference_slots:
+      raise RolPhase7Error(
+          f"preserved object {destination} requires an unimplemented value-slot rewrite"
+      )
+    patches[key] = (
+        binding.persisted_name if binding is not None else None,
+        tuple(attachments.get(key, ())),
+        tuple(sorted(required_flags)),
+        tuple(sorted(required_affects)),
+    )
+  touched.update(_patch_preserved_records(staging_world, patches))
+
+  for relative in sorted(touched):
+    source = staging_world / relative
+    destination = output_dir / "output/world" / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+
+  baseline_tree = tree_manifest(target_world)
+  staged_tree = tree_manifest(staging_world)
+  preservation = _preservation_check(baseline_tree, staged_tree, touched)
+
+  manifest_constants = load_manifest(repo_root / "scripts/world/wtool_constants.json")
+  validation_config = resolve_config(target_world, None)
+  baseline_validation_result = validate_indexed_world(
+      target_world, repo_root, manifest_constants, validation_config
+  )
+  staged_validation_result = validate_indexed_world(
+      staging_world, repo_root, manifest_constants, validation_config
+  )
+  baseline_validation = result_payload(baseline_validation_result)
+  staged_validation = result_payload(staged_validation_result)
+  baseline_validation["root"] = "sealed-phase6-5/world"
+  staged_validation["root"] = "phase7-candidate/world"
+  delta = _validation_delta(baseline_validation, staged_validation)
+  staged_model = load_indexed_world_data(
+      staging_world, repo_root, manifest_constants, validation_config
+  )
+  selected_zones = {
+      int(action["destination_vnum"])
+      for action in selected_actions
+      if action["source_kind"] == "zon" and action["destination_vnum"] is not None
+  }
+  runtime = _runtime_contract(staged_model, selected_zones)
+
+  patched_targets = set(patches)
+  dispositions: list[dict[str, Any]] = []
+  for action in selected_actions:
+    record_id = str(action["source_record_id"])
+    kind = str(action["source_kind"])
+    destination = action["destination_vnum"]
+    target_key = (_KIND_OWNER.get(kind, kind), int(destination)) if destination is not None else None
+    if record_id in _SOC_OWNER_EXCLUSIONS or action["action"] == "EXCLUDE":
+      final_action = "EXCLUDE"
+      strategy = "SMALLEST_UNIT_EXCLUSION"
+    elif preconverted(action):
+      final_action = "PATCH" if target_key in patched_targets else "KEEP"
+      strategy = "PRESERVE_CANONICAL_BASELINE"
+    elif action["action"] == "MERGE":
+      final_action = "MERGE"
+      strategy = "GENERATED_CANONICAL_MERGE"
+    elif kind == "soc":
+      final_action = "ADD"
+      strategy = "DG_COMPILED"
+    else:
+      final_action = "ADD"
+      strategy = "GENERATED_CANONICAL_ADD"
+    row = {
+        "batch": next(
+            index
+            for index, batch in enumerate(batches, start=1)
+            if str(action["basename"]) in batch
+        ),
+        "basename": action["basename"],
+        "source_record_id": record_id,
+        "source_kind": kind,
+        "source_vnum": action["source_vnum"],
+        "destination_vnum": destination,
+        "planned_action": action["action"],
+        "final_action": final_action,
+        "strategy": strategy,
+    }
+    if record_id in record_outputs:
+      row["output"] = record_outputs[record_id]
+    dispositions.append(row)
+
+  reference_exceptions = _selected_reference_exceptions(references, selected_record_ids)
+  batch_rows = [
+      {
+          "batch": index,
+          "packages": batch,
+          "package_count": len(batch),
+          "selected": index <= through_batch,
+          "milestone_after": index in {4, 8, 12},
+          "record_count": sum(
+              1 for action in actions if str(action["basename"]) in set(batch)
+          ),
+      }
+      for index, batch in enumerate(batches, start=1)
+  ]
+  package_rows = [
+      {
+          "basename": package,
+          "batch": next(index for index, batch in enumerate(batches, start=1) if package in batch),
+          "selected": package in selected_packages,
+          "record_count": sum(1 for action in actions if action["basename"] == package),
+      }
+      for package in sorted(package for batch in batches for package in batch)
+  ]
+
+  freeze = {
+      "discovery_run_id": discovery_manifest["run_id"],
+      "plan_run_id": plan_manifest["run_id"],
+      "capability_audit_run_id": capability_manifest["run_id"],
+      "phase6_run_id": phase6_manifest["run_id"],
+      "phase6_5_completion_run_id": completion_manifest["run_id"],
+      "source_tree": tree_manifest(source_root),
+      "target_tree": baseline_tree,
+  }
+  evidence: dict[str, Any] = {
+      "freeze.json": freeze,
+      "dependency-batches.json": {"batch_count": len(batches), "batches": batch_rows},
+      "compiler-summary.json": {
+          "selected_packages": len(selected_packages),
+          "selected_records": len(selected_actions),
+          "source_diagnostics": len(source_diagnostics),
+          "transform_diagnostics": len(transform_diagnostics),
+          "soc_source_records": soc.source_records,
+          "soc_source_actions": soc.source_actions,
+          "soc_triggers": len(soc.triggers),
+          "soc_attachment_owners": len(soc.attachments),
+          "special_source_bindings": special_compilation.source_bindings,
+          "native_special_rows": len(special_compilation.native_bindings),
+          "native_special_targets": len(native),
+          "special_triggers": len(special_compilation.triggers),
+          "composite_special_targets": len(_COMPOSITE_SPECIALS),
+      },
+      "change-plan.json": {
+          "through_batch": through_batch,
+          "generated_files": sorted(generated),
+          "patched_targets": [f"{kind}:{vnum}" for kind, vnum in sorted(patches)],
+          "touched_paths": sorted(touched),
+          "live_target_writes": 0,
+      },
+      "diagnostics/source.json": source_diagnostics,
+      "diagnostics/transforms.json": transform_diagnostics,
+      "diagnostics/soc.json": soc.diagnostics,
+      "diagnostics/specials.json": special_compilation.diagnostics,
+      "validation/baseline.json": baseline_validation,
+      "validation/staged.json": staged_validation,
+      "validation/delta.json": delta,
+      "validation/runtime-contract.json": runtime,
+      "validation/preservation.json": preservation,
+      "validation/staged-tree.json": staged_tree,
+  }
+
+  artifacts: list[dict[str, Any]] = []
+  for relative, payload in sorted(evidence.items()):
+    path = output_dir / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical_json(payload))
+    artifacts.append(_artifact(path, output_dir))
+  for relative in sorted(touched):
+    artifacts.append(_artifact(output_dir / "output/world" / relative, output_dir))
+  for relative, rows in (
+      ("action-ledger.jsonl", dispositions),
+      ("reference-exceptions.jsonl", reference_exceptions),
+      ("package-ledger.jsonl", package_rows),
+  ):
+    path = output_dir / relative
+    count = _write_jsonl(path, rows)
+    artifacts.append(_artifact(path, output_dir, count))
+
+  prior_runs: list[dict[str, Any]] = []
+  for prior_dir in prior_milestone_dirs:
+    prior = _verify_bundle(prior_dir, 7, "cumulative-milestone")
+    if prior.get("through_batch", 0) >= through_batch:
+      raise RolPhase7Error("prior Phase 7 milestone is not earlier than this milestone")
+    if prior.get("frozen_target_tree_sha256") != baseline_tree["tree_sha256"]:
+      raise RolPhase7Error("prior milestone does not share the sealed Phase 6.5 baseline")
+    prior_runs.append(
+        {"run_id": prior["run_id"], "through_batch": prior["through_batch"]}
+    )
+
+  seed = "\n".join(
+      artifact["sha256"]
+      for artifact in sorted(artifacts, key=lambda item: item["path"])
+      if not artifact["path"].startswith("validation/")
+  ).encode("ascii")
+  run_id = f"rol-phase7-b{through_batch}-{hashlib.sha256(seed).hexdigest()[:16]}"
+  final = through_batch == 12
+  source_parse_complete = not any(
+      row.get("severity") == "error" for row in source_diagnostics
+  )
+  manifest = {
+      "schema_version": ROL_PHASE7_SCHEMA_VERSION,
+      "tool_version": TOOL_VERSION,
+      "run_id": run_id,
+      "creation_time": _created_at(created_at),
+      "phase": 7,
+      "stage": "cumulative-milestone",
+      "through_batch": through_batch,
+      "final_milestone": final,
+      "frozen_target_tree_sha256": baseline_tree["tree_sha256"],
+      "staged_tree_sha256": staged_tree["tree_sha256"],
+      "input_runs": freeze | {"prior_milestones": prior_runs},
+      "artifacts": sorted(artifacts, key=lambda item: item["path"]),
+      "acceptance": {
+          "dependency_batches": len(batches),
+          "selected_packages": len(selected_packages),
+          "selected_records": len(selected_actions),
+          "all_selected_records_disposed": len(dispositions) == len(selected_actions),
+          "reference_exceptions_final": all(row["final"] for row in reference_exceptions),
+          "source_parse_complete": source_parse_complete,
+          "special_bindings_accounted": special_compilation.source_bindings == 1721,
+          "composite_profiles_accounted": len(_COMPOSITE_SPECIALS) == 14,
+          "soc_records_accounted": soc.source_records
+          == sum(record.kind == "soc" for record in selected_records) - sum(
+              record.record_id in _SOC_OWNER_EXCLUSIONS for record in selected_records
+          ),
+          "staged_new_active_errors": delta["new_active_errors"],
+          "staged_without_new_errors": delta["new_active_errors"] == 0,
+          "runtime_contract_pass": runtime["all_pass"],
+          "preservation_pass": preservation["pass"],
+          "live_target_writes": 0,
+          "final_records": len(dispositions) if final else None,
+          "final_packages": len(selected_packages) if final else None,
+          "phase7_complete": final
+          and len(dispositions) == 71680
+          and len(selected_packages) == 258
+          and source_parse_complete
+          and delta["new_active_errors"] == 0
+          and runtime["all_pass"]
+          and preservation["pass"],
+      },
+  }
+  manifest_path = output_dir / "run-manifest.json"
+  manifest_path.write_bytes(_canonical_json(manifest))
+  return {
+      "run_id": run_id,
+      "output_dir": output_dir.as_posix(),
+      "through_batch": through_batch,
+      "selected_packages": len(selected_packages),
+      "selected_records": len(selected_actions),
+      "generated_files": len(generated),
+      "patched_records": len(patches),
+      "soc_triggers": len(soc.triggers),
+      "special_triggers": len(special_compilation.triggers),
+      "new_active_errors": delta["new_active_errors"],
+      "runtime_contract_pass": runtime["all_pass"],
+      "preservation_pass": preservation["pass"],
+      "phase7_complete": manifest["acceptance"]["phase7_complete"],
+      "artifacts": len(artifacts) + 1,
+  }
+
+
+def render_rol_phase7_human(summary: dict[str, Any]) -> str:
+  return (
+      f"RoL Phase 7 milestone: {summary['run_id']}\n"
+      f"Output: {summary['output_dir']}\n"
+      f"Batches complete: {summary['through_batch']}/12\n"
+      f"Packages: {summary['selected_packages']}/258\n"
+      f"Records disposed: {summary['selected_records']}/71680\n"
+      f"Generated files: {summary['generated_files']}\n"
+      f"Patched preserved records: {summary['patched_records']}\n"
+      f"SOC triggers: {summary['soc_triggers']}\n"
+      f"Special triggers: {summary['special_triggers']}\n"
+      f"New active errors: {summary['new_active_errors']}\n"
+      f"Runtime contract pass: {str(summary['runtime_contract_pass']).lower()}\n"
+      f"Preservation pass: {str(summary['preservation_pass']).lower()}\n"
+      f"Phase 7 complete: {str(summary['phase7_complete']).lower()}\n"
+  )

--- a/scripts/world/wtool_lib/rol_phase8.py
+++ b/scripts/world/wtool_lib/rol_phase8.py
@@ -1,0 +1,777 @@
+"""Final integration, application, and completion evidence for the RoL corpus."""
+
+from __future__ import annotations
+
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from typing import Any, Iterable
+
+from .config import resolve_config
+from .constants import default_repo_root, load_manifest
+from .flags import decode_tokens
+from .models import TOOL_VERSION
+from .reporting import result_payload
+from .rol_phase7 import _runtime_contract, _validation_delta
+from .rol_pilot_build import (
+    _artifact,
+    _canonical_json,
+    _canonical_line,
+    _created_at,
+    _load_json,
+    _load_jsonl,
+    _sha256_path,
+    _verify_bundle,
+)
+from .rol_skeleton import tree_manifest
+from .world import load_indexed_world_data, validate_indexed_world
+
+
+ROL_PHASE8_SCHEMA_VERSION = 1
+_LOG_NAMES = ("world-tools", "cutest", "install", "syntax", "runtime")
+_ACTION_RECORD_TYPES = {
+    "zon": "zone",
+    "wld": "room",
+    "mob": "mobile",
+    "obj": "object",
+    "shp": "shop",
+    "qst": "hlquest",
+}
+_CODE_EVIDENCE_PATHS = (
+    "scripts/world/wtool_lib/cli.py",
+    "scripts/world/wtool_lib/rol_phase7.py",
+    "scripts/world/wtool_lib/rol_phase8.py",
+    "scripts/world/wtool_lib/rol_transform.py",
+    "src/db.c",
+    "src/spec/spec_assign_mobiles.c",
+    "src/spec/spec_assign_objects.c",
+    "src/spec/spec_registry.c",
+    "src/spec/spec_rol_conversion.c",
+    "src/spec/spec_rol_conversion.h",
+    "unittests/CuTest/test_spec_mechanics.c",
+)
+_DOCUMENTATION_PATHS = (
+    "docs/ongoing-projects/RoL/REALMS_OF_LUMINARI_CANONICAL_CONVERSION_PLAN.md",
+    "docs/ongoing-projects/RoL/RoL-Changelog.md",
+    "docs/ongoing-projects/README_ongoing-projects.md",
+    "docs/utilities/WORLD_VALIDATOR_CLI.md",
+    "docs/guides/TESTING_GUIDE.md",
+    "docs/CHANGELOG.md",
+    "lib/text/help/realms_of_luminari.hlp",
+    "lib/text/help/index",
+)
+
+
+class RolPhase8Error(ValueError):
+  """Raised when Phase 8 cannot prove a safe final integration."""
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+  count = 0
+  path.parent.mkdir(parents=True, exist_ok=True)
+  with path.open("wb") as output:
+    for row in rows:
+      output.write(_canonical_line(row))
+      count += 1
+  return count
+
+
+def _development_environment(lib_root: Path) -> None:
+  values: dict[str, str] = {}
+  env_path = lib_root / ".env"
+  for raw in env_path.read_text(encoding="utf-8").splitlines():
+    line = raw.strip()
+    if not line or line.startswith("#") or "=" not in line:
+      continue
+    key, value = line.split("=", 1)
+    values[key.strip()] = value.strip().strip("'\"")
+  if values.get("APP_ENV", "").casefold() not in {
+      "dev",
+      "development",
+      "local",
+      "test",
+      "testing",
+  }:
+    raise RolPhase8Error("lib/.env does not explicitly identify a development environment")
+
+
+def _phase7_paths(phase7_dir: Path) -> list[str]:
+  change_plan = _load_json(phase7_dir / "change-plan.json")
+  paths = [str(path) for path in change_plan.get("touched_paths", [])]
+  if not paths or len(paths) != len(set(paths)):
+    raise RolPhase8Error("Phase 7 touched-path plan is empty or duplicated")
+  for relative in paths:
+    source = (phase7_dir / "output/world" / relative).resolve()
+    try:
+      source.relative_to((phase7_dir / "output/world").resolve())
+    except ValueError as error:
+      raise RolPhase8Error("Phase 7 output path escapes its world root") from error
+    if not source.is_file():
+      raise RolPhase8Error(f"Phase 7 output is missing: {relative}")
+  return sorted(paths)
+
+
+def _assemble_candidate(phase7_dir: Path, baseline_world: Path, destination: Path) -> None:
+  shutil.copytree(baseline_world, destination, copy_function=shutil.copy2)
+  for relative in _phase7_paths(phase7_dir):
+    source = phase7_dir / "output/world" / relative
+    target = destination / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def _repeat_evidence(primary_dir: Path, repeat_dir: Path) -> dict[str, Any]:
+  primary = _verify_bundle(primary_dir, 7, "cumulative-milestone")
+  repeat = _verify_bundle(repeat_dir, 7, "cumulative-milestone")
+  primary_manifest = (primary_dir / "run-manifest.json").read_bytes()
+  repeat_manifest = (repeat_dir / "run-manifest.json").read_bytes()
+  primary_output = tree_manifest(primary_dir / "output/world")
+  repeat_output = tree_manifest(repeat_dir / "output/world")
+  return {
+      "primary_run_id": primary["run_id"],
+      "repeat_run_id": repeat["run_id"],
+      "manifest_byte_identical": primary_manifest == repeat_manifest,
+      "output_tree_byte_identical": primary_output["tree_sha256"]
+      == repeat_output["tree_sha256"],
+      "primary_output_tree_sha256": primary_output["tree_sha256"],
+      "repeat_output_tree_sha256": repeat_output["tree_sha256"],
+      "pass": primary["run_id"] == repeat["run_id"]
+      and primary_manifest == repeat_manifest
+      and primary_output["tree_sha256"] == repeat_output["tree_sha256"],
+  }
+
+
+def _line_format_audit(root: Path, paths: Iterable[str]) -> dict[str, Any]:
+  rows: list[dict[str, Any]] = []
+  for relative in sorted(paths):
+    data = (root / relative).read_bytes()
+    rows.append(
+        {
+            "path": relative,
+            "ascii": all(byte < 128 for byte in data),
+            "lf_only": b"\r" not in data,
+            "sha256": hashlib.sha256(data).hexdigest(),
+        }
+    )
+  return {
+      "files": rows,
+      "all_ascii": all(row["ascii"] for row in rows),
+      "all_lf_only": all(row["lf_only"] for row in rows),
+      "pass": all(row["ascii"] and row["lf_only"] for row in rows),
+  }
+
+
+def _action_audit(
+    action_rows: list[dict[str, Any]], validation: dict[str, Any]
+) -> dict[str, Any]:
+  targets = {
+      (_ACTION_RECORD_TYPES[kind], int(row["destination_vnum"]))
+      for row in action_rows
+      if (kind := str(row["source_kind"])) in _ACTION_RECORD_TYPES
+      and row.get("destination_vnum") is not None
+      and row.get("final_action") != "EXCLUDE"
+  }
+  blocking = [
+      row
+      for row in validation["findings"]
+      if row["severity"] == "error"
+      and not row.get("suppressed", False)
+      and (row.get("record_type"), row.get("vnum")) in targets
+  ]
+  actions = Counter(str(row["final_action"]) for row in action_rows)
+  kinds = Counter(str(row["source_kind"]) for row in action_rows)
+  missing_destinations = [
+      row["source_record_id"]
+      for row in action_rows
+      if row["final_action"] != "EXCLUDE" and row.get("destination_vnum") is None
+  ]
+  noncanonical = []
+  for row in action_rows:
+    destination = row.get("destination_vnum")
+    if row["final_action"] == "EXCLUDE" or destination is None:
+      continue
+    minimum = 20_000 if row["source_kind"] == "zon" else 2_000_000
+    if int(destination) < minimum:
+      noncanonical.append(str(row["source_record_id"]))
+  return {
+      "rows": len(action_rows),
+      "actions": dict(sorted(actions.items())),
+      "source_kinds": dict(sorted(kinds.items())),
+      "selected_target_records": len(targets),
+      "missing_destinations": missing_destinations,
+      "noncanonical_destinations": noncanonical,
+      "blocking_selected_record_findings": blocking,
+      "pass": len(action_rows) == 71_680
+      and not missing_destinations
+      and not noncanonical
+      and not blocking,
+  }
+
+
+def _behavior_evidence(world, selected_zones: set[int]) -> dict[str, Any]:
+  reset_counts = Counter(
+      command.command for zone in world.zones for command in zone.commands
+  )
+  exits = [exit_record for room in world.rooms for exit_record in room.exits]
+  object_traps = 0
+  for obj in world.objects:
+    decoded = decode_tokens(obj.extra_flags)
+    if 116 in decoded.bits:
+      object_traps += 1
+  hlquest_entries = sum(len(record.entries) for record in world.hlquests)
+  hlquest_commands = sum(
+      len(entry.commands) for record in world.hlquests for entry in record.entries
+  )
+  samples = {
+      "zones": sorted(selected_zones)[:20],
+      "shops": sorted(record.vnum for record in world.shops if record.vnum >= 2_000_000)[:20],
+      "hlquests": sorted(record.vnum for record in world.hlquests if record.vnum >= 2_000_000)[:20],
+      "special_mobiles": sorted(
+          record.vnum
+          for record in world.mobiles
+          if record.vnum >= 2_000_000 and record.spec_proc is not None
+      )[:20],
+      "triggered_rooms": sorted(
+          record.vnum
+          for record in world.rooms
+          if record.vnum >= 2_000_000 and record.attachments
+      )[:20],
+  }
+  counts = {
+      "zones": len(world.zones),
+      "rooms": len(world.rooms),
+      "mobiles": len(world.mobiles),
+      "objects": len(world.objects),
+      "shops": len(world.shops),
+      "triggers": len(world.triggers),
+      "quests": len(world.quests),
+      "hlquests": len(world.hlquests),
+      "hlquest_entries": hlquest_entries,
+      "hlquest_commands": hlquest_commands,
+      "reset_commands": sum(reset_counts.values()),
+      "room_exits": len(exits),
+      "keyed_exits": sum((exit_record.key_vnum or -1) > 0 for exit_record in exits),
+      "containers": sum(obj.item_type == 15 for obj in world.objects),
+      "object_traps": object_traps,
+      "exit_traps": sum(len(room.rol_exit_traps) for room in world.rooms),
+      "mobile_paths": sum(bool(mobile.path_rooms) for mobile in world.mobiles),
+      "mobile_specials": sum(mobile.spec_proc is not None for mobile in world.mobiles),
+      "object_specials": sum(obj.spec_proc is not None for obj in world.objects),
+      "room_specials": sum(room.spec_proc is not None for room in world.rooms),
+      "attachments": sum(len(room.attachments) for room in world.rooms)
+      + sum(len(mobile.attachments) for mobile in world.mobiles)
+      + sum(len(obj.attachments) for obj in world.objects),
+      "shop_products": sum(len(shop.product_vnums) for shop in world.shops),
+  }
+  required_positive = (
+      "rooms",
+      "mobiles",
+      "objects",
+      "shops",
+      "triggers",
+      "hlquests",
+      "reset_commands",
+      "room_exits",
+      "keyed_exits",
+      "containers",
+      "object_traps",
+      "exit_traps",
+      "mobile_specials",
+      "attachments",
+      "shop_products",
+  )
+  return {
+      "counts": counts,
+      "reset_commands_by_opcode": dict(sorted(reset_counts.items())),
+      "deterministic_walkthrough_samples": samples,
+      "required_positive": list(required_positive),
+      "pass": all(counts[name] > 0 for name in required_positive),
+  }
+
+
+def _read_log(path: Path, label: str) -> str:
+  if not path.is_file():
+    raise RolPhase8Error(f"{label} log is required: {path}")
+  return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _code_gates(repo_root: Path, logs: dict[str, Path]) -> dict[str, Any]:
+  if set(logs) != set(_LOG_NAMES):
+    raise RolPhase8Error("Phase 8 requires world-tools, cutest, install, syntax, and runtime logs")
+  texts = {name: _read_log(logs[name], name) for name in _LOG_NAMES}
+  world_matches = re.findall(r"Ran ([0-9]+) tests?", texts["world-tools"])
+  cutest_matches = re.findall(r"OK \(([0-9]+) tests\)", texts["cutest"])
+  converted_diagnostics = [
+      line
+      for line in (texts["syntax"] + "\n" + texts["runtime"]).splitlines()
+      if any(marker in line for marker in ("SYSERR", "ZONE ERROR", "invalid", "missing"))
+      and re.search(r"(?:#|zone\s+)20(?:[0-9]{3}|[0-9]{5,6})\b", line, re.IGNORECASE)
+  ]
+  gates = {
+      "world_tools": {
+          "passed": bool(world_matches) and "OK" in texts["world-tools"],
+          "tests": int(world_matches[-1]) if world_matches else 0,
+      },
+      "production_cutests": {
+          "passed": bool(cutest_matches),
+          "tests": int(cutest_matches[-1]) if cutest_matches else 0,
+      },
+      "install": {
+          "passed": "Installed release:" in texts["install"]
+          and (repo_root / "bin/circle").is_file()
+          and not (repo_root / "circle").exists(),
+          "root_circle_absent": not (repo_root / "circle").exists(),
+          "installed_binary_sha256": _sha256_path(repo_root / "bin/circle"),
+      },
+      "syntax_boot": {
+          "passed": "Syntax check mode enabled." in texts["syntax"]
+          and "Done." in texts["syntax"],
+      },
+      "bounded_runtime_boot": {
+          "passed": all(
+              marker in texts["runtime"]
+              for marker in (
+                  "Entering game loop.",
+                  "Resetting #20000:",
+                  "Normal termination of game.",
+              )
+          ),
+      },
+      "converted_boot_diagnostics": {
+          "passed": not converted_diagnostics,
+          "count": len(converted_diagnostics),
+          "samples": converted_diagnostics[:40],
+      },
+  }
+  gates["world_tools"]["log_sha256"] = _sha256_path(logs["world-tools"])
+  gates["production_cutests"]["log_sha256"] = _sha256_path(logs["cutest"])
+  gates["install"]["log_sha256"] = _sha256_path(logs["install"])
+  gates["syntax_boot"]["log_sha256"] = _sha256_path(logs["syntax"])
+  gates["bounded_runtime_boot"]["log_sha256"] = _sha256_path(logs["runtime"])
+  gates["converted_boot_diagnostics"]["log_sha256"] = _sha256_path(logs["runtime"])
+  return {"gates": gates, "all_pass": all(bool(row["passed"]) for row in gates.values())}
+
+
+def _code_evidence(repo_root: Path) -> dict[str, Any]:
+  rows = []
+  for relative in _CODE_EVIDENCE_PATHS:
+    path = repo_root / relative
+    if not path.is_file():
+      raise RolPhase8Error(f"Phase 8 code evidence path is missing: {relative}")
+    rows.append({"path": relative, "sha256": _sha256_path(path)})
+  return {"files": rows, "installed_binary_sha256": _sha256_path(repo_root / "bin/circle")}
+
+
+def _apply_plan(
+    baseline_world: Path, phase7_dir: Path, paths: Iterable[str]
+) -> list[dict[str, Any]]:
+  rows = []
+  for relative in sorted(paths):
+    before = baseline_world / relative
+    after = phase7_dir / "output/world" / relative
+    rows.append(
+        {
+            "path": relative,
+            "action": "REPLACE" if before.is_file() else "ADD",
+            "before_sha256": _sha256_path(before) if before.is_file() else None,
+            "after_sha256": _sha256_path(after),
+        }
+    )
+  return rows
+
+
+def write_phase8_bundle(
+    phase7_dir: Path,
+    repeat_phase7_dir: Path,
+    completion_dir: Path,
+    target_world: Path,
+    output_dir: Path,
+    logs: dict[str, Path],
+    created_at: str | None = None,
+) -> dict[str, Any]:
+  """Assemble and seal the complete, non-mutating Phase 8 release candidate."""
+
+  repo_root = default_repo_root()
+  phase7_dir = phase7_dir.resolve()
+  repeat_phase7_dir = repeat_phase7_dir.resolve()
+  completion_dir = completion_dir.resolve()
+  target_world = target_world.resolve()
+  output_dir = output_dir.resolve()
+  logs = {name: path.resolve() for name, path in logs.items()}
+  if output_dir.exists():
+    raise RolPhase8Error(f"Phase 8 output directory already exists: {output_dir}")
+  phase7 = _verify_bundle(phase7_dir, 7, "cumulative-milestone")
+  completion = _verify_bundle(completion_dir, "6.5-completion-audit")
+  if not phase7.get("acceptance", {}).get("phase7_complete"):
+    raise RolPhase8Error("Phase 8 requires the accepted final Phase 7 milestone")
+  if not completion.get("acceptance", {}).get("complete"):
+    raise RolPhase8Error("Phase 8 requires the accepted Phase 6.5 completion audit")
+  baseline_tree = tree_manifest(target_world)
+  if baseline_tree["tree_sha256"] != phase7.get("frozen_target_tree_sha256"):
+    raise RolPhase8Error("development world changed after the Phase 7 baseline freeze")
+  repeat = _repeat_evidence(phase7_dir, repeat_phase7_dir)
+  if not repeat["pass"]:
+    raise RolPhase8Error("final Phase 7 repeat generation is not byte-identical")
+
+  paths = _phase7_paths(phase7_dir)
+  with tempfile.TemporaryDirectory(prefix="rol-phase8-") as temporary:
+    candidate_world = Path(temporary) / "world"
+    _assemble_candidate(phase7_dir, target_world, candidate_world)
+    candidate_tree = tree_manifest(candidate_world)
+    if candidate_tree["tree_sha256"] != phase7.get("staged_tree_sha256"):
+      raise RolPhase8Error("Phase 8 candidate does not reproduce the accepted Phase 7 tree")
+
+    constants = load_manifest(repo_root / "scripts/world/wtool_constants.json")
+    config = resolve_config(target_world, None)
+    baseline_validation = result_payload(
+        validate_indexed_world(target_world, repo_root, constants, config)
+    )
+    candidate_validation = result_payload(
+        validate_indexed_world(candidate_world, repo_root, constants, config)
+    )
+    baseline_validation["root"] = "sealed-phase6-5/world"
+    candidate_validation["root"] = "phase8-candidate/world"
+    delta = _validation_delta(baseline_validation, candidate_validation)
+    world = load_indexed_world_data(candidate_world, repo_root, constants, config)
+    action_rows = _load_jsonl(phase7_dir / "action-ledger.jsonl")
+    action_audit = _action_audit(action_rows, candidate_validation)
+    selected_zones = {
+        int(row["destination_vnum"])
+        for row in action_rows
+        if row["source_kind"] == "zon" and row.get("destination_vnum") is not None
+    }
+    runtime = _runtime_contract(world, selected_zones)
+    behavior = _behavior_evidence(world, selected_zones)
+
+  line_format = _line_format_audit(phase7_dir / "output/world", paths)
+  code_gates = _code_gates(repo_root, logs)
+  code_evidence = _code_evidence(repo_root)
+  phase6_acceptance = completion["acceptance"]
+  namespace = {
+      "phase6_5_complete": phase6_acceptance.get("complete") is True,
+      "unresolved_required_references": phase6_acceptance.get(
+          "unresolved_required_package_references"
+      ),
+      "unclosed_consumers": phase6_acceptance.get(
+          "unclosed_runtime_configuration_persistent_consumers"
+      ),
+      "missing_saved_object_prototypes": phase6_acceptance.get(
+          "missing_saved_object_prototypes"
+      ),
+      "nonunique_saved_object_prototypes": phase6_acceptance.get(
+          "nonunique_saved_object_prototypes"
+      ),
+  }
+  namespace["pass"] = (
+      namespace["phase6_5_complete"]
+      and namespace["unresolved_required_references"] == 0
+      and namespace["unclosed_consumers"] == 0
+      and namespace["missing_saved_object_prototypes"] == 0
+      and namespace["nonunique_saved_object_prototypes"] == 0
+  )
+  apply_rows = _apply_plan(target_world, phase7_dir, paths)
+  compiler = _load_json(phase7_dir / "compiler-summary.json")
+  reconciliation = {
+      "phase7_run_id": phase7["run_id"],
+      "phase6_5_completion_run_id": completion["run_id"],
+      "packages": phase7["acceptance"]["final_packages"],
+      "records": phase7["acceptance"]["final_records"],
+      "apply_paths": len(apply_rows),
+      "compiler": compiler,
+      "reference_exceptions": len(_load_jsonl(phase7_dir / "reference-exceptions.jsonl")),
+      "baseline_tree_sha256": baseline_tree["tree_sha256"],
+      "candidate_tree_sha256": candidate_tree["tree_sha256"],
+  }
+
+  output_dir.mkdir(parents=True)
+  output_world = output_dir / "output/world"
+  for relative in paths:
+    source = phase7_dir / "output/world" / relative
+    destination = output_world / relative
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+  artifacts: list[dict[str, Any]] = []
+  evidence = {
+      "freeze.json": {
+          "phase7_manifest_sha256": _sha256_path(phase7_dir / "run-manifest.json"),
+          "repeat_phase7_manifest_sha256": _sha256_path(
+              repeat_phase7_dir / "run-manifest.json"
+          ),
+          "completion_manifest_sha256": _sha256_path(completion_dir / "run-manifest.json"),
+          "baseline_tree": baseline_tree,
+          "candidate_tree": candidate_tree,
+      },
+      "repeat-generation.json": repeat,
+      "reconciliation.json": reconciliation,
+      "namespace-audit.json": namespace,
+      "action-audit.json": action_audit,
+      "behavior-evidence.json": behavior,
+      "runtime-contract.json": runtime,
+      "line-format-audit.json": line_format,
+      "code-gates.json": code_gates,
+      "code-evidence.json": code_evidence,
+      "validation/baseline.json": baseline_validation,
+      "validation/candidate.json": candidate_validation,
+      "validation/delta.json": delta,
+  }
+  for relative, payload in sorted(evidence.items()):
+    path = output_dir / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical_json(payload))
+    artifacts.append(_artifact(path, output_dir))
+  plan_path = output_dir / "apply-plan.jsonl"
+  _write_jsonl(plan_path, apply_rows)
+  artifacts.append(_artifact(plan_path, output_dir, len(apply_rows)))
+  for name in _LOG_NAMES:
+    destination = output_dir / f"logs/{name}.log"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(logs[name], destination)
+    artifacts.append(_artifact(destination, output_dir))
+  for relative in paths:
+    artifacts.append(_artifact(output_world / relative, output_dir))
+
+  ready = all(
+      (
+          repeat["pass"],
+          delta["new_active_errors"] == 0,
+          action_audit["pass"],
+          runtime["all_pass"],
+          behavior["pass"],
+          line_format["pass"],
+          code_gates["all_pass"],
+          namespace["pass"],
+          phase7["acceptance"]["final_records"] == 71_680,
+          phase7["acceptance"]["final_packages"] == 258,
+      )
+  )
+  seed = "\n".join(
+      row["sha256"] for row in sorted(artifacts, key=lambda row: row["path"])
+  ).encode("ascii")
+  run_id = f"rol-phase8-release-{hashlib.sha256(seed).hexdigest()[:16]}"
+  manifest = {
+      "schema_version": ROL_PHASE8_SCHEMA_VERSION,
+      "tool_version": TOOL_VERSION,
+      "run_id": run_id,
+      "creation_time": _created_at(created_at),
+      "phase": 8,
+      "stage": "release-candidate",
+      "phase7_run_id": phase7["run_id"],
+      "phase6_5_completion_run_id": completion["run_id"],
+      "baseline_tree_sha256": baseline_tree["tree_sha256"],
+      "candidate_tree_sha256": candidate_tree["tree_sha256"],
+      "installed_binary_sha256": code_evidence["installed_binary_sha256"],
+      "artifacts": sorted(artifacts, key=lambda row: row["path"]),
+      "acceptance": {
+          "packages": phase7["acceptance"]["final_packages"],
+          "records": phase7["acceptance"]["final_records"],
+          "apply_paths": len(apply_rows),
+          "new_active_errors": delta["new_active_errors"],
+          "selected_records_clean": action_audit["pass"],
+          "runtime_contract_pass": runtime["all_pass"],
+          "behavior_evidence_pass": behavior["pass"],
+          "code_gates_pass": code_gates["all_pass"],
+          "namespace_audit_pass": namespace["pass"],
+          "repeat_generation_byte_identical": repeat["pass"],
+          "ready_to_apply": ready,
+      },
+  }
+  (output_dir / "run-manifest.json").write_bytes(_canonical_json(manifest))
+  return {
+      "run_id": run_id,
+      "output_dir": output_dir.as_posix(),
+      "packages": phase7["acceptance"]["final_packages"],
+      "records": phase7["acceptance"]["final_records"],
+      "apply_paths": len(apply_rows),
+      "new_active_errors": delta["new_active_errors"],
+      "ready_to_apply": ready,
+      "candidate_tree_sha256": candidate_tree["tree_sha256"],
+  }
+
+
+def apply_phase8_bundle(bundle_dir: Path, lib_root: Path) -> dict[str, Any]:
+  """Apply one hash-preconditioned Phase 8 world overlay to development."""
+
+  bundle_dir = bundle_dir.resolve()
+  lib_root = lib_root.resolve()
+  world_root = lib_root / "world"
+  _development_environment(lib_root)
+  manifest = _verify_bundle(bundle_dir, 8, "release-candidate")
+  if not manifest.get("acceptance", {}).get("ready_to_apply"):
+    raise RolPhase8Error("Phase 8 release candidate is not accepted")
+  if _sha256_path(default_repo_root() / "bin/circle") != manifest["installed_binary_sha256"]:
+    raise RolPhase8Error("installed runtime changed after Phase 8 validation")
+  current_tree = tree_manifest(world_root)["tree_sha256"]
+  if current_tree not in {
+      manifest["baseline_tree_sha256"],
+      manifest["candidate_tree_sha256"],
+  }:
+    raise RolPhase8Error("development world changed after Phase 8 staging")
+  operations: list[tuple[Path, Path]] = []
+  unchanged = 0
+  for row in _load_jsonl(bundle_dir / "apply-plan.jsonl"):
+    relative = str(row["path"])
+    source = (bundle_dir / "output/world" / relative).resolve()
+    destination = (world_root / relative).resolve()
+    try:
+      source.relative_to((bundle_dir / "output/world").resolve())
+      destination.relative_to(world_root.resolve())
+    except ValueError as error:
+      raise RolPhase8Error("Phase 8 apply path escapes its declared root") from error
+    current = _sha256_path(destination) if destination.is_file() else None
+    if current == row["after_sha256"]:
+      unchanged += 1
+      continue
+    if current != row["before_sha256"]:
+      raise RolPhase8Error(f"apply destination changed since staging: {relative}")
+    if not source.is_file() or _sha256_path(source) != row["after_sha256"]:
+      raise RolPhase8Error(f"apply source is missing or changed: {relative}")
+    operations.append((source, destination))
+  for source, destination in operations:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+  after_tree = tree_manifest(world_root)["tree_sha256"]
+  if after_tree != manifest["candidate_tree_sha256"]:
+    raise RolPhase8Error("post-apply development tree differs from the accepted candidate")
+  return {
+      "run_id": manifest["run_id"],
+      "changed_paths": len(operations),
+      "already_current_paths": unchanged,
+      "candidate_tree_sha256": after_tree,
+      "idempotent_no_op": not operations,
+  }
+
+
+def _documentation_audit(repo_root: Path) -> dict[str, Any]:
+  rows = []
+  for relative in _DOCUMENTATION_PATHS:
+    path = repo_root / relative
+    if not path.is_file():
+      rows.append({"path": relative, "present": False, "ascii": False, "lf_only": False})
+      continue
+    data = path.read_bytes()
+    rows.append(
+        {
+            "path": relative,
+            "present": True,
+            "ascii": all(byte < 128 for byte in data),
+            "lf_only": b"\r" not in data,
+            "sha256": hashlib.sha256(data).hexdigest(),
+        }
+    )
+  plan = (repo_root / _DOCUMENTATION_PATHS[0]).read_text(encoding="ascii")
+  return {
+      "files": rows,
+      "plan_marks_phase8_complete": "Status: Complete through Phase 8" in plan,
+      "pass": all(row["present"] and row["ascii"] and row["lf_only"] for row in rows)
+      and "Status: Complete through Phase 8" in plan,
+  }
+
+
+def write_phase8_completion(
+    bundle_dir: Path,
+    lib_root: Path,
+    output_dir: Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+  """Seal post-apply Phase 8 validation, documentation, and idempotency evidence."""
+
+  repo_root = default_repo_root()
+  bundle_dir = bundle_dir.resolve()
+  lib_root = lib_root.resolve()
+  output_dir = output_dir.resolve()
+  if output_dir.exists():
+    raise RolPhase8Error(f"Phase 8 completion directory already exists: {output_dir}")
+  manifest = _verify_bundle(bundle_dir, 8, "release-candidate")
+  if not manifest.get("acceptance", {}).get("ready_to_apply"):
+    raise RolPhase8Error("Phase 8 release candidate is not accepted")
+  _development_environment(lib_root)
+  world_root = lib_root / "world"
+  current_tree = tree_manifest(world_root)
+  if current_tree["tree_sha256"] != manifest["candidate_tree_sha256"]:
+    raise RolPhase8Error("Phase 8 candidate has not been applied to development")
+  constants = load_manifest(repo_root / "scripts/world/wtool_constants.json")
+  config = resolve_config(world_root, None)
+  validation = result_payload(validate_indexed_world(world_root, repo_root, constants, config))
+  validation["root"] = "development/world"
+  candidate_validation = _load_json(bundle_dir / "validation/candidate.json")
+  postapply_matches = (
+      validation["complete"] == candidate_validation["complete"]
+      and validation["summary"] == candidate_validation["summary"]
+      and validation["findings"] == candidate_validation["findings"]
+  )
+  repeat_apply = apply_phase8_bundle(bundle_dir, lib_root)
+  documentation = _documentation_audit(repo_root)
+  code_evidence = _load_json(bundle_dir / "code-evidence.json")
+  code_unchanged = all(
+      (repo_root / row["path"]).is_file()
+      and _sha256_path(repo_root / row["path"]) == row["sha256"]
+      for row in code_evidence["files"]
+  )
+  acceptance = {
+      "development_tree_matches_candidate": True,
+      "postapply_validation_matches_candidate": postapply_matches,
+      "repeat_apply_no_op": repeat_apply["idempotent_no_op"],
+      "repeat_apply_changed_paths": repeat_apply["changed_paths"],
+      "documentation_pass": documentation["pass"],
+      "runtime_code_unchanged_since_gates": code_unchanged,
+  }
+  acceptance["complete"] = all(
+      (
+          acceptance["development_tree_matches_candidate"],
+          acceptance["postapply_validation_matches_candidate"],
+          acceptance["repeat_apply_no_op"],
+          acceptance["documentation_pass"],
+          acceptance["runtime_code_unchanged_since_gates"],
+      )
+  )
+  output_dir.mkdir(parents=True)
+  evidence = {
+      "acceptance.json": acceptance,
+      "postapply-validation.json": validation,
+      "postapply-tree.json": current_tree,
+      "repeat-apply.json": repeat_apply,
+      "documentation-audit.json": documentation,
+  }
+  artifacts = []
+  for relative, payload in sorted(evidence.items()):
+    path = output_dir / relative
+    path.write_bytes(_canonical_json(payload))
+    artifacts.append(_artifact(path, output_dir))
+  seed = "\n".join(row["sha256"] for row in artifacts).encode("ascii")
+  run_id = f"rol-phase8-complete-{hashlib.sha256(seed).hexdigest()[:16]}"
+  completion_manifest = {
+      "schema_version": ROL_PHASE8_SCHEMA_VERSION,
+      "tool_version": TOOL_VERSION,
+      "run_id": run_id,
+      "creation_time": _created_at(created_at),
+      "phase": 8,
+      "stage": "completion-audit",
+      "release_run_id": manifest["run_id"],
+      "candidate_tree_sha256": manifest["candidate_tree_sha256"],
+      "artifacts": sorted(artifacts, key=lambda row: row["path"]),
+      "acceptance": acceptance,
+  }
+  (output_dir / "run-manifest.json").write_bytes(_canonical_json(completion_manifest))
+  return {
+      "run_id": run_id,
+      "output_dir": output_dir.as_posix(),
+      "release_run_id": manifest["run_id"],
+      "repeat_apply_no_op": repeat_apply["idempotent_no_op"],
+      "documentation_pass": documentation["pass"],
+      "complete": acceptance["complete"],
+  }
+
+
+def render_rol_phase8_human(summary: dict[str, Any]) -> str:
+  return (
+      f"RoL Phase 8 release: {summary['run_id']}\n"
+      f"Output: {summary['output_dir']}\n"
+      f"Packages: {summary['packages']}\n"
+      f"Records: {summary['records']}\n"
+      f"Apply paths: {summary['apply_paths']}\n"
+      f"Ready to apply: {str(summary['ready_to_apply']).lower()}\n"
+  )

--- a/scripts/world/wtool_lib/rol_source.py
+++ b/scripts/world/wtool_lib/rol_source.py
@@ -590,7 +590,27 @@ def _parse_obj(
     position = start + 1
     strings: list[str | None] = []
     strings_ok = True
-    for _ in range(4):
+    for _ in range(3):
+      position, value, ok = _read_tilde(source.lines, position, end)
+      strings.append(value)
+      strings_ok = strings_ok and ok
+    _, action_probe = _next_content(source.lines, position, end)
+    if (
+        action_probe is not None
+        and _numeric_line(action_probe)
+        and len(_integers(action_probe)) >= 3
+    ):
+      strings.append("")
+      _diagnostic(
+          corpus,
+          "ROLOBJ005",
+          "warning",
+          "source object omits its action description; synthesized an empty field",
+          action_probe,
+          "obj",
+          vnum,
+      )
+    else:
       position, value, ok = _read_tilde(source.lines, position, end)
       strings.append(value)
       strings_ok = strings_ok and ok
@@ -601,6 +621,34 @@ def _parse_obj(
         "description": strings[2],
         "action_description": strings[3],
     }
+
+    while position < end:
+      next_position, extension = _next_content(source.lines, position, end)
+      if extension is None or extension.raw.strip() != b"E":
+        break
+      position = next_position
+      position, keyword, first_ok = _read_tilde(source.lines, position, end)
+      position, description, second_ok = _read_tilde(source.lines, position, end)
+      record.directives.append(
+          {
+              "token": "E",
+              "line": extension.number,
+              "keyword": keyword,
+              "description": description,
+          }
+      )
+      if not first_ok or not second_ok:
+        record.directives[-1]["source_disposition"] = "EXCLUDE"
+      _diagnostic(
+          corpus,
+          "ROLOBJ006",
+          "warning",
+          "moved a pre-header extra description after the canonical object base rows",
+          extension,
+          "obj",
+          vnum,
+      )
+
     rows: list[SourceLine] = []
     for token in ("FLAGS", "VALUES", "ECONOMY"):
       position, line = _next_content(source.lines, position, end)

--- a/scripts/world/wtool_lib/rol_transform.py
+++ b/scripts/world/wtool_lib/rol_transform.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import re
+import textwrap
 from typing import Callable
 
 from .flags import encode_bits
@@ -13,6 +14,15 @@ from .rol_source import RolRecord
 _TARGET_MAGIC_ITEM_TYPES = frozenset({2, 3, 4, 10})
 _TARGET_MAX_LEVEL = 34
 _TARGET_MAX_OBJECT_SPELL_LEVEL = _TARGET_MAX_LEVEL
+_TARGET_MAX_LIQUID = 22
+_SOURCE_LIQUID_MAP = {
+    23: 2,  # champagne -> wine
+    24: 16, # Pepsi -> juice
+    25: 13, # unholy water -> blood
+    26: 2,  # sake -> wine
+    27: 21, # curative liquid -> herbal remedy
+    28: 10, # eggnog -> milk
+}
 _SOURCE_SPELL_MAP: dict[int, tuple[str, int | None]] = {
     9: ("full heal", 28),
     36: ("stone skin", 56),
@@ -668,6 +678,33 @@ def _tilde(value: str | None) -> tuple[str, list[str]]:
   return f"{text}~\n", diagnostics
 
 
+def _bounded_tilde(value: str | None, context: str) -> tuple[str, list[str]]:
+  """Emit a target string without exceeding the runtime's physical-line buffer."""
+
+  text, diagnostics = convert_text(value)
+  output: list[str] = []
+  wrapped = 0
+  for line in text.split("\n"):
+    if len(line.encode("ascii")) <= 480:
+      output.append(line)
+      continue
+    chunks = textwrap.wrap(
+        line,
+        width=480,
+        break_long_words=True,
+        break_on_hyphens=False,
+        replace_whitespace=False,
+        drop_whitespace=True,
+    )
+    output.extend(chunks or [""])
+    wrapped += 1
+  if wrapped:
+    diagnostics.append(
+        f"wrapped {wrapped} overlong {context} physical line(s) for the target reader"
+    )
+  return "\n".join(output) + "~\n", diagnostics
+
+
 def _source_mask_bits(mask: int, logical_offset: int) -> set[int]:
   return {
       logical_offset + bit
@@ -824,6 +861,9 @@ def _shop_message(value: str, monetary: bool = False) -> tuple[str, list[str]]:
   text = text.replace("$p", "that item").replace("$n", "I")
   if "%s" not in text:
     text = f"%s, {text}" if text else "%s."
+  if monetary and "%d" in text and text.find("%d") < text.find("%s"):
+    text = "%s, " + text.replace("%s", "you", 1)
+    diagnostics.append("moved the shop customer placeholder before the monetary placeholder")
   first_name = text.find("%s")
   text = text[: first_name + 2] + text[first_name + 2 :].replace("%s", "you")
   text = re.sub(r"%(?![%sd])", "%%", text)
@@ -1168,9 +1208,21 @@ def emit_hlquest(
   for _, entry_type, payload in sorted(entries, key=lambda item: item[0]):
     if entry_type == "M":
       assert isinstance(payload, dict)
-      keyword, text_diagnostics = _tilde(str(payload.get("keyword", "")))
+      keyword_value = str(payload.get("keyword", ""))
+      message_value = str(payload.get("message", ""))
+      if not keyword_value.strip():
+        keyword_value = "unknown"
+        diagnostics.append(
+            f"replaced an empty quest keyword at source line {payload['line']}"
+        )
+      if not message_value.strip():
+        message_value = "."
+        diagnostics.append(
+            f"replaced an empty ASK reply at source line {payload['line']}"
+        )
+      keyword, text_diagnostics = _bounded_tilde(keyword_value, "quest keyword")
       diagnostics.extend(text_diagnostics)
-      message, text_diagnostics = _tilde(str(payload.get("message", "")))
+      message, text_diagnostics = _bounded_tilde(message_value, "quest reply")
       diagnostics.extend(text_diagnostics)
       lines.extend(["A!\n", keyword, message])
       continue
@@ -1199,7 +1251,12 @@ def emit_hlquest(
           f"folded {len(disappear_messages)} disappear message(s) into the completion "
           f"reply at source line {completion['line']}"
       )
-    reply_text, text_diagnostics = _tilde(reply)
+    if not reply.strip():
+      reply = "."
+      diagnostics.append(
+          f"replaced an empty completion reply at source line {completion['line']}"
+      )
+    reply_text, text_diagnostics = _bounded_tilde(reply, "quest reply")
     diagnostics.extend(text_diagnostics)
     lines.extend(["Q!\n", reply_text])
 
@@ -1540,6 +1597,9 @@ def emit_mobile(
   position = _source_position(int(position_row[0]))
   default_position = _source_position(int(position_row[1]))
   sex = int(position_row[2]) if len(position_row) > 2 else 0
+  if sex not in {0, 1, 2}:
+    diagnostics.append(f"normalized unsupported source sex {sex} to neutral")
+    sex = 0
   lines.append(f"{position} {default_position} {sex}\n")
 
   source_class = int(position_row[3]) if len(position_row) > 3 else 0
@@ -1571,6 +1631,12 @@ def _object_values(
 ) -> list[int]:
   values = list(record.values.get("values", []))
   values = (values + [0] * 16)[:16]
+  if target_type in {17, 23} and not 0 <= values[2] <= _TARGET_MAX_LIQUID:
+    source_liquid = values[2]
+    values[2] = _SOURCE_LIQUID_MAP.get(source_liquid, 0)
+    diagnostics.append(
+        f"mapped unsupported source liquid {source_liquid} to target liquid {values[2]}"
+    )
   if target_type in _TARGET_MAGIC_ITEM_TYPES and values[0] > _TARGET_MAX_OBJECT_SPELL_LEVEL:
     diagnostics.append(
         f"capped source magic-item spell level {values[0]} at target maximum "
@@ -1606,6 +1672,13 @@ def _object_values(
     diagnostics.append(
         f"mapped source spell {source_spell} ({spell_name}) to target spell "
         f"{target_spell} in magic-item slot {slot}"
+    )
+  if target_type in {3, 4} and values[2] > values[1]:
+    source_maximum = values[1]
+    values[1] = values[2]
+    diagnostics.append(
+        f"raised source wand/staff maximum charges {source_maximum} to current "
+        f"charges {values[2]} for the target runtime"
     )
   if source_type == 15 and values[2] > 0:
     source_key = values[2]
@@ -1660,9 +1733,27 @@ def emit_object(
 
   diagnostics: list[str] = []
   strings = record.values.get("strings", {})
+  aliases = str(strings.get("aliases") or "").strip()
+  if not aliases:
+    aliases = f"converted object {destination_vnum}"
+    diagnostics.append("synthesized missing object aliases for target runtime safety")
+  short_description = str(strings.get("short_description") or "").strip()
+  if not short_description:
+    short_description = aliases
+    diagnostics.append("synthesized missing object short description for target runtime safety")
+  description = str(strings.get("description") or "").strip()
+  if not description:
+    description = f"{short_description} is here."
+    diagnostics.append("synthesized missing object room description for target runtime safety")
+  string_values = {
+      "aliases": aliases,
+      "short_description": short_description,
+      "description": description,
+      "action_description": strings.get("action_description"),
+  }
   lines = [f"#{destination_vnum}\n"]
   for key in ("aliases", "short_description", "description", "action_description"):
-    value, text_diagnostics = _tilde(strings.get(key))
+    value, text_diagnostics = _tilde(string_values.get(key))
     diagnostics.extend(text_diagnostics)
     lines.append(value)
 
@@ -1833,6 +1924,8 @@ def _emit_reset(
       if len(arguments) < 4:
         raise ValueError("requires four leading arguments")
       dependency, prototype, maximum, destination = arguments[:4]
+      if prototype <= 0:
+        raise ValueError(f"has non-positive prototype {prototype}")
       target_kind = "mob" if command == "M" else "obj"
       prototype = resolve(target_kind, prototype)
       if command in {"M", "O"}:
@@ -1854,6 +1947,8 @@ def _emit_reset(
       if len(arguments) < 3:
         raise ValueError("requires three leading arguments")
       dependency, prototype, maximum = arguments[:3]
+      if prototype <= 0:
+        raise ValueError(f"has non-positive prototype {prototype}")
       return (
           f"G {dependency} {resolve('obj', prototype)} {maximum} "
           f"{_reset_probability(command, arguments)}\n",
@@ -1864,6 +1959,8 @@ def _emit_reset(
       if len(arguments) < 4:
         raise ValueError("requires four leading arguments")
       dependency, room, direction, state = arguments[:4]
+      if room <= 0:
+        raise ValueError(f"has non-positive room {room}")
       probability = _reset_probability(command, arguments)
       if 0 <= state <= 2 and probability == 100:
         return f"D {dependency} {resolve('wld', room)} {direction} {state}\n", diagnostics
@@ -1880,6 +1977,8 @@ def _emit_reset(
       if len(arguments) < 3:
         raise ValueError("requires three leading arguments")
       dependency, room, prototype = arguments[:3]
+      if room <= 0 or prototype <= 0:
+        raise ValueError(f"has non-positive room/prototype {room}/{prototype}")
       return (
           f"R {dependency} {resolve('wld', room)} {resolve('obj', prototype)} "
           f"{_reset_probability(command, arguments)}\n",
@@ -1892,6 +1991,10 @@ def _emit_reset(
       mode, room, leader, follower = arguments[:4]
       if mode not in {0, 1, 2, 3}:
         raise ValueError(f"has unsupported follow mode {mode}")
+      if room <= 0 or leader <= 0 or follower <= 0:
+        raise ValueError(
+            f"has non-positive room/leader/follower {room}/{leader}/{follower}"
+        )
       return (
           f"F {mode} {resolve('wld', room)} {resolve('mob', leader)} "
           f"{resolve('mob', follower)} 100\n",
@@ -1902,6 +2005,8 @@ def _emit_reset(
       if len(arguments) < 3:
         raise ValueError("requires three leading arguments")
       dependency, room, prototype = arguments[:3]
+      if prototype <= 0:
+        raise ValueError(f"has non-positive prototype {prototype}")
       combat_guard = arguments[3] if len(arguments) >= 4 else 0
       target_room = resolve("wld", room) if room >= 0 else -1
       return (
@@ -1915,6 +2020,12 @@ def _emit_reset(
         raise ValueError("requires dependency, hour, day, and weekday")
       dependency, hour, day, weekday = arguments[:4]
       month = arguments[4] if len(arguments) >= 5 else 0
+      if day < 0:
+        day = 0
+      if weekday < 0:
+        weekday = 0
+      if month < 0:
+        month = 0
       return f"C {dependency} {hour} {day} {weekday} {month}\n", diagnostics
   except (KeyError, ValueError) as error:
     diagnostics.append(f"excluded malformed {command} reset at source line {line}: {error}")
@@ -1964,6 +2075,7 @@ def emit_zone(
   )
 
   current_mobile = False
+  emitted_count = 0
   for directive in record.directives:
     if directive["token"] not in {"M", "O", "P", "G", "E", "D", "R", "F", "X", "T"}:
       continue
@@ -1976,7 +2088,17 @@ def emit_zone(
     emitted, reset_diagnostics = _emit_reset(directive, resolve)
     diagnostics.extend(reset_diagnostics)
     if emitted is not None:
+      if emitted_count == 0:
+        parts = emitted.split(maxsplit=2)
+        if len(parts) >= 2 and parts[0] != "F" and parts[1] != "0":
+          diagnostics.append(
+              f"normalized the first reset dependency {parts[1]} to 0 at source line "
+              f"{directive['line']}"
+          )
+          parts[1] = "0"
+          emitted = " ".join(parts)
       lines.append(emitted)
+      emitted_count += 1
     if directive["token"] == "M":
       current_mobile = emitted is not None
   lines.extend(["S\n", "$\n"])

--- a/src/db.c
+++ b/src/db.c
@@ -5491,6 +5491,12 @@ void reset_zone(zone_rnum zone)
           }
         }
       }
+      else
+      {
+        /* Every reset command must contribute one dependency result. */
+        push_result(0);
+        tobj = NULL;
+      }
       tmob = NULL;
       break;
 

--- a/src/spec/spec_assign_mobiles.c
+++ b/src/spec/spec_assign_mobiles.c
@@ -273,9 +273,7 @@ void assign_mobiles(void)
   ASSIGNMOB(106000, cf_alathar);        // lord alathar
 
   /* Jotunheim */
-  ASSIGNMOB(2096027, thrym);
-  ASSIGNMOB(2096077, planetar);
-  ASSIGNMOB(2096070, ymir);
+  /* Converted Thrym, Planetar, and Ymir behavior is persisted in world data. */
   ASSIGNMOB(2096033, gatehouse_guard);
   ASSIGNMOB(2096032, gatehouse_guard);
   ASSIGNMOB(2096200, jot_invasion_loader); /* this will load invasion */

--- a/src/spec/spec_assign_objects.c
+++ b/src/spec/spec_assign_objects.c
@@ -185,7 +185,7 @@ void assign_objects(void)
 
   /* JOTUNHEIM EQ */
   ASSIGNOBJ(2096012, mistweave);
-  ASSIGNOBJ(2096000, frostbite);
+  /* Converted Frostbite behavior is persisted in world data. */
   ASSIGNOBJ(2096059, ymir_cloak);
   ASSIGNOBJ(2096062, vaprak_claws);
   ASSIGNOBJ(2096056, valkyrie_sword);

--- a/src/spec/spec_registry.c
+++ b/src/spec/spec_registry.c
@@ -194,6 +194,26 @@ static const struct spec_event_contract rol_object_defense_events[] = {
      SPEC_PLACEMENT_EQUIPPED | SPEC_PLACEMENT_COMBAT},
 };
 
+static const struct spec_event_contract rol_composite_mobile_events[] = {
+    {SPEC_EVENT_COMMAND, SPEC_PROTOTYPE_NONE, SPEC_PLACEMENT_NONE},
+    {SPEC_EVENT_MOBILE_ACTIVITY, SPEC_PROTOTYPE_MOB_SPEC, SPEC_PLACEMENT_NONE},
+    {SPEC_EVENT_MOBILE_COMBAT_TURN, SPEC_PROTOTYPE_MOB_SPEC, SPEC_PLACEMENT_COMBAT},
+    {SPEC_EVENT_MOBILE_DEATH, SPEC_PROTOTYPE_MOB_SPEC, SPEC_PLACEMENT_NONE},
+    {SPEC_EVENT_MOBILE_HIT, SPEC_PROTOTYPE_MOB_SPEC, SPEC_PLACEMENT_COMBAT},
+    {SPEC_EVENT_MOBILE_WAS_HIT, SPEC_PROTOTYPE_MOB_SPEC, SPEC_PLACEMENT_COMBAT},
+};
+
+static const struct spec_event_contract rol_composite_object_events[] = {
+    {SPEC_EVENT_COMMAND, SPEC_PROTOTYPE_NONE, SPEC_PLACEMENT_NONE},
+    {SPEC_EVENT_OBJECT_AUTO_PULSE, SPEC_PROTOTYPE_ITEM_AUTOPROC, SPEC_PLACEMENT_NONE},
+    {SPEC_EVENT_ITEM_IDENTIFY, SPEC_PROTOTYPE_NONE, SPEC_PLACEMENT_NONE},
+    {SPEC_EVENT_WEAPON_HIT, SPEC_PROTOTYPE_NONE, SPEC_PLACEMENT_EQUIPPED | SPEC_PLACEMENT_COMBAT},
+    {SPEC_EVENT_DEFENSE_REACTION, SPEC_PROTOTYPE_NONE,
+     SPEC_PLACEMENT_EQUIPPED | SPEC_PLACEMENT_COMBAT},
+    {SPEC_EVENT_COMBAT_MANEUVER, SPEC_PROTOTYPE_NONE,
+     SPEC_PLACEMENT_EQUIPPED | SPEC_PLACEMENT_COMBAT},
+};
+
 static const char *const guild_aliases[] = {"Guildmaster"};
 
 static const struct spec_definition spec_definitions[] = {
@@ -1739,6 +1759,34 @@ static const struct spec_definition spec_definitions[] = {
                        "behavior by exact mobile identity.",
         .legacy_handler = rol_scheduled_mobile,
     },
+    {
+        .canonical_name = "RoL Composite Mobile",
+        .display_name = "RoL Composite Mobile",
+        .owner_mask = SPEC_OWNER_MOBILE,
+        .events = rol_composite_mobile_events,
+        .event_count = SPEC_ARRAY_SIZE(rol_composite_mobile_events),
+        .binding_source_mask = SPEC_BINDING_SOURCE_WORLD,
+        .builder_visibility = SPEC_BUILDER_HIDDEN,
+        .category = "RoL Conversion",
+        .description = "Dispatches the measured multi-registration mobile profiles in the "
+                       "canonical RoL corpus.",
+        .typed_adapter = rol_composite_mobile,
+        .typed_handler = rol_composite_mobile_typed,
+    },
+    {
+        .canonical_name = "RoL Composite Object",
+        .display_name = "RoL Composite Object",
+        .owner_mask = SPEC_OWNER_OBJECT,
+        .events = rol_composite_object_events,
+        .event_count = SPEC_ARRAY_SIZE(rol_composite_object_events),
+        .binding_source_mask = SPEC_BINDING_SOURCE_WORLD,
+        .builder_visibility = SPEC_BUILDER_HIDDEN,
+        .category = "RoL Conversion",
+        .description = "Dispatches the measured multi-registration object profiles in the "
+                       "canonical RoL corpus.",
+        .typed_adapter = rol_composite_object,
+        .typed_handler = rol_composite_object_typed,
+    },
 };
 
 enum
@@ -1860,6 +1908,8 @@ enum
   SPEC_DEFINITION_ROL_UTILITY_OBJECT,
   SPEC_DEFINITION_ROL_UTILITY_ROOM,
   SPEC_DEFINITION_ROL_SCHEDULED_MOBILE,
+  SPEC_DEFINITION_ROL_COMPOSITE_MOBILE,
+  SPEC_DEFINITION_ROL_COMPOSITE_OBJECT,
   SPEC_DEFINITION_INDEX_COUNT
 };
 
@@ -1991,6 +2041,8 @@ static const struct spec_compatibility_name compatibility_names[] = {
     {SPEC_DEFINITION_ROL_UTILITY_OBJECT, -1},
     {SPEC_DEFINITION_ROL_UTILITY_ROOM, -1},
     {SPEC_DEFINITION_ROL_SCHEDULED_MOBILE, -1},
+    {SPEC_DEFINITION_ROL_COMPOSITE_MOBILE, -1},
+    {SPEC_DEFINITION_ROL_COMPOSITE_OBJECT, -1},
 };
 
 _Static_assert(SPEC_ARRAY_SIZE(compatibility_names) <= INT_MAX,

--- a/src/spec/spec_rol_conversion.c
+++ b/src/spec/spec_rol_conversion.c
@@ -31,6 +31,7 @@
 #include "spec_combat.h"
 #include "spec_context.h"
 #include "spec_dispatch.h"
+#include "spec_registry.h"
 #include "spec_rol_darkhold.h"
 #include "spec_rol_conversion.h"
 #include "spec_rol_totem.h"
@@ -61,6 +62,39 @@
 #define ROL_NEWBIE_EVIL_DESTINATION_VNUM 2023399
 #define ROL_WEIGHT_TRIGGER_ROOM_VNUM 2051400
 #define ROL_WEIGHT_TRIGGER_THRESHOLD 5000ULL
+
+struct rol_composite_profile
+{
+  int vnum;
+  size_t behavior_count;
+  const char *behaviors[3];
+};
+
+/*
+ * A prototype has one persisted SpecProc slot.  These exact source prototypes
+ * intentionally register more than one independently converted behavior, so
+ * the canonical corpus persists this bounded dispatcher instead of silently
+ * discarding one registration.
+ */
+static const struct rol_composite_profile rol_composite_mobile_profiles[] = {
+    {2007110, 2, {"RoL Bloodstone Critter", "RoL Corpse Devourer"}},
+    {2007111, 2, {"RoL Bloodstone Critter", "RoL Corpse Devourer"}},
+    {2007112, 2, {"RoL Bloodstone Critter", "RoL Corpse Devourer"}},
+    {2007141, 2, {"RoL Bloodstone Critter", "RoL Corpse Devourer"}},
+    {2007154, 2, {"RoL Corpse Devourer", "RoL Source Periodic"}},
+    {2007177, 2, {"Receptionist", "RoL Source Periodic"}},
+    {2007180, 2, {"RoL Monster Combat", "RoL Source Periodic"}},
+    {2007190, 2, {"RoL Source Periodic", "money_changer"}},
+    {2019701, 3, {"RoL Lich Energy Drain", "RoL Monster Combat", "breath_weapon_acid"}},
+    {2019750, 2, {"RoL Guild Guard", "RoL Monster Combat"}},
+    {2025400, 2, {"RoL Guild Guard", "breath_weapon_gas"}},
+    {2080220, 2, {"RoL Monster Combat", "RoL Poison Bite"}},
+    {2093202, 2, {"RoL Monster Combat", "RoL Source Periodic"}},
+};
+
+static const struct rol_composite_profile rol_composite_object_profiles[] = {
+    {2003088, 2, {"RoL Travel Portal", "RoL Utility Object"}},
+};
 
 enum rol_weapon_effect
 {
@@ -9507,6 +9541,150 @@ int rol_utility_weight_transition(bool triggered, unsigned long long weight)
   if (triggered && weight < ROL_WEIGHT_TRIGGER_THRESHOLD)
     return -1;
   return 0;
+}
+
+static const struct rol_composite_profile *
+rol_composite_profile_for(const struct rol_composite_profile *profiles, size_t profile_count,
+                          int vnum)
+{
+  size_t index;
+
+  for (index = 0; index < profile_count; index++)
+  {
+    if (profiles[index].vnum == vnum)
+      return &profiles[index];
+  }
+
+  return NULL;
+}
+
+size_t rol_composite_mobile_profile_count(void)
+{
+  return sizeof(rol_composite_mobile_profiles) / sizeof(rol_composite_mobile_profiles[0]);
+}
+
+size_t rol_composite_object_profile_count(void)
+{
+  return sizeof(rol_composite_object_profiles) / sizeof(rol_composite_object_profiles[0]);
+}
+
+bool rol_composite_mobile_profile(int mobile_vnum, size_t behavior_index,
+                                  const char **behavior_name)
+{
+  const struct rol_composite_profile *profile;
+
+  profile = rol_composite_profile_for(rol_composite_mobile_profiles,
+                                      rol_composite_mobile_profile_count(), mobile_vnum);
+  if (profile == NULL || behavior_index >= profile->behavior_count)
+    return false;
+  if (behavior_name != NULL)
+    *behavior_name = profile->behaviors[behavior_index];
+  return true;
+}
+
+bool rol_composite_object_profile(int object_vnum, size_t behavior_index,
+                                  const char **behavior_name)
+{
+  const struct rol_composite_profile *profile;
+
+  profile = rol_composite_profile_for(rol_composite_object_profiles,
+                                      rol_composite_object_profile_count(), object_vnum);
+  if (profile == NULL || behavior_index >= profile->behavior_count)
+    return false;
+  if (behavior_name != NULL)
+    *behavior_name = profile->behaviors[behavior_index];
+  return true;
+}
+
+static int rol_composite_dispatch(struct spec_event_context *context,
+                                  const struct rol_composite_profile *profile)
+{
+  const struct spec_definition *definition;
+  spec_invalidate_mask invalidation;
+  enum spec_flow flow;
+  size_t index;
+  int result;
+  int handled;
+
+  if (context == NULL || profile == NULL)
+    return FALSE;
+
+  invalidation = context->invalidation;
+  flow = context->flow;
+  handled = FALSE;
+  for (index = 0; index < profile->behavior_count; index++)
+  {
+    definition = spec_registry_find_for_owner(profile->behaviors[index], context->owner_type);
+    if (definition == NULL ||
+        !spec_definition_supports_event(definition, context->owner_type, context->event))
+      continue;
+
+    context->flow = SPEC_FLOW_CONTINUE;
+    context->invalidation = SPEC_INVALIDATE_NONE;
+    if (definition->typed_handler != NULL)
+      result = definition->typed_handler(context);
+    else
+      result = definition->legacy_handler(context->actor, context->owner, context->command,
+                                          context->argument);
+    handled = handled || result != FALSE;
+    invalidation |= context->invalidation;
+    if (context->flow == SPEC_FLOW_STOP)
+      flow = SPEC_FLOW_STOP;
+  }
+
+  context->invalidation = invalidation;
+  context->flow = flow;
+  return handled;
+}
+
+int rol_composite_mobile(struct char_data *ch, void *me, int cmd, const char *argument)
+{
+  UNUSED(ch);
+  UNUSED(me);
+  UNUSED(cmd);
+  UNUSED(argument);
+
+  return FALSE;
+}
+
+int rol_composite_mobile_typed(struct spec_event_context *context)
+{
+  struct char_data *mobile;
+  const struct rol_composite_profile *profile;
+
+  if (context == NULL || context->owner_type != SPEC_OWNER_MOBILE || context->owner == NULL)
+    return FALSE;
+  mobile = context->owner;
+  if (!IS_NPC(mobile))
+    return FALSE;
+  profile = rol_composite_profile_for(rol_composite_mobile_profiles,
+                                      rol_composite_mobile_profile_count(), GET_MOB_VNUM(mobile));
+  return rol_composite_dispatch(context, profile);
+}
+
+int rol_composite_object(struct char_data *ch, void *me, int cmd, const char *argument)
+{
+  UNUSED(ch);
+  UNUSED(me);
+  UNUSED(cmd);
+  UNUSED(argument);
+
+  return FALSE;
+}
+
+int rol_composite_object_typed(struct spec_event_context *context)
+{
+  struct obj_data *object;
+  const struct rol_composite_profile *profile;
+
+  if (context == NULL || context->owner_type != SPEC_OWNER_OBJECT || context->owner == NULL)
+    return FALSE;
+  object = context->owner;
+  if (!VALID_OBJ_RNUM(object))
+    return FALSE;
+  profile = rol_composite_profile_for(rol_composite_object_profiles,
+                                      rol_composite_object_profile_count(), GET_OBJ_VNUM(object));
+  return rol_composite_dispatch(context, profile);
 }
 
 static bool rol_utility_room_command_is(int cmd, const char *name)

--- a/src/spec/spec_rol_conversion.h
+++ b/src/spec/spec_rol_conversion.h
@@ -137,6 +137,10 @@ int rol_monster_combat_typed(struct spec_event_context *context);
 int rol_residual_mobile_typed(struct spec_event_context *context);
 int rol_utility_room(struct char_data *ch, void *me, int cmd, const char *argument);
 int rol_utility_room_typed(struct spec_event_context *context);
+int rol_composite_mobile(struct char_data *ch, void *me, int cmd, const char *argument);
+int rol_composite_mobile_typed(struct spec_event_context *context);
+int rol_composite_object(struct char_data *ch, void *me, int cmd, const char *argument);
+int rol_composite_object_typed(struct spec_event_context *context);
 
 enum rol_scheduled_gate_state rol_scheduled_gate_state_for_hour(int hour);
 enum rol_scheduled_naval_branch rol_scheduled_naval_branch_for(bool standing, bool fighting);
@@ -335,5 +339,11 @@ bool rol_handle_conjured_death(struct char_data *ch);
 bool rol_update_mobile_home_after_move(struct char_data *ch, int source_room, int destination_room);
 int rol_utility_newbie_east_destination_vnum(int race);
 int rol_utility_weight_transition(bool triggered, unsigned long long weight);
+size_t rol_composite_mobile_profile_count(void);
+size_t rol_composite_object_profile_count(void);
+bool rol_composite_mobile_profile(int mobile_vnum, size_t behavior_index,
+                                  const char **behavior_name);
+bool rol_composite_object_profile(int object_vnum, size_t behavior_index,
+                                  const char **behavior_name);
 
 #endif /* LUMINARI_SPEC_ROL_CONVERSION_H */

--- a/unittests/CuTest/test_spec_effective_binding.c
+++ b/unittests/CuTest/test_spec_effective_binding.c
@@ -636,7 +636,7 @@ void TestSpecAssignmentModulesExposeNarrowBoundaries(CuTest *tc)
             strstr(objects, "void assign_objects(") != NULL &&
             strstr(objects, "src/spec/spec_assign_objects.c:") != NULL &&
             strstr(rooms, "void assign_rooms(") != NULL &&
-            strstr(rooms, "src/spec/spec_assign_rooms.c:") != NULL && assignment_tokens == 785 &&
+            strstr(rooms, "src/spec/spec_assign_rooms.c:") != NULL && assignment_tokens == 781 &&
             strstr(assignment_header, "spec_assign_table_boot_validate") != NULL &&
             strstr(assignment_header, "spec_registry") == NULL &&
             strstr(registry_header, "get_spec_func_name(spec_legacy_handler func)") != NULL &&

--- a/unittests/CuTest/test_spec_mechanics.c
+++ b/unittests/CuTest/test_spec_mechanics.c
@@ -4338,3 +4338,29 @@ void Test_spec_rol_lich_rite_validates_irreversible_conversion_preflight(CuTest 
   complete_cmd_info = saved_complete_cmd_info;
   spec_mechanics_end(&fixture);
 }
+
+void Test_spec_rol_composite_profiles_cover_measured_multi_bindings(CuTest *tc)
+{
+  static const int mobile_vnums[] = {2007110, 2007111, 2007112, 2007141, 2007154, 2007177, 2007180,
+                                     2007190, 2019701, 2019750, 2025400, 2080220, 2093202};
+  const char *behavior;
+  size_t index;
+
+  CuAssertIntEquals(tc, 13, (int)rol_composite_mobile_profile_count());
+  CuAssertIntEquals(tc, 1, (int)rol_composite_object_profile_count());
+  for (index = 0; index < sizeof(mobile_vnums) / sizeof(mobile_vnums[0]); index++)
+  {
+    behavior = NULL;
+    CuAssertTrue(tc, rol_composite_mobile_profile(mobile_vnums[index], 0, &behavior));
+    CuAssertTrue(tc, behavior != NULL && behavior[0] != '\0');
+  }
+  CuAssertTrue(tc, !rol_composite_mobile_profile(2007110, 2, &behavior));
+  CuAssertTrue(tc, rol_composite_mobile_profile(2019701, 2, &behavior));
+  CuAssertStrEquals(tc, "breath_weapon_acid", behavior);
+  CuAssertTrue(tc, !rol_composite_mobile_profile(2019701, 3, &behavior));
+  CuAssertTrue(tc, rol_composite_object_profile(2003088, 0, &behavior));
+  CuAssertStrEquals(tc, "RoL Travel Portal", behavior);
+  CuAssertTrue(tc, rol_composite_object_profile(2003088, 1, &behavior));
+  CuAssertStrEquals(tc, "RoL Utility Object", behavior);
+  CuAssertTrue(tc, !rol_composite_object_profile(2003088, 2, &behavior));
+}

--- a/unittests/CuTest/test_spec_registry_persistence.c
+++ b/unittests/CuTest/test_spec_registry_persistence.c
@@ -524,12 +524,14 @@ void Test_spec_registry_current_name_inventory(CuTest *tc)
                                                "RoL Tarrasque Encounter",
                                                "RoL Utility Object",
                                                "RoL Utility Room",
-                                               "RoL Scheduled Mobile"};
+                                               "RoL Scheduled Mobile",
+                                               "RoL Composite Mobile",
+                                               "RoL Composite Object"};
   int expected_count;
   int index;
 
   expected_count = (int)(sizeof(expected_names) / sizeof(expected_names[0]));
-  CuAssertIntEquals(tc, 118, expected_count);
+  CuAssertIntEquals(tc, 120, expected_count);
   CuAssertIntEquals(tc, expected_count, get_spec_func_count());
 
   for (index = 0; index < expected_count; index++)
@@ -569,8 +571,8 @@ void Test_spec_registry_legacy_accessor_boundaries(CuTest *tc)
   CuAssertTrue(tc, get_spec_func_by_index(-1) == NULL);
   CuAssertTrue(tc, get_spec_func_name_by_index(count) == NULL);
   CuAssertTrue(tc, get_spec_func_by_index(count) == NULL);
-  CuAssertStrEquals(tc, "RoL Scheduled Mobile", get_spec_func_name_by_index(count - 1));
-  CuAssertTrue(tc, get_spec_func_by_index(count - 1) == rol_scheduled_mobile);
+  CuAssertStrEquals(tc, "RoL Composite Object", get_spec_func_name_by_index(count - 1));
+  CuAssertTrue(tc, get_spec_func_by_index(count - 1) == rol_composite_object);
   CuAssertTrue(tc, get_spec_func_name(NULL) == NULL);
 }
 

--- a/unittests/CuTest/test_spec_registry_validation.c
+++ b/unittests/CuTest/test_spec_registry_validation.c
@@ -186,9 +186,9 @@ void Test_spec_registry_production_metadata_validates(CuTest *tc)
   error[0] = '\0';
   CuAssert(tc, error, spec_registry_validate(error, sizeof(error)));
   CuAssertStrEquals(tc, "", error);
-  CuAssertIntEquals(tc, 117, (int)spec_registry_count());
+  CuAssertIntEquals(tc, 119, (int)spec_registry_count());
   CuAssertIntEquals(tc, 98, (int)spec_registry_legacy_count());
-  CuAssertIntEquals(tc, 19, (int)spec_registry_typed_count());
+  CuAssertIntEquals(tc, 21, (int)spec_registry_typed_count());
 
   alias_count = 0;
   for (definition_index = 0; definition_index < spec_registry_count(); definition_index++)
@@ -206,7 +206,11 @@ void Test_spec_registry_production_metadata_validates(CuTest *tc)
     CuAssertTrue(tc, (definition->legacy_handler != NULL) != (definition->typed_handler != NULL));
     if (definition->typed_handler != NULL)
       CuAssertPtrNotNull(tc, definition->typed_adapter);
-    CuAssertIntEquals(tc, SPEC_BUILDER_VISIBLE, definition->builder_visibility);
+    if (strcmp(definition->canonical_name, "RoL Composite Mobile") == 0 ||
+        strcmp(definition->canonical_name, "RoL Composite Object") == 0)
+      CuAssertIntEquals(tc, SPEC_BUILDER_HIDDEN, definition->builder_visibility);
+    else
+      CuAssertIntEquals(tc, SPEC_BUILDER_VISIBLE, definition->builder_visibility);
     CuAssertTrue(tc, spec_definition_allows_binding(definition, SPEC_BINDING_SOURCE_WORLD));
     alias_count += definition->alias_count;
   }
@@ -464,6 +468,14 @@ void Test_spec_registry_canonical_inventory_and_metadata(CuTest *tc)
       {"RoL Utility Room", rol_utility_room, SPEC_OWNER_ROOM, SPEC_EVENT_COMMAND,
        SPEC_BINDING_SOURCE_WORLD},
       {"RoL Scheduled Mobile", rol_scheduled_mobile, SPEC_OWNER_MOBILE, SPEC_EVENT_MOBILE_ACTIVITY,
+       SPEC_BINDING_SOURCE_WORLD},
+      {"RoL Composite Mobile", rol_composite_mobile, SPEC_OWNER_MOBILE,
+       SPEC_EVENT_COMMAND | SPEC_EVENT_MOBILE_ACTIVITY | SPEC_EVENT_MOBILE_COMBAT_TURN |
+           SPEC_EVENT_MOBILE_DEATH | SPEC_EVENT_MOBILE_HIT | SPEC_EVENT_MOBILE_WAS_HIT,
+       SPEC_BINDING_SOURCE_WORLD},
+      {"RoL Composite Object", rol_composite_object, SPEC_OWNER_OBJECT,
+       SPEC_EVENT_COMMAND | SPEC_EVENT_OBJECT_AUTO_PULSE | SPEC_EVENT_ITEM_IDENTIFY |
+           SPEC_EVENT_WEAPON_HIT | SPEC_EVENT_DEFENSE_REACTION | SPEC_EVENT_COMBAT_MANEUVER,
        SPEC_BINDING_SOURCE_WORLD},
   };
   const struct spec_definition *definition;

--- a/unittests/CuTest/test_spec_typed_handlers.c
+++ b/unittests/CuTest/test_spec_typed_handlers.c
@@ -179,6 +179,8 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
   const struct spec_definition *utility_object_definition;
   const struct spec_definition *utility_room_definition;
   const struct spec_definition *tarrasque_definition;
+  const struct spec_definition *composite_mobile_definition;
+  const struct spec_definition *composite_object_definition;
   struct spec_binding *binding;
   char error[256];
 
@@ -198,6 +200,8 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
   utility_object_definition = spec_registry_find_by_name("RoL Utility Object");
   utility_room_definition = spec_registry_find_by_name("RoL Utility Room");
   tarrasque_definition = spec_registry_find_by_name("RoL Tarrasque Encounter");
+  composite_mobile_definition = spec_registry_find_by_name("RoL Composite Mobile");
+  composite_object_definition = spec_registry_find_by_name("RoL Composite Object");
   CuAssertPtrNotNull(tc, bank_definition);
   CuAssertPtrNotNull(tc, cloak_definition);
   CuAssertPtrNotNull(tc, guild_guard_definition);
@@ -214,6 +218,8 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
   CuAssertPtrNotNull(tc, utility_object_definition);
   CuAssertPtrNotNull(tc, utility_room_definition);
   CuAssertPtrNotNull(tc, tarrasque_definition);
+  CuAssertPtrNotNull(tc, composite_mobile_definition);
+  CuAssertPtrNotNull(tc, composite_object_definition);
   if (bank_definition == NULL || cloak_definition == NULL || guild_guard_definition == NULL ||
       command_sentinel_definition == NULL || toll_keeper_definition == NULL ||
       banana_definition == NULL || darkhold_object_definition == NULL ||
@@ -221,10 +227,11 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
       weapon_definition == NULL || avernus_object_definition == NULL ||
       avernus_garden_definition == NULL || monster_combat_definition == NULL ||
       utility_object_definition == NULL || utility_room_definition == NULL ||
-      tarrasque_definition == NULL)
+      tarrasque_definition == NULL || composite_mobile_definition == NULL ||
+      composite_object_definition == NULL)
     return;
 
-  CuAssertIntEquals(tc, 19, (int)spec_registry_typed_count());
+  CuAssertIntEquals(tc, 21, (int)spec_registry_typed_count());
   CuAssertIntEquals(tc, 98, (int)spec_registry_legacy_count());
   CuAssertPtrEquals(tc, NULL, (void *)bank_definition->legacy_handler);
   CuAssertPtrEquals(tc, NULL, (void *)cloak_definition->legacy_handler);
@@ -244,6 +251,8 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
   CuAssertPtrNotNull(tc, (void *)utility_object_definition->typed_handler);
   CuAssertPtrNotNull(tc, (void *)utility_room_definition->typed_handler);
   CuAssertPtrNotNull(tc, (void *)tarrasque_definition->typed_handler);
+  CuAssertPtrNotNull(tc, (void *)composite_mobile_definition->typed_handler);
+  CuAssertPtrNotNull(tc, (void *)composite_object_definition->typed_handler);
   CuAssertTrue(tc, spec_definition_callback(bank_definition) == bank);
   CuAssertTrue(tc, spec_definition_callback(cloak_definition) == vampire_cloak);
   CuAssertTrue(tc, spec_definition_callback(guild_guard_definition) == rol_guild_guard);
@@ -259,6 +268,8 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
   CuAssertTrue(tc, spec_definition_callback(utility_object_definition) == rol_utility_object);
   CuAssertTrue(tc, spec_definition_callback(utility_room_definition) == rol_utility_room);
   CuAssertTrue(tc, spec_definition_callback(tarrasque_definition) == rol_tarrasque);
+  CuAssertTrue(tc, spec_definition_callback(composite_mobile_definition) == rol_composite_mobile);
+  CuAssertTrue(tc, spec_definition_callback(composite_object_definition) == rol_composite_object);
   CuAssertTrue(tc, spec_registry_find_by_handler(bank) == bank_definition);
   CuAssertTrue(tc, spec_registry_find_by_handler(vampire_cloak) == cloak_definition);
   CuAssertTrue(tc,
@@ -270,6 +281,10 @@ void Test_spec_typed_registry_preserves_callback_and_persisted_identities(CuTest
   CuAssertTrue(tc, spec_registry_find_by_handler(rol_utility_object) == utility_object_definition);
   CuAssertTrue(tc, spec_registry_find_by_handler(rol_utility_room) == utility_room_definition);
   CuAssertTrue(tc, spec_registry_find_by_handler(rol_tarrasque) == tarrasque_definition);
+  CuAssertTrue(tc,
+               spec_registry_find_by_handler(rol_composite_mobile) == composite_mobile_definition);
+  CuAssertTrue(tc,
+               spec_registry_find_by_handler(rol_composite_object) == composite_object_definition);
   CuAssertTrue(tc, spec_definition_supports_event(tarrasque_definition, SPEC_OWNER_MOBILE,
                                                   SPEC_EVENT_MOBILE_DEATH));
   CuAssertTrue(tc, spec_definition_supports_event(tarrasque_definition, SPEC_OWNER_OBJECT,


### PR DESCRIPTION
## Summary

- completes the 12-batch Phase 7 canonical corpus conversion and Phase 8 release tooling
- reconciles all 258 active packages and 71,680 selected records
- adds deterministic milestone, release, apply, repeat-generation, and completion audits
- hardens irregular source-object parsing and target-safe world transforms
- adds typed composite runtime dispatch for all 14 multi-binding special profiles
- fixes failed object-reset dependency propagation
- updates tests, operator guidance, builder documentation, and changelogs

## Why

The active Realms of Luminari corpus needed to be converted at canonical identities, integrated without overwriting existing Luminari content, and sealed with reproducible evidence. Runtime and parser gaps found during final boot validation also needed production-linked fixes.

## Validation

- make test-world-tools: 409 passed
- make test: 699 passed
- make install: passed; root circle artifact absent
- syntax boot: passed
- bounded private-MariaDB runtime boot: passed
- converted-zone runtime diagnostics: zero
- candidate and post-apply tree hashes: identical
- repeat generation: byte-identical
- repeat apply: zero changed paths
- documentation and ASCII/LF audits: passed
- commit and push hooks: passed, including compile verification

## Deployment notes

World data under lib/world, conversion evidence under lib/rol-conversion, and the runtime help file are intentionally Git-ignored deployment data. The validated development checkout retains the fully applied world; this pull request publishes the converter, runtime support, tests, and durable documentation.