### PR TITLE
Finalize RoL skill-equivalence feat availability

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,19 +11,19 @@
   d20 checks, ability scores, and the existing feat and daily-use machinery.
   - `shadow` covertly tails a target between rooms. Taking up and keeping the trail are contested
     stealth checks against the mark's perception, re-rolled on every room the mark leaves. It is
-    learnable by any class with 5 ranks of stealth.
+    learnable by any class with 21 ranks of stealth.
   - `calm` chants to end every fight in the room, resisted with a will save against
     10 + half level + charisma bonus. Limited daily uses; mind-affecting immunity ignores it.
-    It is learnable by any class with charisma 13.
+    It is learnable by any class with charisma 19.
   - `camp` pitches a wilderness campsite on a survival check set by terrain and weather, speeding
     hitpoint and movement recovery for the group while they rest and making the site their return
     point. It is learnable by any class with 3 ranks of survival.
   - `garrote` strangles a target that cannot see you from a hide-then-sneak posture, leaving it
-    silenced and staggered on a failed fortitude save. It is learnable by any class with 8 ranks of
-    stealth and base attack bonus 4.
+    silenced and staggered on a failed fortitude save. It is learnable by any class with 14 ranks
+    of stealth and base attack bonus 8.
   - `accompany` lets a grouped performer back another performer's song, raising its effectiveness
     and taking the song over when the lead falters. It is learnable by any class with 5 ranks of
-    perform.
+    perform, and bards gain it for free at level 2.
 - Added flat-file and database help for all five, plus an idempotent SQL migration and verifier.
 
 #### Fixed
@@ -41,8 +41,9 @@
 - Added production-linked CuTest coverage for camp recovery gating, accompaniment bonus
   eligibility, performance handoff with and without the song's feat, tail breaks on lost stealth
   and on combat, both-direction link cleanup, Garrote hand layouts, Calm's daily-use registry,
-  exact command wiring, class neutrality, and both maintained help sources. The full
-  fixture-backed production-linked suite passes all 853 cases.
+  exact command wiring, prerequisite values, the Bard Accompany grant, normal learnability, and
+  both maintained help sources. The full
+  fixture-backed production-linked suite passes all 854 cases.
 
 ### Native thrown weapons
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,26 +10,39 @@
   feats in `src/rol_feats.c`, keeping RoL's gameplay purpose while expressing the mechanics with
   d20 checks, ability scores, and the existing feat and daily-use machinery.
   - `shadow` covertly tails a target between rooms. Taking up and keeping the trail are contested
-    stealth checks against the mark's perception, re-rolled on every room the mark leaves.
-    Granted to rogues at 6 and rangers at 8, learnable with 5 ranks of stealth.
+    stealth checks against the mark's perception, re-rolled on every room the mark leaves. It is
+    learnable by any class with 5 ranks of stealth.
   - `calm` chants to end every fight in the room, resisted with a will save against
     10 + half level + charisma bonus. Limited daily uses; mind-affecting immunity ignores it.
-    Granted to bards at 8, learnable with charisma 13.
+    It is learnable by any class with charisma 13.
   - `camp` pitches a wilderness campsite on a survival check set by terrain and weather, speeding
     hitpoint and movement recovery for the group while they rest and making the site their return
-    point. Granted to rangers and druids at 3, learnable with 3 ranks of survival.
+    point. It is learnable by any class with 3 ranks of survival.
   - `garrote` strangles a target that cannot see you from a hide-then-sneak posture, leaving it
-    silenced and staggered on a failed fortitude save. Granted to rogues at 10 and assassins at 3,
-    learnable with 8 ranks of stealth and base attack bonus 4.
-  - `accompany` lets a grouped bard back another bard's performance, raising its effectiveness and
-    taking the song over when the lead falters. Granted to bards at 6.
+    silenced and staggered on a failed fortitude save. It is learnable by any class with 8 ranks of
+    stealth and base attack bonus 4.
+  - `accompany` lets a grouped performer back another performer's song, raising its effectiveness
+    and taking the song over when the lead falters. It is learnable by any class with 5 ranks of
+    perform.
 - Added flat-file and database help for all five, plus an idempotent SQL migration and verifier.
+
+#### Fixed
+
+- Kept campsite recovery bound to the saved campsite room, made accompaniment require continuing
+  shared group membership, and ended shadow links immediately when the tail moves away or enters
+  combat.
+- Persisted Calm's daily-use cooldown across logout and delegated Garrote's free-hand check to the
+  shared equipment accounting used by the rest of the game.
+- Aligned the flat and database help aliases, class-neutral prerequisites, implemented mechanics,
+  deterministic keyword ownership, and content verification.
 
 #### Tests
 
 - Added production-linked CuTest coverage for camp recovery gating, accompaniment bonus
   eligibility, performance handoff with and without the song's feat, tail breaks on lost stealth
-  and on combat, both-direction link cleanup, and command/feat registration.
+  and on combat, both-direction link cleanup, Garrote hand layouts, Calm's daily-use registry,
+  exact command wiring, class neutrality, and both maintained help sources. The full
+  fixture-backed production-linked suite passes all 853 cases.
 
 ### Native thrown weapons
 

--- a/docs/ongoing-projects/ROL_SKILL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SKILL_EQUIVALENCE_GAPS.md
@@ -66,7 +66,7 @@ performance machinery. Behavior lives in `src/rol_feats.c`.
 |-----------|------------------|---------|----------|------------|
 | shadow | `FEAT_SHADOW` | `shadow <target>` | Contested stealth against the mark's perception to take up the trail, re-rolled every time the mark leaves the room. Requires sneaking. Hooked into `perform_move_full()`. | Learnable by any class with 5 ranks of stealth |
 | calm | `FEAT_CALM` | `calm` | Will save against 10 + half level + charisma bonus stops each fight in the room and clears NPC memory. Mind-affecting immunity ignores it. Limited daily uses through `eROL_CALM`. | Learnable by any class with charisma 13 |
-| establish camp | `FEAT_ESTABLISH_CAMP` | `camp` | Survival check against a terrain and weather difficulty. The camp affect halves again the recovery of anyone in the group settled into it, through `hit_gain()` and `move_gain()`, and sets the campers' load room. | Learnable by any class with 3 ranks of survival |
+| establish camp | `FEAT_ESTABLISH_CAMP` | `camp` | Survival check against a terrain and weather difficulty. The camp affect adds 50 percent to the hitpoint and movement recovery of anyone in the group settled into that campsite, through `hit_gain()` and `move_gain()`, and sets the campers' load room. | Learnable by any class with 3 ranks of survival |
 | garrote | `FEAT_GARROTE` | `garrote <target>` | Attack from a hide-then-sneak posture against a target that cannot see you, needing a free hand. On a failed fortitude save against 10 + half level + dexterity bonus the target is silenced and staggered. Creatures that do not breathe are immune. | Learnable by any class with 8 ranks of stealth and BAB 4 |
 | accompany | `FEAT_ACCOMPANY` | `accompany <performer>` | A grouped performer backs the lead's performance, adding a capped effectiveness bonus from perform and instrument, and takes the song over when the lead's verse fails or stutters. | Learnable by any class with 5 ranks of perform |
 
@@ -80,19 +80,37 @@ granted by or registered as a bonus feat for any class.
 
 ## Implementation checkpoint
 
-The class-neutral conversion was validated on 2026-08-23. The production and
-CuTest binaries compile without warnings, the full fixture-backed `make test`
-run passes all 849 CuTest cases, and `make install` installs the tested server
-and removes the root-level binary. The class-neutrality test verifies that all
-five feats are learnable through the normal feat menu and absent from every
-class feat-assignment list.
+The class-neutral conversion and final lifecycle audit were validated on
+2026-08-23. The production and CuTest binaries compile without warnings, the
+full fixture-backed `make test` run passes all 853 CuTest cases, and
+`make install` installs the tested server and removes the root-level binary.
+The class-neutrality test verifies that all five feats are learnable through
+the normal feat menu and absent from every class feat-assignment list.
+
+The final audit also verifies the behavior at subsystem boundaries:
+
+- A shadow link ends immediately when the tail independently leaves the mark
+  or enters combat, and extraction clears links in both directions.
+- Calm uses the registered `eROL_CALM` daily-use event and saves that event in
+  the player `Evnt:` block, so logging out cannot reset spent uses.
+- A camp stores its full 32-bit room VNUM in fields retained by affect
+  persistence. Its recovery bonus works only while resting at that campsite,
+  not after carrying the affect into another room.
+- Garrote delegates hand accounting to `hands_available()`, including held
+  objects, shields, two-handed equipment, and characters with an extra arm.
+- Accompaniment contributes to or takes over a performance only while the
+  accompanist and lead still share a group and room.
+- The exact command handlers, command checks, and action costs are registered;
+  the flat and database help sources cover the same command keywords; and the
+  database verifier checks player access, exact keyword sets and help content.
 
 This fresh development worktree has no `lib/mysql_config` and no deployed world
 files. The validation therefore used the checked-in special-procedure world
 fixture and skipped only the database-dependent syntax boot. An unmodified
-`make test` reaches all 849 cases but reports those two missing-runtime-data
+`make test` reaches all 853 cases but reports those two missing-runtime-data
 failures; neither is related to the RoL feats. No production database was
-accessed or modified.
+accessed or modified; the idempotent SQL help migration and its read-only
+verifier are ready for the normal deployment workflow.
 
 ## Internal state markers, not player skills
 

--- a/docs/ongoing-projects/ROL_SKILL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SKILL_EQUIVALENCE_GAPS.md
@@ -64,28 +64,29 @@ performance machinery. Behavior lives in `src/rol_feats.c`.
 
 | RoL skill | LuminariMUD feat | Command | Mechanic | Availability |
 |-----------|------------------|---------|----------|------------|
-| shadow | `FEAT_SHADOW` | `shadow <target>` | Contested stealth against the mark's perception to take up the trail, re-rolled every time the mark leaves the room. Requires sneaking. Hooked into `perform_move_full()`. | Learnable by any class with 5 ranks of stealth |
-| calm | `FEAT_CALM` | `calm` | Will save against 10 + half level + charisma bonus stops each fight in the room and clears NPC memory. Mind-affecting immunity ignores it. Limited daily uses through `eROL_CALM`. | Learnable by any class with charisma 13 |
+| shadow | `FEAT_SHADOW` | `shadow <target>` | Contested stealth against the mark's perception to take up the trail, re-rolled every time the mark leaves the room. Requires sneaking. Hooked into `perform_move_full()`. | Learnable by any class with 21 ranks of stealth |
+| calm | `FEAT_CALM` | `calm` | Will save against 10 + half level + charisma bonus stops each fight in the room and clears NPC memory. Mind-affecting immunity ignores it. Limited daily uses through `eROL_CALM`. | Learnable by any class with charisma 19 |
 | establish camp | `FEAT_ESTABLISH_CAMP` | `camp` | Survival check against a terrain and weather difficulty. The camp affect adds 50 percent to the hitpoint and movement recovery of anyone in the group settled into that campsite, through `hit_gain()` and `move_gain()`, and sets the campers' load room. | Learnable by any class with 3 ranks of survival |
-| garrote | `FEAT_GARROTE` | `garrote <target>` | Attack from a hide-then-sneak posture against a target that cannot see you, needing a free hand. On a failed fortitude save against 10 + half level + dexterity bonus the target is silenced and staggered. Creatures that do not breathe are immune. | Learnable by any class with 8 ranks of stealth and BAB 4 |
-| accompany | `FEAT_ACCOMPANY` | `accompany <performer>` | A grouped performer backs the lead's performance, adding a capped effectiveness bonus from perform and instrument, and takes the song over when the lead's verse fails or stutters. | Learnable by any class with 5 ranks of perform |
+| garrote | `FEAT_GARROTE` | `garrote <target>` | Attack from a hide-then-sneak posture against a target that cannot see you, needing a free hand. On a failed fortitude save against 10 + half level + dexterity bonus the target is silenced and staggered. Creatures that do not breathe are immune. | Learnable by any class with 14 ranks of stealth and BAB 8 |
+| accompany | `FEAT_ACCOMPANY` | `accompany <performer>` | A grouped performer backs the lead's performance, adding a capped effectiveness bonus from perform and instrument, and takes the song over when the lead's verse fails or stutters. | Learnable by any class with 5 ranks of perform; bards gain it for free at level 2 |
 
 Supporting changes: `SKILL_SHADOW`, `SKILL_CALM`, `SKILL_CAMP`, `SKILL_GARROTE`
 and `SKILL_ACCOMPANY` were added as affect and damage identifiers and registered
 with `skillo()`; `SHADOWING()` and `ACCOMPANYING()` were added to
 `char_special_data` with the same lifecycle cleanup as `GUARDING()`. Help is in
 `lib/text/help/help.hlp` and `sql/components/help_rol_feat_entries.sql`, and
-coverage is in `unittests/CuTest/test_rol_feats.c`. None of the five feats is
-granted by or registered as a bonus feat for any class.
+coverage is in `unittests/CuTest/test_rol_feats.c`. Accompany is granted free to
+bards at level 2; none of the other four feats is granted by a class.
 
 ## Implementation checkpoint
 
 The class-neutral conversion and final lifecycle audit were validated on
 2026-08-23. The production and CuTest binaries compile without warnings, the
-full fixture-backed `make test` run passes all 853 CuTest cases, and
+full fixture-backed `make test` run passes all 854 CuTest cases, and
 `make install` installs the tested server and removes the root-level binary.
-The class-neutrality test verifies that all five feats are learnable through
-the normal feat menu and absent from every class feat-assignment list.
+The class-assignment test verifies that all five feats are learnable through
+the normal feat menu, that Accompany is granted only to bards at level 2, and
+that the other four feats are absent from every class feat-assignment list.
 
 The final audit also verifies the behavior at subsystem boundaries:
 
@@ -107,7 +108,7 @@ The final audit also verifies the behavior at subsystem boundaries:
 This fresh development worktree has no `lib/mysql_config` and no deployed world
 files. The validation therefore used the checked-in special-procedure world
 fixture and skipped only the database-dependent syntax boot. An unmodified
-`make test` reaches all 853 cases but reports those two missing-runtime-data
+`make test` reaches all 854 cases but reports those two missing-runtime-data
 failures; neither is related to the RoL feats. No production database was
 accessed or modified; the idempotent SQL help migration and its read-only
 verifier are ready for the normal deployment workflow.

--- a/docs/ongoing-projects/ROL_SKILL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SKILL_EQUIVALENCE_GAPS.md
@@ -1,7 +1,8 @@
 # RoL Skills Without a Close LuminariMUD Equivalent
 
 Status: re-verified against both source trees 2026-08-23. All five player-facing
-gaps have since been implemented as LuminariMUD feats; see "Ported gaps" below.
+gaps have since been implemented as class-neutral, learnable LuminariMUD feats;
+see "Ported gaps" below.
 
 This is the companion to `ROL_SPELL_EQUIVALENCE_GAPS.md`, alongside
 `ROL_RACE_EQUIVALENCE_GAPS.md`. That document covers
@@ -61,20 +62,37 @@ Each gap was re-expressed as a feat rather than as a `skillo()` percentage skill
 using d20 checks, ability scores, and the existing feat, daily-use, and
 performance machinery. Behavior lives in `src/rol_feats.c`.
 
-| RoL skill | LuminariMUD feat | Command | Mechanic | Granted by |
+| RoL skill | LuminariMUD feat | Command | Mechanic | Availability |
 |-----------|------------------|---------|----------|------------|
-| shadow | `FEAT_SHADOW` | `shadow <target>` | Contested stealth against the mark's perception to take up the trail, re-rolled every time the mark leaves the room. Requires sneaking. Hooked into `perform_move_full()`. | Rogue 6, Ranger 8; learnable with 5 ranks of stealth |
-| calm | `FEAT_CALM` | `calm` | Will save against 10 + half level + charisma bonus stops each fight in the room and clears NPC memory. Mind-affecting immunity ignores it. Limited daily uses through `eROL_CALM`. | Bard 8; learnable with charisma 13 |
-| establish camp | `FEAT_ESTABLISH_CAMP` | `camp` | Survival check against a terrain and weather difficulty. The camp affect halves again the recovery of anyone in the group settled into it, through `hit_gain()` and `move_gain()`, and sets the campers' load room. | Ranger 3, Druid 3; learnable with 3 ranks of survival |
-| garrote | `FEAT_GARROTE` | `garrote <target>` | Attack from a hide-then-sneak posture against a target that cannot see you, needing a free hand. On a failed fortitude save against 10 + half level + dexterity bonus the target is silenced and staggered. Creatures that do not breathe are immune. | Rogue 10, Assassin 3; learnable with 8 ranks of stealth and BAB 4 |
-| accompany | `FEAT_ACCOMPANY` | `accompany <performer>` | A grouped bard backs the lead's performance, adding a capped effectiveness bonus from perform and instrument, and takes the song over when the lead's verse fails or stutters. | Bard 6 |
+| shadow | `FEAT_SHADOW` | `shadow <target>` | Contested stealth against the mark's perception to take up the trail, re-rolled every time the mark leaves the room. Requires sneaking. Hooked into `perform_move_full()`. | Learnable by any class with 5 ranks of stealth |
+| calm | `FEAT_CALM` | `calm` | Will save against 10 + half level + charisma bonus stops each fight in the room and clears NPC memory. Mind-affecting immunity ignores it. Limited daily uses through `eROL_CALM`. | Learnable by any class with charisma 13 |
+| establish camp | `FEAT_ESTABLISH_CAMP` | `camp` | Survival check against a terrain and weather difficulty. The camp affect halves again the recovery of anyone in the group settled into it, through `hit_gain()` and `move_gain()`, and sets the campers' load room. | Learnable by any class with 3 ranks of survival |
+| garrote | `FEAT_GARROTE` | `garrote <target>` | Attack from a hide-then-sneak posture against a target that cannot see you, needing a free hand. On a failed fortitude save against 10 + half level + dexterity bonus the target is silenced and staggered. Creatures that do not breathe are immune. | Learnable by any class with 8 ranks of stealth and BAB 4 |
+| accompany | `FEAT_ACCOMPANY` | `accompany <performer>` | A grouped performer backs the lead's performance, adding a capped effectiveness bonus from perform and instrument, and takes the song over when the lead's verse fails or stutters. | Learnable by any class with 5 ranks of perform |
 
 Supporting changes: `SKILL_SHADOW`, `SKILL_CALM`, `SKILL_CAMP`, `SKILL_GARROTE`
 and `SKILL_ACCOMPANY` were added as affect and damage identifiers and registered
 with `skillo()`; `SHADOWING()` and `ACCOMPANYING()` were added to
 `char_special_data` with the same lifecycle cleanup as `GUARDING()`. Help is in
 `lib/text/help/help.hlp` and `sql/components/help_rol_feat_entries.sql`, and
-coverage is in `unittests/CuTest/test_rol_feats.c`.
+coverage is in `unittests/CuTest/test_rol_feats.c`. None of the five feats is
+granted by or registered as a bonus feat for any class.
+
+## Implementation checkpoint
+
+The class-neutral conversion was validated on 2026-08-23. The production and
+CuTest binaries compile without warnings, the full fixture-backed `make test`
+run passes all 849 CuTest cases, and `make install` installs the tested server
+and removes the root-level binary. The class-neutrality test verifies that all
+five feats are learnable through the normal feat menu and absent from every
+class feat-assignment list.
+
+This fresh development worktree has no `lib/mysql_config` and no deployed world
+files. The validation therefore used the checked-in special-procedure world
+fixture and skipped only the database-dependent syntax boot. An unmodified
+`make test` reaches all 849 cases but reports those two missing-runtime-data
+failures; neither is related to the RoL feats. No production database was
+accessed or modified.
 
 ## Internal state markers, not player skills
 

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -23,10 +23,10 @@ ACCOMPANY
 Usage: accompany <performer>
        accompany
 
-Requires:  the accompany feat, bard level 6
+Requires:  the accompany feat, 5 ranks of perform
 
-Instead of leading a song of your own, you back the performance of a bard
-you are grouped with in your room.  Your perform ability and instrument
+Instead of leading a song of your own, you back a grouped performer's song
+in your room.  Your perform ability and instrument
 raise the quality of every verse the lead performs, up to a cap, and if the
 lead's performance falters or stutters you take the song over rather than
 letting it end.

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -23,7 +23,8 @@ ACCOMPANY
 Usage: accompany <performer>
        accompany
 
-Requires:  the accompany feat (any class; 5 ranks of perform)
+Requires:  the accompany feat (any class; 5 ranks of perform); bards gain it
+           for free at level 2
 
 Instead of leading a song of your own, you back a grouped performer's song
 in your room.  Your perform ability and instrument raise the quality of every
@@ -3192,7 +3193,7 @@ CALM PACIFY
 
 Usage: calm
 
-Requires:  the calm feat (any class; charisma 13)
+Requires:  the calm feat (any class; charisma 19)
 Action  :  Standard Action
 Uses    :  limited per day, at least 1 plus your charisma bonus
 
@@ -10341,7 +10342,7 @@ GARROTE STRANGLE
 
 Usage: garrote <target>
 
-Requires:  the garrote feat (any class; 8 ranks of stealth and BAB 4),
+Requires:  the garrote feat (any class; 14 ranks of stealth and BAB 8),
            sneaking and hiding (in that order), and at least one free hand
 Action  :  Standard and Move Action
 
@@ -21178,7 +21179,7 @@ SHADOW TAIL
 Usage: shadow <target>
        shadow
 
-Requires:  the shadow feat (any class; 5 ranks of stealth), sneaking
+Requires:  the shadow feat (any class; 21 ranks of stealth), sneaking
 
 You covertly tail a target from room to room.  Taking up the trail is a
 contested stealth check against your mark's perception, and the contest is

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -23,13 +23,12 @@ ACCOMPANY
 Usage: accompany <performer>
        accompany
 
-Requires:  the accompany feat, 5 ranks of perform
+Requires:  the accompany feat (any class; 5 ranks of perform)
 
 Instead of leading a song of your own, you back a grouped performer's song
-in your room.  Your perform ability and instrument
-raise the quality of every verse the lead performs, up to a cap, and if the
-lead's performance falters or stutters you take the song over rather than
-letting it end.
+in your room.  Your perform ability and instrument raise the quality of every
+verse the lead performs, up to a cap, and if the lead's performance falters or
+stutters you take the song over rather than letting it end.
 
 Type accompany with no argument to stop accompanying.  You must stop your
 own performance before you can accompany someone else, and you cannot
@@ -3189,13 +3188,13 @@ the station is from your current location.  Travelling by carriage is completely
 safe from encounters.
 See Also:  SURVEY, WILDERNESS
 #0
-CALM
+CALM PACIFY
 
 Usage: calm
 
-Requires:  the calm feat
+Requires:  the calm feat (any class; charisma 13)
 Action  :  Standard Action
-Uses    :  limited per day, 1 plus your charisma bonus
+Uses    :  limited per day, at least 1 plus your charisma bonus
 
 You intone a settling chant that tries to end every fight in the room.  Each
 combatant resists with a will save against 10 + half your level + your
@@ -3210,12 +3209,12 @@ CAMP ESTABLISH-CAMP
 
 Usage: camp
 
-Requires:  the establish camp feat
+Requires:  the establish camp feat (any class; 3 ranks of survival)
 Action  :  Standard and Move Action
 Check   :  survival against a difficulty set by terrain and weather
 
 You clear a site, set your gear and get a fire going.  You and any grouped
-companions in the room recover hitpoints and movement far faster while
+companions in the room recover hitpoints and movement 50 percent faster while
 sleeping, reclining, resting or sitting in the camp, and the campsite becomes
 your return point, so quitting from camp brings you back to it.
 
@@ -10338,12 +10337,12 @@ prime-material plane, you will need to be _off_ of it.
 	YSee also:	n SPELLS CHARMEE
 	n
 #0
-GARROTE
+GARROTE STRANGLE
 
 Usage: garrote <target>
 
-Requires:  the garrote feat, sneaking and hiding (in that order),
-           no shield, no two-handed weapon and a free off hand
+Requires:  the garrote feat (any class; 8 ranks of stealth and BAB 4),
+           sneaking and hiding (in that order), and at least one free hand
 Action  :  Standard and Move Action
 
 You loop a cord around the throat of a target that cannot see you.  The
@@ -10353,7 +10352,8 @@ strangling damage, and unless the target makes a fortitude save against
 staggered for a short time.
 
 Creatures that do not breathe, such as undead, constructs, golems and
-elementals, cannot be garroted, and neither can anything incorporeal.
+elementals, cannot be garroted, and neither can anything incorporeal.  The
+target cannot be larger than you or more than one size category smaller.
 
 See also: FEAT INFO GARROTE, BACKSTAB, SAP, SNEAK, HIDE
 #0
@@ -21173,12 +21173,12 @@ POWER-SHADOW-BODY SHADOW-BODY
 	YSee also:	n PSIONICS
 	n
 #0
-SHADOW
+SHADOW TAIL
 
 Usage: shadow <target>
        shadow
 
-Requires:  the shadow feat, sneaking
+Requires:  the shadow feat (any class; 5 ranks of stealth), sneaking
 
 You covertly tail a target from room to room.  Taking up the trail is a
 contested stealth check against your mark's perception, and the contest is

--- a/sql/components/help_rol_feat_entries.sql
+++ b/sql/components/help_rol_feat_entries.sql
@@ -10,7 +10,7 @@ VALUES ('ACCOMPANY', 'Accompany
 Usage: accompany <performer>
        accompany
 
-Requires: the accompany feat (any class; 5 ranks of perform)
+Requires: the accompany feat (any class; 5 ranks of perform); bards gain it for free at level 2
 
 Instead of leading a song of your own, you back a grouped performer''s song in
 your room. Your perform ability and instrument raise the quality of every verse
@@ -32,7 +32,7 @@ VALUES ('CALM', 'Calm
 
 Usage: calm
 
-Requires: the calm feat (any class; charisma 13)
+Requires: the calm feat (any class; charisma 19)
 Action:   Standard Action
 Uses:     limited per day, at least 1 plus your charisma bonus
 
@@ -79,7 +79,7 @@ VALUES ('GARROTE', 'Garrote
 
 Usage: garrote <target>
 
-Requires: the garrote feat (any class; 8 ranks of stealth and BAB 4), sneaking
+Requires: the garrote feat (any class; 14 ranks of stealth and BAB 8), sneaking
           and hiding (in that order), and at least one free hand
 Action:   Standard and Move Action
 
@@ -106,7 +106,7 @@ VALUES ('SHADOW', 'Shadow
 Usage: shadow <target>
        shadow
 
-Requires: the shadow feat (any class; 5 ranks of stealth), sneaking
+Requires: the shadow feat (any class; 21 ranks of stealth), sneaking
 
 You covertly tail a target from room to room. Taking up the trail is a contested
 stealth check against your mark''s perception, and the contest is repeated every

--- a/sql/components/help_rol_feat_entries.sql
+++ b/sql/components/help_rol_feat_entries.sql
@@ -10,10 +10,10 @@ VALUES ('ACCOMPANY', 'Accompany
 Usage: accompany <performer>
        accompany
 
-Requires: the accompany feat, bard level 6
+Requires: the accompany feat, 5 ranks of perform
 
-Instead of leading a song of your own, you back the performance of a bard you
-are grouped with in your room. Your perform ability and instrument raise the
+Instead of leading a song of your own, you back a grouped performer''s song in
+your room. Your perform ability and instrument raise the
 quality of every verse the lead performs, up to a cap, and if the lead''s
 performance falters or stutters you take the song over rather than letting it
 end.

--- a/sql/components/help_rol_feat_entries.sql
+++ b/sql/components/help_rol_feat_entries.sql
@@ -10,19 +10,18 @@ VALUES ('ACCOMPANY', 'Accompany
 Usage: accompany <performer>
        accompany
 
-Requires: the accompany feat, 5 ranks of perform
+Requires: the accompany feat (any class; 5 ranks of perform)
 
 Instead of leading a song of your own, you back a grouped performer''s song in
-your room. Your perform ability and instrument raise the
-quality of every verse the lead performs, up to a cap, and if the lead''s
-performance falters or stutters you take the song over rather than letting it
-end.
+your room. Your perform ability and instrument raise the quality of every verse
+the lead performs, up to a cap, and if the lead''s performance falters or
+stutters you take the song over rather than letting it end.
 
 Type accompany with no argument to stop accompanying. You must stop your own
 performance before you can accompany someone else, and you cannot accompany
 while silenced.
 
-See also: PERFORM, INSTRUMENT', 0, FALSE)
+See also: PERFORM, INSTRUMENT, FEAT INFO ACCOMPANY', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
   auto_generated = VALUES(auto_generated);
 
@@ -33,15 +32,17 @@ VALUES ('CALM', 'Calm
 
 Usage: calm
 
-Requires: the calm feat
+Requires: the calm feat (any class; charisma 13)
 Action:   Standard Action
-Uses:     limited per day, 1 plus your charisma bonus
+Uses:     limited per day, at least 1 plus your charisma bonus
 
 You intone a settling chant that tries to end every fight in the room. Each
 combatant resists with a will save against 10 + half your level + your charisma
 bonus. Those who fail disengage, forget their current quarrel, and are left too
 settled to be calmed again for a few rounds. Creatures immune to mind-affecting
-effects ignore the chant, and you cannot chant while silenced.', 0, FALSE)
+effects ignore the chant, and you cannot chant while silenced.
+
+See also: FEAT INFO CALM, PACIFY', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
   auto_generated = VALUES(auto_generated);
 
@@ -53,20 +54,20 @@ VALUES ('CAMP', 'Establish Camp
 
 Usage: camp
 
-Requires: the establish camp feat
+Requires: the establish camp feat (any class; 3 ranks of survival)
 Action:   Standard and Move Action
 Check:    survival against a difficulty set by terrain and weather
 
 You clear a site, set your gear and get a fire going. You and any grouped
-companions in the room recover hitpoints and movement far faster while sleeping,
-reclining, resting or sitting in the camp, and the campsite becomes your return
-point, so quitting from camp brings you back to it.
+companions in the room recover hitpoints and movement 50 percent faster while
+sleeping, reclining, resting or sitting in the camp, and the campsite becomes
+your return point, so quitting from camp brings you back to it.
 
 Camps cannot be pitched indoors, on or under water, while flying, or during
 combat. Rough ground such as desert, marsh, mountains and the deep underdark
 raises the difficulty, as does rain or a lightning storm.
 
-See also: SURVEY, HARVEST, WILDERNESS', 0, FALSE)
+See also: FEAT INFO ESTABLISH CAMP, SURVEY, HARVEST, WILDERNESS', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
   auto_generated = VALUES(auto_generated);
 
@@ -78,8 +79,8 @@ VALUES ('GARROTE', 'Garrote
 
 Usage: garrote <target>
 
-Requires: the garrote feat, sneaking and hiding (in that order), no shield, no
-          two-handed weapon and a free off hand
+Requires: the garrote feat (any class; 8 ranks of stealth and BAB 4), sneaking
+          and hiding (in that order), and at least one free hand
 Action:   Standard and Move Action
 
 You loop a cord around the throat of a target that cannot see you. The attack
@@ -89,9 +90,10 @@ level + your dexterity bonus it is left choking: silenced and staggered for a
 short time.
 
 Creatures that do not breathe, such as undead, constructs, golems and
-elementals, cannot be garroted, and neither can anything incorporeal.
+elementals, cannot be garroted, and neither can anything incorporeal. The target
+cannot be larger than you or more than one size category smaller.
 
-See also: BACKSTAB, SAP, SNEAK, HIDE', 0, FALSE)
+See also: FEAT INFO GARROTE, BACKSTAB, SAP, SNEAK, HIDE', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
   auto_generated = VALUES(auto_generated);
 
@@ -104,7 +106,7 @@ VALUES ('SHADOW', 'Shadow
 Usage: shadow <target>
        shadow
 
-Requires: the shadow feat, sneaking
+Requires: the shadow feat (any class; 5 ranks of stealth), sneaking
 
 You covertly tail a target from room to room. Taking up the trail is a contested
 stealth check against your mark''s perception, and the contest is repeated every
@@ -118,9 +120,33 @@ break off.
 This is not the Shadowdancer shadow line: shadow jump, shadow walk, one with
 shadow and shadow master are separate abilities.
 
-See also: SNEAK, HIDE, STEALTH', 0, FALSE)
+See also: FEAT INFO SHADOW, SNEAK, HIDE, STEALTH', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
   auto_generated = VALUES(auto_generated);
 
 INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES ('SHADOW', 'SHADOW');
 INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES ('SHADOW', 'TAIL');
+
+/* Keep the maintained keyword sets exact on repeat runs. */
+DELETE FROM help_keywords
+WHERE help_tag = 'ACCOMPANY' AND keyword NOT IN ('ACCOMPANY');
+DELETE FROM help_keywords
+WHERE help_tag = 'CALM' AND keyword NOT IN ('CALM', 'PACIFY');
+DELETE FROM help_keywords
+WHERE help_tag = 'CAMP' AND keyword NOT IN ('CAMP', 'ESTABLISH-CAMP');
+DELETE FROM help_keywords
+WHERE help_tag = 'GARROTE' AND keyword NOT IN ('GARROTE', 'STRANGLE');
+DELETE FROM help_keywords
+WHERE help_tag = 'SHADOW' AND keyword NOT IN ('SHADOW', 'TAIL');
+
+/* Each exact player command has one authoritative help owner. */
+DELETE FROM help_keywords
+WHERE UPPER(keyword) = 'ACCOMPANY' AND BINARY help_tag <> 'ACCOMPANY';
+DELETE FROM help_keywords
+WHERE UPPER(keyword) = 'CALM' AND BINARY help_tag <> 'CALM';
+DELETE FROM help_keywords
+WHERE UPPER(keyword) = 'CAMP' AND BINARY help_tag <> 'CAMP';
+DELETE FROM help_keywords
+WHERE UPPER(keyword) = 'GARROTE' AND BINARY help_tag <> 'GARROTE';
+DELETE FROM help_keywords
+WHERE UPPER(keyword) = 'SHADOW' AND BINARY help_tag <> 'SHADOW';

--- a/sql/components/verify_help_rol_feat_entries.sql
+++ b/sql/components/verify_help_rol_feat_entries.sql
@@ -1,15 +1,19 @@
 -- Read-only verification for help_rol_feat_entries.sql.
 
 SELECT
-  'entry_count' AS check_name,
+  'rol_feat_entries' AS check_name,
   COUNT(*) AS actual,
   5 AS expected,
   IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
 FROM help_entries
-WHERE tag IN ('ACCOMPANY', 'CALM', 'CAMP', 'GARROTE', 'SHADOW');
+WHERE tag IN ('ACCOMPANY', 'CALM', 'CAMP', 'GARROTE', 'SHADOW')
+  AND min_level = 0
+  AND auto_generated = FALSE
+  AND entry IS NOT NULL
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
 
 SELECT
-  'keyword_count' AS check_name,
+  'rol_feat_keywords' AS check_name,
   COUNT(*) AS actual,
   9 AS expected,
   IF(COUNT(*) = 9, 'PASS', 'FAIL') AS result
@@ -25,3 +29,50 @@ WHERE (help_tag, keyword) IN (
   ('SHADOW', 'SHADOW'),
   ('SHADOW', 'TAIL')
 );
+
+SELECT
+  'rol_feat_keyword_sets' AS check_name,
+  COUNT(*) AS actual,
+  9 AS expected,
+  IF(COUNT(*) = 9, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag IN ('ACCOMPANY', 'CALM', 'CAMP', 'GARROTE', 'SHADOW');
+
+SELECT
+  'rol_feat_command_keyword_owners' AS check_name,
+  COUNT(*) AS actual,
+  0 AS expected,
+  IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE (UPPER(keyword) = 'ACCOMPANY' AND BINARY help_tag <> 'ACCOMPANY')
+   OR (UPPER(keyword) = 'CALM' AND BINARY help_tag <> 'CALM')
+   OR (UPPER(keyword) = 'CAMP' AND BINARY help_tag <> 'CAMP')
+   OR (UPPER(keyword) = 'GARROTE' AND BINARY help_tag <> 'GARROTE')
+   OR (UPPER(keyword) = 'SHADOW' AND BINARY help_tag <> 'SHADOW');
+
+SELECT
+  'rol_feat_content' AS check_name,
+  COUNT(*) AS actual,
+  17 AS expected,
+  IF(COUNT(*) = 17, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT 'ACCOMPANY' AS tag, 'any class; 5 ranks of perform' AS required_text
+  UNION ALL SELECT 'ACCOMPANY', 'grouped performer'
+  UNION ALL SELECT 'ACCOMPANY', 'take the song over'
+  UNION ALL SELECT 'CALM', 'any class; charisma 13'
+  UNION ALL SELECT 'CALM', 'at least 1 plus your charisma bonus'
+  UNION ALL SELECT 'CALM', 'mind-affecting'
+  UNION ALL SELECT 'CAMP', 'any class; 3 ranks of survival'
+  UNION ALL SELECT 'CAMP', '50 percent faster'
+  UNION ALL SELECT 'CAMP', 'return point'
+  UNION ALL SELECT 'GARROTE', 'any class; 8 ranks of stealth and BAB 4'
+  UNION ALL SELECT 'GARROTE', 'at least one free hand'
+  UNION ALL SELECT 'GARROTE', 'more than one size category smaller'
+  UNION ALL SELECT 'GARROTE', 'silenced and staggered'
+  UNION ALL SELECT 'SHADOW', 'any class; 5 ranks of stealth'
+  UNION ALL SELECT 'SHADOW', 'contested stealth check'
+  UNION ALL SELECT 'SHADOW', 'entering combat'
+  UNION ALL SELECT 'SHADOW', 'without joining a group'
+) AS expected_content ON BINARY h.tag = expected_content.tag
+WHERE INSTR(h.entry, expected_content.required_text) > 0;

--- a/sql/components/verify_help_rol_feat_entries.sql
+++ b/sql/components/verify_help_rol_feat_entries.sql
@@ -53,24 +53,25 @@ WHERE (UPPER(keyword) = 'ACCOMPANY' AND BINARY help_tag <> 'ACCOMPANY')
 SELECT
   'rol_feat_content' AS check_name,
   COUNT(*) AS actual,
-  17 AS expected,
-  IF(COUNT(*) = 17, 'PASS', 'FAIL') AS result
+  18 AS expected,
+  IF(COUNT(*) = 18, 'PASS', 'FAIL') AS result
 FROM help_entries AS h
 JOIN (
   SELECT 'ACCOMPANY' AS tag, 'any class; 5 ranks of perform' AS required_text
+  UNION ALL SELECT 'ACCOMPANY', 'bards gain it for free at level 2'
   UNION ALL SELECT 'ACCOMPANY', 'grouped performer'
   UNION ALL SELECT 'ACCOMPANY', 'take the song over'
-  UNION ALL SELECT 'CALM', 'any class; charisma 13'
+  UNION ALL SELECT 'CALM', 'any class; charisma 19'
   UNION ALL SELECT 'CALM', 'at least 1 plus your charisma bonus'
   UNION ALL SELECT 'CALM', 'mind-affecting'
   UNION ALL SELECT 'CAMP', 'any class; 3 ranks of survival'
   UNION ALL SELECT 'CAMP', '50 percent faster'
   UNION ALL SELECT 'CAMP', 'return point'
-  UNION ALL SELECT 'GARROTE', 'any class; 8 ranks of stealth and BAB 4'
+  UNION ALL SELECT 'GARROTE', 'any class; 14 ranks of stealth and BAB 8'
   UNION ALL SELECT 'GARROTE', 'at least one free hand'
   UNION ALL SELECT 'GARROTE', 'more than one size category smaller'
   UNION ALL SELECT 'GARROTE', 'silenced and staggered'
-  UNION ALL SELECT 'SHADOW', 'any class; 5 ranks of stealth'
+  UNION ALL SELECT 'SHADOW', 'any class; 21 ranks of stealth'
   UNION ALL SELECT 'SHADOW', 'contested stealth check'
   UNION ALL SELECT 'SHADOW', 'entering combat'
   UNION ALL SELECT 'SHADOW', 'without joining a group'

--- a/src/character/class.c
+++ b/src/character/class.c
@@ -6240,6 +6240,7 @@ void load_class_list(void)
   feat_assignment(CLASS_BARD, FEAT_COUNTERSONG, Y, 1, N);
   feat_assignment(CLASS_BARD, FEAT_SONG_OF_HEALING, Y, 1, N);
   feat_assignment(CLASS_BARD, FEAT_DANCE_OF_PROTECTION, Y, 2, N);
+  feat_assignment(CLASS_BARD, FEAT_ACCOMPANY, Y, 2, N);
   feat_assignment(CLASS_BARD, FEAT_SONG_OF_FOCUSED_MIND, Y, 3, N);
   feat_assignment(CLASS_BARD, FEAT_SONG_OF_HEROISM, Y, 5, N);
   feat_assignment(CLASS_BARD, FEAT_ORATORY_OF_REJUVENATION, Y, 7, N);

--- a/src/character/class.c
+++ b/src/character/class.c
@@ -4610,8 +4610,6 @@ void load_class_list(void)
   feat_assignment(CLASS_ROGUE, FEAT_SNEAK_ATTACK, Y, 23, Y);
   /* talent lvl 24, sap */
   feat_assignment(CLASS_ROGUE, FEAT_SAP, Y, 24, N);
-  feat_assignment(CLASS_ROGUE, FEAT_SHADOW, Y, 6, N);
-  feat_assignment(CLASS_ROGUE, FEAT_GARROTE, Y, 10, N);
   feat_assignment(CLASS_ROGUE, FEAT_SNEAK_ATTACK, Y, 25, Y);
   feat_assignment(CLASS_ROGUE, FEAT_TRAP_SENSE, Y, 26, Y);
   feat_assignment(CLASS_ROGUE, FEAT_SNEAK_ATTACK, Y, 27, Y);
@@ -4937,7 +4935,6 @@ void load_class_list(void)
   feat_assignment(CLASS_DRUID, FEAT_ARMOR_PROFICIENCY_SHIELD, Y, 1, N);
   feat_assignment(CLASS_DRUID, FEAT_ANIMAL_COMPANION, Y, 1, N);
   feat_assignment(CLASS_DRUID, FEAT_NATURE_SENSE, Y, 1, N);
-  feat_assignment(CLASS_DRUID, FEAT_ESTABLISH_CAMP, Y, 3, N);
   feat_assignment(CLASS_DRUID, FEAT_WILD_EMPATHY, Y, 2, N);
   feat_assignment(CLASS_DRUID, FEAT_WOODLAND_STRIDE, Y, 2, N);
   feat_assignment(CLASS_DRUID, FEAT_TRACKLESS_STEP, Y, 3, N);
@@ -6095,8 +6092,6 @@ void load_class_list(void)
   feat_assignment(CLASS_RANGER, FEAT_RAPID_SHOT, Y, 7, N);
   feat_assignment(CLASS_RANGER, FEAT_WOODLAND_STRIDE, Y, 8, N);
   feat_assignment(CLASS_RANGER, FEAT_TRACK, Y, 9, N);
-  feat_assignment(CLASS_RANGER, FEAT_ESTABLISH_CAMP, Y, 3, N);
-  feat_assignment(CLASS_RANGER, FEAT_SHADOW, Y, 8, N);
   feat_assignment(CLASS_RANGER, FEAT_EVASION, Y, 10, N);
   feat_assignment(CLASS_RANGER, FEAT_FAVORED_ENEMY_AVAILABLE, Y, 10, Y);
   /*CM*/
@@ -6247,8 +6242,6 @@ void load_class_list(void)
   feat_assignment(CLASS_BARD, FEAT_DANCE_OF_PROTECTION, Y, 2, N);
   feat_assignment(CLASS_BARD, FEAT_SONG_OF_FOCUSED_MIND, Y, 3, N);
   feat_assignment(CLASS_BARD, FEAT_SONG_OF_HEROISM, Y, 5, N);
-  feat_assignment(CLASS_BARD, FEAT_ACCOMPANY, Y, 6, N);
-  feat_assignment(CLASS_BARD, FEAT_CALM, Y, 8, N);
   feat_assignment(CLASS_BARD, FEAT_ORATORY_OF_REJUVENATION, Y, 7, N);
   feat_assignment(CLASS_BARD, FEAT_SONG_OF_FLIGHT, Y, 9, N);
   feat_assignment(CLASS_BARD, FEAT_EFFICIENT_PERFORMANCE, Y, 10, N);
@@ -8807,8 +8800,6 @@ void load_class_list(void)
 
   feat_assignment(CLASS_ASSASSIN, FEAT_POISON_SAVE_BONUS, Y, 2, Y);
   feat_assignment(CLASS_ASSASSIN, FEAT_UNCANNY_DODGE, Y, 2, N);
-  feat_assignment(CLASS_ASSASSIN, FEAT_GARROTE, Y, 3, N);
-
   feat_assignment(CLASS_ASSASSIN, FEAT_SNEAK_ATTACK, Y, 3, Y);
 
   feat_assignment(CLASS_ASSASSIN, FEAT_HIDDEN_WEAPONS, Y, 4, N);

--- a/src/character/feats.c
+++ b/src/character/feats.c
@@ -5979,11 +5979,11 @@ void assign_feats(void)
         "instead of starting one of your own.  Your perform ability and instrument raise the "
         "quality of the lead performance, and if the lead falters you take the song over rather "
         "than letting it end.  Type 'accompany' alone to stop accompanying.");
-  feat_prereq_ability(FEAT_SHADOW, ABILITY_STEALTH, 5);
-  feat_prereq_attribute(FEAT_CALM, AB_CHA, 13);
+  feat_prereq_ability(FEAT_SHADOW, ABILITY_STEALTH, 21);
+  feat_prereq_attribute(FEAT_CALM, AB_CHA, 19);
   feat_prereq_ability(FEAT_ESTABLISH_CAMP, ABILITY_SURVIVAL, 3);
-  feat_prereq_ability(FEAT_GARROTE, ABILITY_STEALTH, 8);
-  feat_prereq_bab(FEAT_GARROTE, 4);
+  feat_prereq_ability(FEAT_GARROTE, ABILITY_STEALTH, 14);
+  feat_prereq_bab(FEAT_GARROTE, 8);
   feat_prereq_ability(FEAT_ACCOMPANY, ABILITY_PERFORM, 5);
 
   /* self explanatory */

--- a/src/character/feats.c
+++ b/src/character/feats.c
@@ -5948,16 +5948,16 @@ void assign_feats(void)
         "While sneaking you can begin covertly tailing a target with 'shadow <target>'.  Starting "
         "the tail is a contested stealth check against your mark's perception, and the contest is "
         "repeated every time your mark leaves the room.  While the tail holds you move with your "
-        "mark without joining $s group and without being announced to the room.  Type 'shadow' "
-        "alone to break off.  Losing a contest, being seen, entering combat or being unable to "
-        "keep pace all end the tail.");
+        "mark without joining the mark's group and without being announced to the room.  Type "
+        "'shadow' alone to break off.  Losing a contest, being seen, entering combat or being "
+        "unable to keep pace all end the tail.");
   feato(FEAT_CALM, "calm", TRUE, TRUE, FALSE, FEAT_TYPE_GENERAL,
         "chant that stops fights in the room",
         "You intone a calming chant that attempts to end every fight in the room.  Each combatant "
         "resists with a will save against 10 + half your level + your charisma bonus.  Those that "
-        "fail disengage and are left too settled to renew the fight for a few rounds.  Creatures "
-        "immune to mind-affecting effects ignore the chant entirely.  Calm is a standard action "
-        "and is usable a limited number of times per day.");
+        "fail disengage and cannot be affected by another calm for a few rounds.  Creatures immune "
+        "to mind-affecting effects ignore the chant entirely.  Calm is a standard action and is "
+        "usable a limited number of times per day.");
   feato(FEAT_ESTABLISH_CAMP, "establish camp", TRUE, TRUE, FALSE, FEAT_TYPE_GENERAL,
         "pitch a wilderness camp that speeds recovery",
         "With 'camp' you pitch a proper camp outdoors, which requires a survival check against a "
@@ -5967,12 +5967,12 @@ void assign_feats(void)
         "be pitched indoors, underwater, while flying or while in combat.");
   feato(FEAT_GARROTE, "garrote", TRUE, TRUE, FALSE, FEAT_TYPE_COMBAT,
         "strangling attack made from concealment",
-        "While both sneaking and hiding, and with at least one hand free of a shield or "
-        "two-handed weapon, you can loop a cord around the throat of a target that cannot see "
-        "you.  A successful attack deals strangling damage and, unless the target makes a "
-        "fortitude save against 10 + half your level + your dexterity bonus, leaves it choking: "
-        "silenced and staggered for a short time.  Targets that do not breathe cannot be "
-        "garroted.  Garrote is a standard and move action.");
+        "While both sneaking and hiding, and with at least one hand free, you can loop a cord "
+        "around the throat of a target that cannot see you.  A successful attack deals "
+        "strangling damage and, unless the target makes a fortitude save against 10 + half your "
+        "level + your dexterity bonus, leaves it choking: silenced and staggered for a short "
+        "time.  Targets that do not breathe cannot be garroted.  Garrote is a standard and move "
+        "action.");
   feato(FEAT_ACCOMPANY, "accompany", TRUE, TRUE, FALSE, FEAT_TYPE_GENERAL,
         "join and support another performer's song",
         "With 'accompany <performer>' you join a grouped performer's song in your room "

--- a/src/character/feats.c
+++ b/src/character/feats.c
@@ -5973,9 +5973,9 @@ void assign_feats(void)
         "fortitude save against 10 + half your level + your dexterity bonus, leaves it choking: "
         "silenced and staggered for a short time.  Targets that do not breathe cannot be "
         "garroted.  Garrote is a standard and move action.");
-  feato(FEAT_ACCOMPANY, "accompany", TRUE, FALSE, FALSE, FEAT_TYPE_PERFORMANCE,
+  feato(FEAT_ACCOMPANY, "accompany", TRUE, TRUE, FALSE, FEAT_TYPE_GENERAL,
         "join and support another performer's song",
-        "With 'accompany <performer>' you join the performance of a grouped bard in your room "
+        "With 'accompany <performer>' you join a grouped performer's song in your room "
         "instead of starting one of your own.  Your perform ability and instrument raise the "
         "quality of the lead performance, and if the lead falters you take the song over rather "
         "than letting it end.  Type 'accompany' alone to stop accompanying.");
@@ -5984,6 +5984,7 @@ void assign_feats(void)
   feat_prereq_ability(FEAT_ESTABLISH_CAMP, ABILITY_SURVIVAL, 3);
   feat_prereq_ability(FEAT_GARROTE, ABILITY_STEALTH, 8);
   feat_prereq_bab(FEAT_GARROTE, 4);
+  feat_prereq_ability(FEAT_ACCOMPANY, ABILITY_PERFORM, 5);
 
   /* self explanatory */
   feato(FEAT_LAST_FEAT, "do not take me", FALSE, FALSE, FALSE, FEAT_TYPE_NONE, "placeholder feat",

--- a/src/combat/fight.c
+++ b/src/combat/fight.c
@@ -1775,6 +1775,9 @@ bool set_fighting(struct char_data *ch, struct char_data *vict)
   FIGHTING(ch) = vict;
   GET_WARBEAT_USED(ch) = 0;
 
+  /* entering combat immediately ends any covert tail this character held */
+  stop_shadowing(ch, TRUE);
+
   if (!CONFIG_PK_ALLOWED)
     check_killer(ch, vict);
 

--- a/src/movement/movement.c
+++ b/src/movement/movement.c
@@ -1089,6 +1089,9 @@ int perform_move_full(struct char_data *ch, int dir, int need_specials_check, bo
     if (!do_simple_move(ch, dir, need_specials_check))
       return (0);
 
+    /* moving independently ends a covert tail once the mark is left behind */
+    shadow_movement_complete(ch);
+
     /* anyone tailing this character tries to keep up, unannounced */
     shadowers_follow(ch, was_in, dir);
 

--- a/src/players.c
+++ b/src/players.c
@@ -3921,6 +3921,9 @@ bool save_char_checked(struct char_data *ch, int mode)
       BUFFER_WRITE("%d %ld %d\n", pMudEvent->iId, event_time(pMudEvent->pEvent),
                    get_daily_uses(ch, FEAT_DRAGOON_POINTS) -
                        daily_uses_remaining(ch, FEAT_DRAGOON_POINTS));
+    if ((pMudEvent = char_has_mud_event(ch, eROL_CALM)))
+      BUFFER_WRITE("%d %ld %d\n", pMudEvent->iId, event_time(pMudEvent->pEvent),
+                   get_daily_uses(ch, FEAT_CALM) - daily_uses_remaining(ch, FEAT_CALM));
     if ((pMudEvent = char_has_mud_event(ch, eC_DRAGONMOUNT)))
       BUFFER_WRITE("%d %ld %d\n", pMudEvent->iId, event_time(pMudEvent->pEvent),
                    get_daily_uses(ch, FEAT_DRAGON_BOND) -

--- a/src/rol_feats.c
+++ b/src/rol_feats.c
@@ -102,6 +102,16 @@ static void shadow_tail_broken(struct char_data *tail, struct char_data *mark, b
   }
 }
 
+/* A tail moving independently loses a mark that is no longer in the room. */
+void shadow_movement_complete(struct char_data *ch)
+{
+  if (ch == NULL || SHADOWING(ch) == NULL)
+    return;
+
+  if (IN_ROOM(ch) == NOWHERE || IN_ROOM(SHADOWING(ch)) != IN_ROOM(ch))
+    shadow_tail_broken(ch, SHADOWING(ch), FALSE);
+}
+
 /* called from perform_move_full() once the mark has changed rooms */
 void shadowers_follow(struct char_data *ch, room_rnum was_in, int dir)
 {
@@ -347,26 +357,48 @@ static int camp_difficulty(struct char_data *ch)
   return dc;
 }
 
-/* extra hitpoint, movement and psp recovery for anyone resting in a camp */
+/* recover the persistent 32-bit room vnum packed into the affect's two short fields */
+static room_vnum camp_affect_room(const struct affected_type *af)
+{
+  uint32_t encoded_room = 0;
+
+  if (af == NULL)
+    return NOWHERE;
+
+  encoded_room = ((uint32_t)(uint16_t)af->specific << 16) | (uint16_t)af->modifier;
+  return (room_vnum)encoded_room;
+}
+
+/* extra hitpoint and movement recovery for anyone resting at their campsite */
 int camp_recovery_bonus(struct char_data *ch, int gain)
 {
-  if (ch == NULL || !affected_by_spell(ch, SKILL_CAMP))
+  struct affected_type *af = NULL;
+
+  if (ch == NULL || !VALID_ROOM_RNUM(IN_ROOM(ch)))
     return 0;
 
   if (GET_POS(ch) < POS_SLEEPING || GET_POS(ch) > POS_SITTING)
     return 0;
 
-  return gain / 2;
+  for (af = ch->affected; af; af = af->next)
+    if (af->spell == SKILL_CAMP && camp_affect_room(af) == GET_ROOM_VNUM(IN_ROOM(ch)))
+      return gain / 2;
+
+  return 0;
 }
 
 /* shelter one camper */
 static void camp_shelter_char(struct char_data *ch, struct char_data *tch)
 {
   struct affected_type af;
+  uint32_t encoded_room = 0;
 
   new_affect(&af);
   af.spell = SKILL_CAMP;
   af.duration = CAMP_DURATION;
+  encoded_room = (uint32_t)GET_ROOM_VNUM(IN_ROOM(tch));
+  af.modifier = (sh_int)(uint16_t)(encoded_room & UINT16_MAX);
+  af.specific = (sh_int)(uint16_t)(encoded_room >> 16);
   affect_join(tch, &af, FALSE, FALSE, FALSE, FALSE);
 
   if (!IS_NPC(tch))
@@ -375,6 +407,14 @@ static void camp_shelter_char(struct char_data *ch, struct char_data *tch)
   if (tch != ch)
     act("$n's camp is ready for you to settle into.", FALSE, ch, 0, tch, TO_VICT);
 }
+
+#ifdef LUMINARI_CUTEST
+void test_camp_shelter_char(struct char_data *ch)
+{
+  if (ch != NULL && VALID_ROOM_RNUM(IN_ROOM(ch)))
+    camp_shelter_char(ch, ch);
+}
+#endif
 
 ACMDCHECK(can_camp)
 {
@@ -492,12 +532,7 @@ ACMDCHECK(can_garrote)
   ACMDCHECK_TEMPFAIL_IF(!AFF_FLAGGED(ch, AFF_HIDE) || !AFF_FLAGGED(ch, AFF_SNEAK),
                         "You have to be sneaking and hiding (in that order) before you can "
                         "garrote anyone.\r\n");
-  ACMDCHECK_TEMPFAIL_IF(GET_EQ(ch, WEAR_WIELD_2H) != NULL,
-                        "Both of your hands are busy with your weapon.\r\n");
-  ACMDCHECK_TEMPFAIL_IF(GET_EQ(ch, WEAR_SHIELD) != NULL,
-                        "You cannot work a cord with a shield strapped on.\r\n");
-  ACMDCHECK_TEMPFAIL_IF(GET_EQ(ch, WEAR_WIELD_OFFHAND) != NULL,
-                        "You need a free hand to loop the cord.\r\n");
+  ACMDCHECK_TEMPFAIL_IF(hands_available(ch) < 1, "You need a free hand to loop the cord.\r\n");
   return CAN_CMD;
 }
 
@@ -657,6 +692,9 @@ static bool accompanist_is_able(struct char_data *tch, struct char_data *lead)
     return FALSE;
 
   if (IN_ROOM(tch) != IN_ROOM(lead) || GET_POS(tch) <= POS_STUNNED)
+    return FALSE;
+
+  if (GROUP(tch) == NULL || GROUP(tch) != GROUP(lead))
     return FALSE;
 
   if (!HAS_FEAT(tch, FEAT_ACCOMPANY) || IS_PERFORMING(tch))

--- a/src/rol_feats.h
+++ b/src/rol_feats.h
@@ -11,10 +11,14 @@
 /* shadow: covert tailing */
 void stop_shadowing(struct char_data *ch, bool notify);
 void clear_shadow_links(struct char_data *ch);
+void shadow_movement_complete(struct char_data *ch);
 void shadowers_follow(struct char_data *ch, room_rnum was_in, int dir);
 
 /* establish camp: wilderness campsite */
 int camp_recovery_bonus(struct char_data *ch, int gain);
+#ifdef LUMINARI_CUTEST
+void test_camp_shelter_char(struct char_data *ch);
+#endif
 
 /* accompany: supporting another performer */
 void stop_accompanying(struct char_data *ch, bool notify);

--- a/unittests/CuTest/test_rol_feats.c
+++ b/unittests/CuTest/test_rol_feats.c
@@ -30,9 +30,10 @@
 
 struct rol_feat_fixture
 {
-  struct room_data room;
+  struct room_data rooms[2];
   struct char_data lead;
   struct char_data second;
+  struct group_data group;
   struct player_special_data lead_specials;
   struct player_special_data second_specials;
   struct descriptor_data lead_descriptor;
@@ -44,6 +45,10 @@ struct rol_feat_fixture
   room_rnum saved_top_of_world;
   mob_rnum saved_top_of_mobt;
 };
+
+typedef void (*rol_command_handler)(struct char_data *ch, const char *argument, int cmd,
+                                    int subcmd);
+typedef int (*rol_command_check)(struct char_data *ch, const char *argument, bool show_error);
 
 static void setup_test_char(struct char_data *ch, struct player_special_data *specials,
                             struct descriptor_data *descriptor, const char *name)
@@ -88,11 +93,15 @@ static void begin_rol_feat_fixture(struct rol_feat_fixture *fixture)
 
   fixture->lead.next_in_room = &fixture->second;
   fixture->lead.next = &fixture->second;
+  fixture->group.leader = &fixture->lead;
+  fixture->lead.group = &fixture->group;
+  fixture->second.group = &fixture->group;
 
-  fixture->room.number = 100;
-  fixture->room.people = &fixture->lead;
-  world = &fixture->room;
-  top_of_world = 0;
+  fixture->rooms[0].number = 169900;
+  fixture->rooms[0].people = &fixture->lead;
+  fixture->rooms[1].number = 169901;
+  world = fixture->rooms;
+  top_of_world = 1;
   character_list = &fixture->lead;
   fixture->mob_index_entry.vnum = DG_CASTER_PROXY;
   mob_index = &fixture->mob_index_entry;
@@ -123,14 +132,34 @@ static void end_rol_feat_fixture(struct rol_feat_fixture *fixture)
   top_of_mobt = fixture->saved_top_of_mobt;
 }
 
-static void give_camp_affect(struct char_data *ch)
+static bool rol_feat_file_contains(const char *relative_path, const char *needle)
 {
-  struct affected_type af;
+  const char *root = NULL;
+  char line[MAX_STRING_LENGTH];
+  char path[PATH_MAX];
+  FILE *file = NULL;
 
-  new_affect(&af);
-  af.spell = SKILL_CAMP;
-  af.duration = 10;
-  affect_join(ch, &af, FALSE, FALSE, FALSE, FALSE);
+  root = getenv("LUMINARI_TEST_ROOT");
+  if (root == NULL || *root == '\0')
+    root = ".";
+  if (snprintf(path, sizeof(path), "%s/%s", root, relative_path) >= (int)sizeof(path))
+    return FALSE;
+
+  file = fopen(path, "r");
+  if (file == NULL)
+    return FALSE;
+
+  while (fgets(line, sizeof(line), file) != NULL)
+  {
+    if (strstr(line, needle) != NULL)
+    {
+      fclose(file);
+      return TRUE;
+    }
+  }
+
+  fclose(file);
+  return FALSE;
 }
 
 /* A camp only speeds recovery for someone actually settled into it. */
@@ -143,14 +172,46 @@ void TestCampRecoveryRequiresRestingInCamp(CuTest *tc)
   GET_POS(&fixture.lead) = POS_RESTING;
   CuAssertIntEquals(tc, 0, camp_recovery_bonus(&fixture.lead, 40));
 
-  give_camp_affect(&fixture.lead);
+  test_camp_shelter_char(&fixture.lead);
   CuAssertIntEquals(tc, 20, camp_recovery_bonus(&fixture.lead, 40));
 
   GET_POS(&fixture.lead) = POS_SLEEPING;
   CuAssertIntEquals(tc, 20, camp_recovery_bonus(&fixture.lead, 40));
 
+  IN_ROOM(&fixture.lead) = 1;
+  CuAssertIntEquals(tc, 0, camp_recovery_bonus(&fixture.lead, 40));
+
+  IN_ROOM(&fixture.lead) = 0;
+  CuAssertIntEquals(tc, 20, camp_recovery_bonus(&fixture.lead, 40));
+
   GET_POS(&fixture.lead) = POS_STANDING;
   CuAssertIntEquals(tc, 0, camp_recovery_bonus(&fixture.lead, 40));
+
+  end_rol_feat_fixture(&fixture);
+}
+
+/* Calm's limited uses are wired to the generic daily-use event machinery. */
+void TestCalmUsesDailyCooldownRegistry(CuTest *tc)
+{
+  struct rol_feat_fixture fixture;
+  struct mud_event_data *event = NULL;
+  int uses = 0;
+
+  begin_rol_feat_fixture(&fixture);
+  if (feat_list[FEAT_CALM].name == NULL)
+    assign_feats();
+
+  GET_CHA(&fixture.lead) = 16;
+  uses = get_daily_uses(&fixture.lead, FEAT_CALM);
+
+  CuAssertIntEquals(tc, eROL_CALM, feat_list[FEAT_CALM].event);
+  CuAssertTrue(tc, uses > 1);
+  CuAssertIntEquals(tc, 1, start_daily_use_cooldown(&fixture.lead, FEAT_CALM));
+  CuAssertIntEquals(tc, uses - 1, daily_uses_remaining(&fixture.lead, FEAT_CALM));
+
+  event = char_has_mud_event(&fixture.lead, eROL_CALM);
+  CuAssertTrue(tc, event != NULL);
+  CuAssertStrEquals(tc, "uses:1", event->sVariables);
 
   end_rol_feat_fixture(&fixture);
 }
@@ -169,6 +230,10 @@ void TestAccompanimentBonusRequiresAnAbleAccompanist(CuTest *tc)
   CuAssertIntEquals(tc, 0, accompaniment_bonus(&fixture.lead));
 
   SET_FEAT(&fixture.second, FEAT_ACCOMPANY, 1);
+  fixture.second.group = NULL;
+  CuAssertIntEquals(tc, 0, accompaniment_bonus(&fixture.lead));
+
+  fixture.second.group = &fixture.group;
   bonus = accompaniment_bonus(&fixture.lead);
   CuAssertTrue(tc, bonus >= 1);
   CuAssertTrue(tc, bonus <= 12);
@@ -223,6 +288,33 @@ void TestAccompanyTakeoverNeedsTheSongFeat(CuTest *tc)
   end_rol_feat_fixture(&fixture);
 }
 
+/* Garrote accepts any equipment layout that leaves at least one hand free. */
+void TestGarroteRequiresAFreeHand(CuTest *tc)
+{
+  struct rol_feat_fixture fixture;
+  struct obj_data held_one;
+  struct obj_data held_two;
+
+  begin_rol_feat_fixture(&fixture);
+  memset(&held_one, 0, sizeof(held_one));
+  memset(&held_two, 0, sizeof(held_two));
+
+  SET_FEAT(&fixture.lead, FEAT_GARROTE, 1);
+  SET_BIT_AR(AFF_FLAGS(&fixture.lead), AFF_HIDE);
+  SET_BIT_AR(AFF_FLAGS(&fixture.lead), AFF_SNEAK);
+  CuAssertIntEquals(tc, CAN_CMD, can_garrote(&fixture.lead, "", FALSE));
+
+  GET_EQ(&fixture.lead, WEAR_HOLD_1) = &held_one;
+  CuAssertIntEquals(tc, CAN_CMD, can_garrote(&fixture.lead, "", FALSE));
+
+  GET_EQ(&fixture.lead, WEAR_HOLD_2) = &held_two;
+  CuAssertTrue(tc, can_garrote(&fixture.lead, "", FALSE) != CAN_CMD);
+
+  GET_EQ(&fixture.lead, WEAR_HOLD_1) = NULL;
+  GET_EQ(&fixture.lead, WEAR_HOLD_2) = NULL;
+  end_rol_feat_fixture(&fixture);
+}
+
 /* A tail cannot be kept up by someone who has stopped moving silently. */
 void TestShadowTailBreaksWithoutSneak(CuTest *tc)
 {
@@ -235,6 +327,24 @@ void TestShadowTailBreaksWithoutSneak(CuTest *tc)
 
   CuAssertPtrEquals(tc, NULL, SHADOWING(&fixture.second));
   CuAssertIntEquals(tc, 0, IN_ROOM(&fixture.second));
+
+  end_rol_feat_fixture(&fixture);
+}
+
+/* Moving away independently ends the tail instead of leaving a stale link. */
+void TestShadowTailBreaksWhenTailMovesAway(CuTest *tc)
+{
+  struct rol_feat_fixture fixture;
+
+  begin_rol_feat_fixture(&fixture);
+
+  SHADOWING(&fixture.second) = &fixture.lead;
+  shadow_movement_complete(&fixture.second);
+  CuAssertPtrEquals(tc, &fixture.lead, SHADOWING(&fixture.second));
+
+  IN_ROOM(&fixture.second) = 1;
+  shadow_movement_complete(&fixture.second);
+  CuAssertPtrEquals(tc, NULL, SHADOWING(&fixture.second));
 
   end_rol_feat_fixture(&fixture);
 }
@@ -283,7 +393,17 @@ void TestShadowAndAccompanyLinksAreClearedBothWays(CuTest *tc)
 /* Every converted skill is reachable as a command and as a feat. */
 void TestConvertedRolSkillsAreRegistered(CuTest *tc)
 {
-  static const char *commands[] = {"shadow", "calm", "camp", "garrote", "accompany"};
+  static const struct
+  {
+    const char *name;
+    rol_command_handler handler;
+    rol_command_check check;
+    int actions;
+  } commands[] = {{"shadow", do_shadow, can_shadow, ACTION_MOVE},
+                  {"calm", do_calm, can_calm, ACTION_STANDARD},
+                  {"camp", do_camp, can_camp, ACTION_STANDARD | ACTION_MOVE},
+                  {"garrote", do_garrote, can_garrote, ACTION_STANDARD | ACTION_MOVE},
+                  {"accompany", do_accompany, can_accompany, ACTION_MOVE}};
   static const char *feats[] = {"shadow", "calm", "establish camp", "garrote", "accompany"};
   size_t i;
   int j;
@@ -294,9 +414,12 @@ void TestConvertedRolSkillsAreRegistered(CuTest *tc)
     found = FALSE;
     for (j = 0; *cmd_info[j].command != '\n'; j++)
     {
-      if (str_cmp(cmd_info[j].command, commands[i]) == 0)
+      if (str_cmp(cmd_info[j].command, commands[i].name) == 0)
       {
         found = TRUE;
+        CuAssertTrue(tc, cmd_info[j].command_pointer == commands[i].handler);
+        CuAssertTrue(tc, cmd_info[j].command_check_pointer == commands[i].check);
+        CuAssertIntEquals(tc, commands[i].actions, cmd_info[j].actions_required);
         break;
       }
     }
@@ -305,6 +428,28 @@ void TestConvertedRolSkillsAreRegistered(CuTest *tc)
 
   for (i = 0; i < sizeof(feats) / sizeof(feats[0]); i++)
     CuAssertTrue(tc, find_feat_num(feats[i]) > 0);
+}
+
+/* Both maintained help sources and their verifier cover every converted feat. */
+void TestConvertedRolFeatHelpSourcesAreComplete(CuTest *tc)
+{
+  static const char *flat_keywords[] = {"ACCOMPANY", "CALM PACIFY", "CAMP ESTABLISH-CAMP",
+                                        "GARROTE STRANGLE", "SHADOW TAIL"};
+  static const char *database_tags[] = {"VALUES ('ACCOMPANY'", "VALUES ('CALM'", "VALUES ('CAMP'",
+                                        "VALUES ('GARROTE'", "VALUES ('SHADOW'"};
+  size_t i = 0;
+
+  for (i = 0; i < sizeof(flat_keywords) / sizeof(flat_keywords[0]); i++)
+    CuAssertTrue(tc, rol_feat_file_contains("lib/text/help/help.hlp", flat_keywords[i]));
+
+  for (i = 0; i < sizeof(database_tags) / sizeof(database_tags[0]); i++)
+    CuAssertTrue(
+        tc, rol_feat_file_contains("sql/components/help_rol_feat_entries.sql", database_tags[i]));
+
+  CuAssertTrue(tc, rol_feat_file_contains("sql/components/verify_help_rol_feat_entries.sql",
+                                          "rol_feat_content"));
+  CuAssertTrue(tc, rol_feat_file_contains("sql/components/verify_help_rol_feat_entries.sql",
+                                          "rol_feat_command_keyword_owners"));
 }
 
 /* Converted RoL skills are selected normally and never granted by a class. */

--- a/unittests/CuTest/test_rol_feats.c
+++ b/unittests/CuTest/test_rol_feats.c
@@ -437,6 +437,12 @@ void TestConvertedRolFeatHelpSourcesAreComplete(CuTest *tc)
                                         "GARROTE STRANGLE", "SHADOW TAIL"};
   static const char *database_tags[] = {"VALUES ('ACCOMPANY'", "VALUES ('CALM'", "VALUES ('CAMP'",
                                         "VALUES ('GARROTE'", "VALUES ('SHADOW'"};
+  static const char *prerequisite_text[] = {"5 ranks of perform",
+                                            "free at level 2",
+                                            "charisma 19",
+                                            "3 ranks of survival",
+                                            "14 ranks of stealth and BAB 8",
+                                            "21 ranks of stealth"};
   size_t i = 0;
 
   for (i = 0; i < sizeof(flat_keywords) / sizeof(flat_keywords[0]); i++)
@@ -446,18 +452,80 @@ void TestConvertedRolFeatHelpSourcesAreComplete(CuTest *tc)
     CuAssertTrue(
         tc, rol_feat_file_contains("sql/components/help_rol_feat_entries.sql", database_tags[i]));
 
+  for (i = 0; i < sizeof(prerequisite_text) / sizeof(prerequisite_text[0]); i++)
+  {
+    CuAssertTrue(tc, rol_feat_file_contains("lib/text/help/help.hlp", prerequisite_text[i]));
+    CuAssertTrue(tc, rol_feat_file_contains("sql/components/help_rol_feat_entries.sql",
+                                            prerequisite_text[i]));
+  }
+
   CuAssertTrue(tc, rol_feat_file_contains("sql/components/verify_help_rol_feat_entries.sql",
                                           "rol_feat_content"));
   CuAssertTrue(tc, rol_feat_file_contains("sql/components/verify_help_rol_feat_entries.sql",
                                           "rol_feat_command_keyword_owners"));
+  CuAssertTrue(tc, rol_feat_file_contains("sql/components/help_rol_feat_entries.sql",
+                                          "bards gain it for free at level 2"));
 }
 
-/* Converted RoL skills are selected normally and never granted by a class. */
-void TestConvertedRolFeatsAreClassNeutralAndLearnable(CuTest *tc)
+static int rol_feat_prerequisite_count(int feat_num)
+{
+  struct feat_prerequisite *prereq = NULL;
+  int count = 0;
+
+  for (prereq = feat_list[feat_num].prerequisite_list; prereq != NULL; prereq = prereq->next)
+    count++;
+
+  return count;
+}
+
+static bool rol_feat_has_prerequisite(int feat_num, int prerequisite_type, int value0, int value1)
+{
+  struct feat_prerequisite *prereq = NULL;
+
+  for (prereq = feat_list[feat_num].prerequisite_list; prereq != NULL; prereq = prereq->next)
+  {
+    if (prereq->prerequisite_type == prerequisite_type && prereq->values[0] == value0 &&
+        prereq->values[1] == value1)
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+/* Converted feat selection gates stay aligned with their intended advancement bands. */
+void TestConvertedRolFeatPrerequisitesAreExact(CuTest *tc)
+{
+  if (feat_list[FEAT_SHADOW].name == NULL)
+    assign_feats();
+
+  CuAssertIntEquals(tc, 1, rol_feat_prerequisite_count(FEAT_SHADOW));
+  CuAssertTrue(tc,
+               rol_feat_has_prerequisite(FEAT_SHADOW, FEAT_PREREQ_ABILITY, ABILITY_STEALTH, 21));
+
+  CuAssertIntEquals(tc, 1, rol_feat_prerequisite_count(FEAT_CALM));
+  CuAssertTrue(tc, rol_feat_has_prerequisite(FEAT_CALM, FEAT_PREREQ_ATTRIBUTE, AB_CHA, 19));
+
+  CuAssertIntEquals(tc, 1, rol_feat_prerequisite_count(FEAT_ESTABLISH_CAMP));
+  CuAssertTrue(
+      tc, rol_feat_has_prerequisite(FEAT_ESTABLISH_CAMP, FEAT_PREREQ_ABILITY, ABILITY_SURVIVAL, 3));
+
+  CuAssertIntEquals(tc, 2, rol_feat_prerequisite_count(FEAT_GARROTE));
+  CuAssertTrue(tc,
+               rol_feat_has_prerequisite(FEAT_GARROTE, FEAT_PREREQ_ABILITY, ABILITY_STEALTH, 14));
+  CuAssertTrue(tc, rol_feat_has_prerequisite(FEAT_GARROTE, FEAT_PREREQ_BAB, 8, 0));
+
+  CuAssertIntEquals(tc, 1, rol_feat_prerequisite_count(FEAT_ACCOMPANY));
+  CuAssertTrue(tc,
+               rol_feat_has_prerequisite(FEAT_ACCOMPANY, FEAT_PREREQ_ABILITY, ABILITY_PERFORM, 5));
+}
+
+/* All five feats remain learnable; only bards receive Accompany for free. */
+void TestConvertedRolFeatsAreNormallyLearnableWithExactClassGrants(CuTest *tc)
 {
   static const int feats[] = {FEAT_SHADOW, FEAT_CALM, FEAT_ESTABLISH_CAMP, FEAT_GARROTE,
                               FEAT_ACCOMPANY};
   struct class_feat_assign *assignment;
+  int accompany_assignments = 0;
   size_t i;
   int class_num;
 
@@ -477,9 +545,18 @@ void TestConvertedRolFeatsAreClassNeutralAndLearnable(CuTest *tc)
       for (assignment = class_list[class_num].featassign_list; assignment != NULL;
            assignment = assignment->next)
       {
-        CuAssert(tc, "converted RoL feat unexpectedly assigned by a class",
-                 assignment->feat_num != feats[i]);
+        if (assignment->feat_num != feats[i])
+          continue;
+
+        CuAssertIntEquals(tc, FEAT_ACCOMPANY, feats[i]);
+        CuAssertIntEquals(tc, CLASS_BARD, class_num);
+        CuAssertTrue(tc, assignment->is_classfeat);
+        CuAssertIntEquals(tc, 2, assignment->level_received);
+        CuAssertTrue(tc, !assignment->stacks);
+        accompany_assignments++;
       }
     }
   }
+
+  CuAssertIntEquals(tc, 1, accompany_assignments);
 }

--- a/unittests/CuTest/test_rol_feats.c
+++ b/unittests/CuTest/test_rol_feats.c
@@ -12,15 +12,16 @@
 #include "../../src/act.h"
 #include "../../src/bardic_performance.h"
 #include "../../src/character/abilities.h"
+#include "../../src/constants.h"
 #include "../../src/character/feats.h"
 #include "../../src/combat/fight.h"
-#include "../../src/constants.h"
 #include "../../src/db.h"
 #include "../../src/dgscript/dg_event.h"
 #include "../../src/dgscript/dg_scripts.h"
 #include "../../src/handler.h"
 #include "../../src/interpreter.h"
 #include "../../src/magic/spells.h"
+#include "../../src/character/class.h"
 #include "../../src/mud_event.h"
 #include "../../src/net/protocol.h"
 #include "../../src/rol_feats.h"
@@ -304,4 +305,36 @@ void TestConvertedRolSkillsAreRegistered(CuTest *tc)
 
   for (i = 0; i < sizeof(feats) / sizeof(feats[0]); i++)
     CuAssertTrue(tc, find_feat_num(feats[i]) > 0);
+}
+
+/* Converted RoL skills are selected normally and never granted by a class. */
+void TestConvertedRolFeatsAreClassNeutralAndLearnable(CuTest *tc)
+{
+  static const int feats[] = {FEAT_SHADOW, FEAT_CALM, FEAT_ESTABLISH_CAMP, FEAT_GARROTE,
+                              FEAT_ACCOMPANY};
+  struct class_feat_assign *assignment;
+  size_t i;
+  int class_num;
+
+  if (feat_list[FEAT_SHADOW].name == NULL)
+    assign_feats();
+  if (class_list[CLASS_WIZARD].name == NULL)
+    load_class_list();
+
+  for (i = 0; i < sizeof(feats) / sizeof(feats[0]); i++)
+  {
+    CuAssertTrue(tc, feat_list[feats[i]].can_learn);
+    CuAssertTrue(tc, feat_list[feats[i]].feat_type > FEAT_TYPE_NONE);
+    CuAssertTrue(tc, feat_list[feats[i]].feat_type < NUM_LEARNABLE_FEAT_TYPES);
+
+    for (class_num = 0; class_num < NUM_CLASSES; class_num++)
+    {
+      for (assignment = class_list[class_num].featassign_list; assignment != NULL;
+           assignment = assignment->next)
+      {
+        CuAssert(tc, "converted RoL feat unexpectedly assigned by a class",
+                 assignment->feat_num != feats[i]);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Keep all five converted RoL feats normally learnable while granting Accompany free to bards at level 2.
- Harden Shadow and Accompany lifecycle cleanup and enforce feat ownership at subsystem boundaries.
- Align prerequisite values, both help sources, SQL verification, project documentation, and production-linked regression coverage.

## Verification

- `make -j$(nproc)`
- `LUMINARI_TEST_SKIP_SYNTAX_BOOT=1 LUMINARI_TEST_SPEC_WORLD_ROOT="$PWD/unittests/CuTest/fixtures/spec_world_inventory" make test` (854 tests passed)
- `make install`
- Commit and pre-push hooks, including the compile check