### PR TITLE
[codex] Complete RoL spell equivalence gaps

### DIFF
--- a/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
@@ -6,7 +6,9 @@ completed and independently re-verified 2026-08-24 against
 implementation checkpoints added all 89 functional gaps through native magic
 paths and focused direct handlers. A follow-up handler-level review found 14
 live RoL spells that had been incorrectly classified as covered by loose
-substitutes; all 14 now have native implementations.
+substitutes; all 14 now have native implementations. A final documentation
+audit added the 73 missing help topics from the first three checkpoints and
+synchronized canonical help coverage for all 89 spells.
 
 This list compares every unique spell registered through `SPELL_CREATE()` in
 Realms of Luminari with LuminariMUD's registered spells and closely equivalent
@@ -256,8 +258,23 @@ Validation completed with a warning-free GNU C23 build and all 880
 production-linked CuTests under the documented isolated-test settings. The
 full world-tool suite passed, and the 132-test RoL transformer suite passed
 against the installed source corpus with two optional-pilot skips. The
-generated constants manifest is current, installation succeeds, and the four
-flat-file help topics match their development-database entries.
+generated constants manifest is current, and installation succeeds.
+
+### Completion checkpoint 8: help and inventory parity
+
+The completion audit matched the 89 inventory rows below to 89 distinct
+positive converter targets, 89 live `spello()` registrations, and the same 89
+entries in the production-linked registration tests. All 45 registrations that
+use `MAG_MANUAL` have explicit dispatcher cases. The converter still covers
+all 340 required positive source identities as 331 castable mappings and nine
+explicit non-castable identities.
+
+The audit also found that 73 spells from implementation checkpoints 1-3 had
+never received canonical help topics. Those topics now exist in
+`lib/text/help/help.hlp`, bringing flat-file coverage to 89 of 89. All 89
+canonical entries and their searchable keywords are present in the development
+database, and every database body and level now byte-matches the flat-file
+source.
 
 The complete inventory of all 89 implemented gaps remains below, preserving
 the original source-to-target accounting.

--- a/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
@@ -2,10 +2,10 @@
 
 Status: implementation incomplete. The source registry audit was completed and
 independently re-verified 2026-08-24 against `sparser.c`, `spells.h`,
-`spell_parser.c`, and `psionics.c`. Four implementation checkpoints added 79
+`spell_parser.c`, and `psionics.c`. Five implementation checkpoints added 83
 functional gaps through native magic paths and focused direct handlers. A
 follow-up handler-level review found 14 live RoL spells that had been
-incorrectly classified as covered by loose substitutes. Ten of those spells
+incorrectly classified as covered by loose substitutes. Six of those spells
 still require native implementations.
 
 This list compares every unique spell registered through `SPELL_CREATE()` in
@@ -30,7 +30,7 @@ below and must not be treated as live RoL content.
 - RoL registrations reviewed: 332 (327 live, 5 never compiled)
 - Live registrations with a close LuminariMUD equivalent: 229
 - Live registrations without a close equivalent: 98
-- Player-facing or functional gaps: 89 (79 implemented, 10 remaining)
+- Player-facing or functional gaps: 89 (83 implemented, 6 remaining)
 - RoL internal or stub registrations without an equivalent: 9
 - Registered only inside `#if 0` (never compiled): 5
 
@@ -57,7 +57,7 @@ converter map is numerically complete but not semantically complete.
 `_SOURCE_SPELL_MAP` contains 340 positive source IDs: all 327 live
 `SPELL_CREATE()` IDs, all 335 distinct positive `SPELL_*` numeric IDs in the
 source header, and the two non-spell IDs actually found in magic-item spell
-slots. Ten live source spells currently map to substitutes that do not
+slots. Six live source spells currently map to substitutes that do not
 preserve their mechanics. Those mappings must move to the new native spell IDs
 after the remaining spells are implemented.
 
@@ -77,22 +77,18 @@ positive target spell.
 
 ## Remaining player-facing or functional gaps
 
-These 10 live RoL spells require distinct native registrations and mechanics.
+These six live RoL spells require distinct native registrations and mechanics.
 The current converter targets are listed only to identify the inadequate
 substitutes; they are not acceptable final mappings.
 
 | RoL ID | RoL spell | Current substitute | Required source behavior |
 |-------:|-----------|--------------------|--------------------------|
-| 90 | cyclone | whirlwind | Deals air damage to eligible enemies throughout the room, halves a PC caster's damage when the zone wind speed is 25 or lower, and allows the normal spell save and area-avoidance checks. Whirlwind lacks the environmental dependency and is not an adequate identity-preserving replacement. |
-| 303 | lich touch | grave touch | Deals direct damage, interacts with cold and fire shields, and on a failed save applies a Strength penalty and slow; dragons ignore the secondary effects. Grave touch applies fear/shaken instead. LuminariMUD's racial lich-touch ability also has different healing, damage, paralysis, and daily-use mechanics and is not a normal spell. |
 | 343 | call lycanthrope | summon creature vi | Summons one randomly selected lycanthrope prototype, permits only one such follower, scales it to at most level 40 from caster level minus 10, assigns scaled hit points, charms it, and schedules charm expiration. Summon creature VI creates a dire tiger. |
 | 376 | tazriks frenzied hound | faithful hound | Opens a temporary vortex and makes a hellhound strike one randomly selected eligible room target once per combat pulse for three strikes. It does not create a persistent follower. |
 | 482 | elemental water embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 5 hit points per shared level, water breathing, fire/gas/acid protection, and 25 percent additional height and weight. |
 | 483 | elemental fire embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 7 hit points per shared level, fire shield, -65 source armor class, haste, flight, gas/fire protection, and 35 percent additional height and weight. |
 | 484 | elemental earth embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants gas/cold protection and 50 percent additional height and weight. The live RoL handler grants roughly 7 hit points per shared level because it uses `EFHP_FACTOR`; the separately declared `EEHP_FACTOR` value of 10 is unused and should be resolved deliberately during implementation. |
 | 485 | elemental air embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 3 hit points per shared level, -50 source armor class, haste, flight, gas/acid protection, and 15 percent additional height and weight. |
-| 487 | lava burst | fire storm | Deals fire damage to eligible enemies throughout the room and starts persistent burning damage on survivors successfully damaged. It also participates in RoL's spell-merge check. Fire storm supplies only the initial area damage. |
-| 488 | ice layer | grease | Targets one corporeal standing opponent; on a failed Agility save it deals `2d10` direct damage, makes the target prone, and applies one combat pulse of action lag. Demons, devils, angels, beholders, dragons, and immaterial targets are immune. Grease applies a lasting movement penalty but neither damage nor prone. |
 
 All four elemental embodiment spells share additional behavior that must remain
 common in the target implementation: the target must be a same-side PC, the
@@ -219,8 +215,23 @@ assignment.
 | unholy aura | Applies its own duration-scaled affect identity while supplying the fire-shield state. |
 | camouflage | Ends all combat involving the unmounted caster and applies persistent hide under a distinct spell affect until concealment breaks. |
 
-The complete inventory of the 79 implemented gaps remains below, preserving
-the original source-to-target accounting. The 10 remaining gaps are listed in
+### Implementation checkpoint 5: environmental damage and direct control
+
+These four spells replace loose damage or control substitutes with their traced
+source-specific rules. None has a class or domain assignment.
+
+| Spell | Implemented gameplay purpose |
+|-------|------------------------------|
+| cyclone | Deals room-wide air damage and halves a PC caster's damage when the latest cached zone wind speed is 25 or lower. A missing cache safely uses the low-wind fallback. |
+| lich touch | Deals unsaved unholy touch damage, applies the source fire-elemental and shield adjustments, and separately saves against accumulating Strength loss and slow; dragons ignore the secondary effects. |
+| lava burst | Deals room-wide fire damage and ignites successfully damaged survivors for five rounds. RoL calls its merge hook, but its live merge table has no lava-burst pairing, so there is no additional merge behavior to reproduce. |
+| ice layer | Uses Reflex as the target system's Agility-save counterpart, deals `2d10` bludgeoning damage on failure, knocks the target to the sitting/prone state, and applies one combat pulse of lag while preserving all source immunities. |
+
+The converter now preserves RoL beholder identity with a dedicated converted
+mobile flag so ice layer can distinguish beholders from generic aberrations.
+
+The complete inventory of the 83 implemented gaps remains below, preserving
+the original source-to-target accounting. The six remaining gaps are listed in
 the preceding section.
 
 | RoL ID | RoL spell | RoL constant |
@@ -231,6 +242,7 @@ the preceding section.
 | 84 | rejuvenate major | `SPELL_REJUVENATE_MAJOR` |
 | 88 | rejuvenate minor | `SPELL_REJUVENATE_MINOR` |
 | 89 | age | `SPELL_AGE` |
+| 90 | cyclone | `SPELL_CYCLONE` |
 | 119 | preserve | `SPELL_PRESERVE` |
 | 154 | command undead | `SPELL_COMMAND_UNDEAD` |
 | 163 | slow poison | `SPELL_SLOW_POISON` |
@@ -252,6 +264,7 @@ the preceding section.
 | 299 | rain of blood | `SPELL_RAIN_OF_BLOOD` |
 | 301 | embalm | `SPELL_EMBALM` |
 | 302 | rot | `SPELL_ROT` |
+| 303 | lich touch | `SPELL_LICH_TOUCH` |
 | 305 | ice tomb | `SPELL_ICE_TOMB` |
 | 319 | constriction | `SPELL_CONSTRICTION` |
 | 321 | airy water | `SPELL_AIRY_WATER` |
@@ -295,6 +308,8 @@ the preceding section.
 | 476 | shadechill | `SPELL_SHADECHILL` |
 | 478 | agility | `SPELL_AGILITY` |
 | 479 | air blast | `SPELL_AIR_BLAST` |
+| 487 | lava burst | `SPELL_LAVA_BURST` |
+| 488 | ice layer | `SPELL_ICE_LAYER` |
 | 492 | shadow flux | `SPELL_SHADOW_FLUX` |
 | 505 | natures blessing | `SPELL_NATURES_BLESSING` |
 | 514 | song of travel | `BARD_TRAVEL` |

--- a/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
@@ -1,12 +1,12 @@
 # RoL Spells Without a Close LuminariMUD Equivalent
 
-Status: implementation incomplete. The source registry audit was completed and
-independently re-verified 2026-08-24 against `sparser.c`, `spells.h`,
-`spell_parser.c`, and `psionics.c`. Six implementation checkpoints added 85
-functional gaps through native magic paths and focused direct handlers. A
-follow-up handler-level review found 14 live RoL spells that had been
-incorrectly classified as covered by loose substitutes. Four of those spells
-still require native implementations.
+Status: implementation and validation complete. The source registry audit was
+completed and independently re-verified 2026-08-24 against
+`sparser.c`, `spells.h`, `spell_parser.c`, and `psionics.c`. Seven
+implementation checkpoints added all 89 functional gaps through native magic
+paths and focused direct handlers. A follow-up handler-level review found 14
+live RoL spells that had been incorrectly classified as covered by loose
+substitutes; all 14 now have native implementations.
 
 This list compares every unique spell registered through `SPELL_CREATE()` in
 Realms of Luminari with LuminariMUD's registered spells and closely equivalent
@@ -30,7 +30,7 @@ below and must not be treated as live RoL content.
 - RoL registrations reviewed: 332 (327 live, 5 never compiled)
 - Live registrations with a close LuminariMUD equivalent: 229
 - Live registrations without a close equivalent: 98
-- Player-facing or functional gaps: 89 (85 implemented, 4 remaining)
+- Player-facing or functional gaps: 89 (89 implemented, 0 remaining)
 - RoL internal or stub registrations without an equivalent: 9
 - Registered only inside `#if 0` (never compiled): 5
 
@@ -53,13 +53,14 @@ player-facing gaps were implemented. Playable race gaps are tracked in
 `ROL_RACE_EQUIVALENCE_GAPS.md`.
 
 This remains a feature-equivalence list. The corresponding magic-item
-converter map is numerically complete but not semantically complete.
-`_SOURCE_SPELL_MAP` contains 340 positive source IDs: all 327 live
+converter is numerically complete and routes every identified player-facing
+gap to a native implementation. `_SOURCE_SPELL_MAP` contains 331 castable
+positive source IDs. `_NON_CASTABLE_SOURCE_SPELLS` separately accounts for nine
+stub, maintenance, or proc-only IDs that must fail closed in a castable world-data
+slot. Their union covers all 340 required positive source IDs: all 327 live
 `SPELL_CREATE()` IDs, all 335 distinct positive `SPELL_*` numeric IDs in the
 source header, and the two non-spell IDs actually found in magic-item spell
-slots. Four live source spells currently map to substitutes that do not
-preserve their mechanics. Those mappings must move to the new native spell IDs
-after the remaining spells are implemented.
+slots.
 
 The active corpus check converts all 511 magic items: 71 potions, 251 scrolls,
 80 wands, and 109 staves. Those records contain 117 distinct positive source
@@ -77,24 +78,7 @@ positive target spell.
 
 ## Remaining player-facing or functional gaps
 
-These four live RoL spells require distinct native registrations and mechanics.
-The current converter targets are listed only to identify the inadequate
-substitutes; they are not acceptable final mappings.
-
-| RoL ID | RoL spell | Current substitute | Required source behavior |
-|-------:|-----------|--------------------|--------------------------|
-| 482 | elemental water embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 5 hit points per shared level, water breathing, fire/gas/acid protection, and 25 percent additional height and weight. |
-| 483 | elemental fire embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 7 hit points per shared level, fire shield, -65 source armor class, haste, flight, gas/fire protection, and 35 percent additional height and weight. |
-| 484 | elemental earth embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants gas/cold protection and 50 percent additional height and weight. The live RoL handler grants roughly 7 hit points per shared level because it uses `EFHP_FACTOR`; the separately declared `EEHP_FACTOR` value of 10 is unused and should be resolved deliberately during implementation. |
-| 485 | elemental air embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 3 hit points per shared level, -50 source armor class, haste, flight, gas/acid protection, and 15 percent additional height and weight. |
-
-All four elemental embodiment spells share additional behavior that must remain
-common in the target implementation: the target must be a same-side PC, the
-target must be unmounted and not already embodying an element, and the caster
-can maintain only one embodiment. Each spell creates a linked caster-side
-maintenance affect so expiration and removal can clean up the transformation.
-Geniekind is not a usable base for this behavior: it is self-only, selects a
-genie type, applies different traits, and summons a genie follower.
+None. All 89 player-facing or functional gaps have native implementations.
 
 ## Implemented player-facing or functional gaps
 
@@ -242,9 +226,41 @@ The converter marks only source mobile prototypes 525 and 526 with a dedicated
 summon-role flag, so call lycanthrope does not select unrelated lycanthropes.
 The converter's spell mappings now target both native registrations.
 
-The complete inventory of the 85 implemented gaps remains below, preserving
-the original source-to-target accounting. The four remaining gaps are listed in
-the preceding section.
+### Implementation checkpoint 7: linked elemental embodiments
+
+These four spells replace geniekind substitutes with a shared transformation
+and maintenance lifecycle. None has a class or domain assignment.
+
+| Spell | Implemented gameplay purpose |
+|-------|------------------------------|
+| elemental water embodiment | Grants roughly 5 hit points per shared level, water breathing, 50 percent fire/poison/acid resistance, and 25 percent additional height and weight. |
+| elemental fire embodiment | Grants roughly 7 hit points per shared level, fire shield, +6 natural armor, haste, flight, 50 percent poison/fire resistance, and 35 percent additional height and weight. |
+| elemental earth embodiment | Grants roughly 7 hit points per shared level, 50 percent poison/cold resistance, and 50 percent additional height and weight. The factor of 7 deliberately preserves the live RoL handler's use of `EFHP_FACTOR`; the unused declared `EEHP_FACTOR` value of 10 is not substituted. |
+| elemental air embodiment | Grants roughly 3 hit points per shared level, +5 natural armor, haste, flight, 50 percent poison/acid resistance, and 15 percent additional height and weight. |
+
+All four require a same-side, unmounted PC target that is not already using an
+elemental embodiment. A caster can maintain only one embodiment. Runtime source
+IDs link the target transformation to a caster-side maintenance affect, so
+explicit removal or either character leaving the game tears down both sides.
+The linked affects are transient: player and pet persistence omit them, and the
+source dispel exclusions are preserved. The base duration is ten before the
+caster's spell-duration modifier, and hit-point variation remains within five
+percent of the shared-level base.
+
+The converter now maps source IDs 482-485 to the four native registrations.
+Source stub IDs 64, 93, and 361; maintenance IDs 291-294 and 498; and proc
+marker 374 are explicit non-castable identities and cause a conversion error if
+found in a magic-item spell slot.
+
+Validation completed with a warning-free GNU C23 build and all 880
+production-linked CuTests under the documented isolated-test settings. The
+full world-tool suite passed, and the 132-test RoL transformer suite passed
+against the installed source corpus with two optional-pilot skips. The
+generated constants manifest is current, installation succeeds, and the four
+flat-file help topics match their development-database entries.
+
+The complete inventory of all 89 implemented gaps remains below, preserving
+the original source-to-target accounting.
 
 | RoL ID | RoL spell | RoL constant |
 |-------:|-----------|--------------|
@@ -322,6 +338,10 @@ the preceding section.
 | 476 | shadechill | `SPELL_SHADECHILL` |
 | 478 | agility | `SPELL_AGILITY` |
 | 479 | air blast | `SPELL_AIR_BLAST` |
+| 482 | elemental water embodiment | `SPELL_ELEMENTAL_WATER` |
+| 483 | elemental fire embodiment | `SPELL_ELEMENTAL_FIRE` |
+| 484 | elemental earth embodiment | `SPELL_ELEMENTAL_EARTH` |
+| 485 | elemental air embodiment | `SPELL_ELEMENTAL_AIR` |
 | 487 | lava burst | `SPELL_LAVA_BURST` |
 | 488 | ice layer | `SPELL_ICE_LAYER` |
 | 492 | shadow flux | `SPELL_SHADOW_FLUX` |

--- a/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
@@ -2,11 +2,11 @@
 
 Status: implementation incomplete. The source registry audit was completed and
 independently re-verified 2026-08-24 against `sparser.c`, `spells.h`,
-`spell_parser.c`, and `psionics.c`. Three implementation checkpoints added 75
+`spell_parser.c`, and `psionics.c`. Four implementation checkpoints added 79
 functional gaps through native magic paths and focused direct handlers. A
 follow-up handler-level review found 14 live RoL spells that had been
-incorrectly classified as covered by loose substitutes. Those 14 spells still
-require native implementations.
+incorrectly classified as covered by loose substitutes. Ten of those spells
+still require native implementations.
 
 This list compares every unique spell registered through `SPELL_CREATE()` in
 Realms of Luminari with LuminariMUD's registered spells and closely equivalent
@@ -30,7 +30,7 @@ below and must not be treated as live RoL content.
 - RoL registrations reviewed: 332 (327 live, 5 never compiled)
 - Live registrations with a close LuminariMUD equivalent: 229
 - Live registrations without a close equivalent: 98
-- Player-facing or functional gaps: 89 (75 implemented, 14 remaining)
+- Player-facing or functional gaps: 89 (79 implemented, 10 remaining)
 - RoL internal or stub registrations without an equivalent: 9
 - Registered only inside `#if 0` (never compiled): 5
 
@@ -57,7 +57,7 @@ converter map is numerically complete but not semantically complete.
 `_SOURCE_SPELL_MAP` contains 340 positive source IDs: all 327 live
 `SPELL_CREATE()` IDs, all 335 distinct positive `SPELL_*` numeric IDs in the
 source header, and the two non-spell IDs actually found in magic-item spell
-slots. Fourteen live source spells currently map to substitutes that do not
+slots. Ten live source spells currently map to substitutes that do not
 preserve their mechanics. Those mappings must move to the new native spell IDs
 after the remaining spells are implemented.
 
@@ -77,20 +77,16 @@ positive target spell.
 
 ## Remaining player-facing or functional gaps
 
-These 14 live RoL spells require distinct native registrations and mechanics.
+These 10 live RoL spells require distinct native registrations and mechanics.
 The current converter targets are listed only to identify the inadequate
 substitutes; they are not acceptable final mappings.
 
 | RoL ID | RoL spell | Current substitute | Required source behavior |
 |-------:|-----------|--------------------|--------------------------|
 | 90 | cyclone | whirlwind | Deals air damage to eligible enemies throughout the room, halves a PC caster's damage when the zone wind speed is 25 or lower, and allows the normal spell save and area-avoidance checks. Whirlwind lacks the environmental dependency and is not an adequate identity-preserving replacement. |
-| 233 | heal undead | negative energy ray | Heals only undead for `4d(level)` hit points, respects blackmantle, and uses a specialized 100-point heal for the RoL PC-lich-to-PC-lich case. Negative energy ray is an offensive ray that only incidentally heals undead through the generic negative-energy rule. |
 | 303 | lich touch | grave touch | Deals direct damage, interacts with cold and fire shields, and on a failed save applies a Strength penalty and slow; dragons ignore the secondary effects. Grave touch applies fear/shaken instead. LuminariMUD's racial lich-touch ability also has different healing, damage, paralysis, and daily-use mechanics and is not a normal spell. |
 | 343 | call lycanthrope | summon creature vi | Summons one randomly selected lycanthrope prototype, permits only one such follower, scales it to at most level 40 from caster level minus 10, assigns scaled hit points, charms it, and schedules charm expiration. Summon creature VI creates a dire tiger. |
 | 376 | tazriks frenzied hound | faithful hound | Opens a temporary vortex and makes a hellhound strike one randomly selected eligible room target once per combat pulse for three strikes. It does not create a persistent follower. |
-| 377 | dark wrath | divine power | Self-only and unavailable while fighting; grants a level-scaled damage-roll bonus of +1 to +3 and improves the generic spell save by 3 to 5 for a level-scaled duration. Divine power adds unrelated Strength, hit-roll, hit-point, and luck bonuses and lacks the spell-save benefit. |
-| 378 | unholy aura | fire shield | A distinct self-only spell that applies the fire-shield affect for a base source duration of three, modified by specialization. Sharing the underlying fire-shield flag does not preserve the spell identity, duration, script/item reference, or independent affect lifecycle. |
-| 473 | camouflage | invisibility | Self-only, cannot be used while mounted, ends the caster's combat and all attacks against the caster, and applies both hide and camouflage state. Invisibility uses a different detection state and does not provide this disengagement behavior. |
 | 482 | elemental water embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 5 hit points per shared level, water breathing, fire/gas/acid protection, and 25 percent additional height and weight. |
 | 483 | elemental fire embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 7 hit points per shared level, fire shield, -65 source armor class, haste, flight, gas/fire protection, and 35 percent additional height and weight. |
 | 484 | elemental earth embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants gas/cold protection and 50 percent additional height and weight. The live RoL handler grants roughly 7 hit points per shared level because it uses `EFHP_FACTOR`; the separately declared `EEHP_FACTOR` value of 10 is unused and should be resolved deliberately during implementation. |
@@ -210,8 +206,21 @@ expressed by one native routine. None has a class or domain assignment.
 | earth fog | Temporarily fills the room with obscuring earthen fog. |
 | fire fog | Temporarily illuminates the room with fiery fog. |
 
-The complete inventory of the 75 implemented gaps remains below, preserving
-the original source-to-target accounting. The 14 remaining gaps are listed in
+### Implementation checkpoint 4: undead healing, divine wards, and concealment
+
+These four spells preserve source-specific identities and lifecycle rules that
+their former substitutes could not represent. None has a class or domain
+assignment.
+
+| Spell | Implemented gameplay purpose |
+|-------|------------------------------|
+| heal undead | Heals only undead for `4d(level)`, respects blackmantle, and restores 100 hit points in the PC-lich-to-PC-lich case. |
+| dark wrath | While out of combat, grants the source level-scaled damage and all-spell-save bonuses for the source duration bands. |
+| unholy aura | Applies its own duration-scaled affect identity while supplying the fire-shield state. |
+| camouflage | Ends all combat involving the unmounted caster and applies persistent hide under a distinct spell affect until concealment breaks. |
+
+The complete inventory of the 79 implemented gaps remains below, preserving
+the original source-to-target accounting. The 10 remaining gaps are listed in
 the preceding section.
 
 | RoL ID | RoL spell | RoL constant |
@@ -235,6 +244,7 @@ the preceding section.
 | 230 | protect undead | `SPELL_PROT_UNDEAD` |
 | 231 | protection from undead | `SPELL_PROT_FROM_UNDEAD` |
 | 232 | command horde | `SPELL_COMMAND_HORDE` |
+| 233 | heal undead | `SPELL_HEAL_UNDEAD` |
 | 235 | create spring | `SPELL_CREATE_SPRING` |
 | 237 | moonwell | `SPELL_MOONWELL` |
 | 297 | nerve dance | `SPELL_NERVE_DANCE` |
@@ -260,6 +270,8 @@ the preceding section.
 | 366 | phantasmal blades | `SPELL_PHANTASMAL_BLADES` |
 | 370 | soul bind | `SPELL_SOUL_BIND` |
 | 371 | death pact | `SPELL_DEATH_PACT` |
+| 377 | dark wrath | `SPELL_DARK_WRATH` |
+| 378 | unholy aura | `SPELL_UNHOLY_AURA` |
 | 380 | needle swarm | `SPELL_NEEDLE_SWARM` |
 | 381 | snapping teeth | `SPELL_SNAPPING_TEETH` |
 | 392 | beltyns burning blood | `SPELL_BELTYNS_BURNING_BLOOD` |
@@ -278,6 +290,7 @@ the preceding section.
 | 467 | blackthorns | `SPELL_BLACKTHORNS` |
 | 470 | feign death | `SPELL_FEIGN_DEATH` |
 | 471 | tranquility | `SPELL_TRANQUILITY` |
+| 473 | camouflage | `SPELL_CAMOUFLAGE` |
 | 475 | phantom heal | `SPELL_PHANTOM_HEAL` |
 | 476 | shadechill | `SPELL_SHADECHILL` |
 | 478 | agility | `SPELL_AGILITY` |

--- a/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md
@@ -2,10 +2,10 @@
 
 Status: implementation incomplete. The source registry audit was completed and
 independently re-verified 2026-08-24 against `sparser.c`, `spells.h`,
-`spell_parser.c`, and `psionics.c`. Five implementation checkpoints added 83
+`spell_parser.c`, and `psionics.c`. Six implementation checkpoints added 85
 functional gaps through native magic paths and focused direct handlers. A
 follow-up handler-level review found 14 live RoL spells that had been
-incorrectly classified as covered by loose substitutes. Six of those spells
+incorrectly classified as covered by loose substitutes. Four of those spells
 still require native implementations.
 
 This list compares every unique spell registered through `SPELL_CREATE()` in
@@ -30,7 +30,7 @@ below and must not be treated as live RoL content.
 - RoL registrations reviewed: 332 (327 live, 5 never compiled)
 - Live registrations with a close LuminariMUD equivalent: 229
 - Live registrations without a close equivalent: 98
-- Player-facing or functional gaps: 89 (83 implemented, 6 remaining)
+- Player-facing or functional gaps: 89 (85 implemented, 4 remaining)
 - RoL internal or stub registrations without an equivalent: 9
 - Registered only inside `#if 0` (never compiled): 5
 
@@ -57,7 +57,7 @@ converter map is numerically complete but not semantically complete.
 `_SOURCE_SPELL_MAP` contains 340 positive source IDs: all 327 live
 `SPELL_CREATE()` IDs, all 335 distinct positive `SPELL_*` numeric IDs in the
 source header, and the two non-spell IDs actually found in magic-item spell
-slots. Six live source spells currently map to substitutes that do not
+slots. Four live source spells currently map to substitutes that do not
 preserve their mechanics. Those mappings must move to the new native spell IDs
 after the remaining spells are implemented.
 
@@ -77,14 +77,12 @@ positive target spell.
 
 ## Remaining player-facing or functional gaps
 
-These six live RoL spells require distinct native registrations and mechanics.
+These four live RoL spells require distinct native registrations and mechanics.
 The current converter targets are listed only to identify the inadequate
 substitutes; they are not acceptable final mappings.
 
 | RoL ID | RoL spell | Current substitute | Required source behavior |
 |-------:|-----------|--------------------|--------------------------|
-| 343 | call lycanthrope | summon creature vi | Summons one randomly selected lycanthrope prototype, permits only one such follower, scales it to at most level 40 from caster level minus 10, assigns scaled hit points, charms it, and schedules charm expiration. Summon creature VI creates a dire tiger. |
-| 376 | tazriks frenzied hound | faithful hound | Opens a temporary vortex and makes a hellhound strike one randomly selected eligible room target once per combat pulse for three strikes. It does not create a persistent follower. |
 | 482 | elemental water embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 5 hit points per shared level, water breathing, fire/gas/acid protection, and 25 percent additional height and weight. |
 | 483 | elemental fire embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants roughly 7 hit points per shared level, fire shield, -65 source armor class, haste, flight, gas/fire protection, and 35 percent additional height and weight. |
 | 484 | elemental earth embodiment | geniekind | Transforms an eligible allied PC for a base duration of ten, modified by specialization; grants gas/cold protection and 50 percent additional height and weight. The live RoL handler grants roughly 7 hit points per shared level because it uses `EFHP_FACTOR`; the separately declared `EEHP_FACTOR` value of 10 is unused and should be resolved deliberately during implementation. |
@@ -230,8 +228,22 @@ source-specific rules. None has a class or domain assignment.
 The converter now preserves RoL beholder identity with a dedicated converted
 mobile flag so ice layer can distinguish beholders from generic aberrations.
 
-The complete inventory of the 83 implemented gaps remains below, preserving
-the original source-to-target accounting. The six remaining gaps are listed in
+### Implementation checkpoint 6: volatile summons and recurring events
+
+These two spells replace persistent generic summon substitutes with their
+source-specific lifecycles. Neither has a class or domain assignment.
+
+| Spell | Implemented gameplay purpose |
+|-------|------------------------------|
+| call lycanthrope | Randomly selects one of the two converted summon prototypes, limits the caster to one, scales it from caster level minus 10 to a maximum of 40, assigns level- and Constitution-scaled hit points, and charms it. After 30 seconds an idle summon departs; a fighting summon checks the caster's Charisma and either remains charmed for another 30 seconds or breaks free and attacks its former master. |
+| tazriks frenzied hound | Opens an Abyssal vortex and schedules one unsaved, non-resistible physical bite against a random eligible corporeal target per combat pulse for exactly three strikes. No persistent mobile is created. |
+
+The converter marks only source mobile prototypes 525 and 526 with a dedicated
+summon-role flag, so call lycanthrope does not select unrelated lycanthropes.
+The converter's spell mappings now target both native registrations.
+
+The complete inventory of the 85 implemented gaps remains below, preserving
+the original source-to-target accounting. The four remaining gaps are listed in
 the preceding section.
 
 | RoL ID | RoL spell | RoL constant |
@@ -273,6 +285,7 @@ the preceding section.
 | 332 | blacklight burst | `SPELL_BLACKLIGHT_BURST` |
 | 334 | minute meteors | `SPELL_MINUTE_METEORS` |
 | 341 | unseen servant | `SPELL_UNSEEN_SERVANT` |
+| 343 | call lycanthrope | `SPELL_CALL_LYCANTHROPE` |
 | 349 | thunder lance | `SPELL_THUNDER_LANCE` |
 | 350 | shadow bolt | `SPELL_SHADOW_BOLT` |
 | 351 | shadow burst | `SPELL_SHADOW_BURST` |
@@ -283,6 +296,7 @@ the preceding section.
 | 366 | phantasmal blades | `SPELL_PHANTASMAL_BLADES` |
 | 370 | soul bind | `SPELL_SOUL_BIND` |
 | 371 | death pact | `SPELL_DEATH_PACT` |
+| 376 | tazriks frenzied hound | `SPELL_TAZRIKS_FRENZIED_HOUND` |
 | 377 | dark wrath | `SPELL_DARK_WRATH` |
 | 378 | unholy aura | `SPELL_UNHOLY_AURA` |
 | 380 | needle swarm | `SPELL_NEEDLE_SWARM` |

--- a/docs/world_game-data/HLQUEST_FILE_FORMAT.md
+++ b/docs/world_game-data/HLQUEST_FILE_FORMAT.md
@@ -154,12 +154,12 @@ first-match and execution behavior in the runtime view.
 | `M` | Existing mobile VNUM. | Existing room VNUM, or `0` for the current room. |
 | `A` | Unused; canonical value is `0`. | Unused; canonical value is `0`. |
 | `D` | Unused; canonical value is `0`. | Unused; canonical value is `0`. |
-| `T` | Runtime-safe spell/skill `1..598` (`SPELL_RESERVED_DBC + 1` through `NUM_SPELLS - 1`). | Unused; canonical value is `0`. |
+| `T` | Runtime-safe spell/skill `1..612` (`SPELL_RESERVED_DBC + 1` through `NUM_SPELLS - 1`). | Unused; canonical value is `0`. |
 | `X` | Direction `0..5` in the current source-derived direction table. | Existing room VNUM with an exit in that direction. |
 | `F` | Unused; canonical value is `0`. | Unused; canonical value is `0`. |
 | `K` | Target class `0..37`, or `9999` for the lich transition. | Prerequisite class `0..37`, or `9999` for the lich transition. |
 | `U` | Church `0..12`. | Unused; canonical value is `0`. |
-| `S` | Runtime-safe spell/skill `1..598`. | Unused; canonical value is `0`. |
+| `S` | Runtime-safe spell/skill `1..612`. | Unused; canonical value is `0`. |
 | `P` | Signed quest-point delta `-100000000..100000000`. | Unused; canonical value is `0`. |
 | `E` | Non-negative experience through `2140000000`. | Unused; canonical value is `0`. |
 

--- a/docs/world_game-data/MOB_FLAGS.md
+++ b/docs/world_game-data/MOB_FLAGS.md
@@ -759,7 +759,7 @@ running automatic statistics.
 - `src/magic/spells.c` - Teleport target check (`spell_teleport()`)
 - `src/magic/magic.c` - Creation placement (`mag_creations()`)
 
-### RoL compatibility flags (Indices: 105-125)
+### RoL compatibility flags (Indices: 105-127)
 **Effect:** Preserve shared Realms of Luminari mobile behaviors during deterministic conversion.
 - `MOB_ROL_NICE_THIEF` allows stealing but suppresses automatic retaliation when caught
 - `MOB_ROL_STAY_SECTOR` restricts random wandering to the mobile's current sector
@@ -797,6 +797,10 @@ running automatic statistics.
   weapons dissolve on death. In the target it removes one-handed, off-hand, and two-handed
   wielded weapons before either special death handling or ordinary corpse creation, without
   consuming the persistent SpecProc slot.
+- `MOB_ROL_BEHOLDER` preserves source beholder identity for mechanics with explicit beholder
+  immunities.
+- `MOB_ROL_LYCANTHROPE_SUMMON` marks only the two converted prototypes selected by call
+  lycanthrope; ordinary lycanthropes do not receive the summon role.
 - These flags are converter-owned compatibility data; builders should use native flags
   and classes for new content unless reproducing converted RoL behavior
 
@@ -947,6 +951,8 @@ running automatic statistics.
 | 123 | MOB_ROL_TOTEM_SPIRIT | RoL-Totem-Spirit | Compatibility | Totem spirit fades without a corpse |
 | 124 | MOB_ROL_BLACK_VAPOR_DEATH | RoL-Black-Vapor-Death | Compatibility | Bloodstone undead becomes black vapor without a corpse |
 | 125 | MOB_ROL_ABYSS_FORGED | RoL-Abyss-Forged | Compatibility | Wielded abyss-forged weapons dissolve on death |
+| 126 | MOB_ROL_BEHOLDER | RoL-Beholder | Compatibility | Preserves source beholder identity for explicit immunities |
+| 127 | MOB_ROL_LYCANTHROPE_SUMMON | RoL-Lycanthrope-Summon | Compatibility | Prototype eligible for call lycanthrope |
 
 ---
 

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -36726,5 +36726,63 @@ log/perfmon-pre-copyover.txt with the complete current report. Only the newest s
 is retained; a failed snapshot leaves the prior complete file intact and does not stop
 the copyover.
 
+#0
+HEAL-UNDEAD
+
+Usage: cast 'heal undead' <target>
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): One undead character in the room
+
+Heal undead restores 4d(caster level) hit points to an undead target. It has no
+effect on a living target, and blackmantle prevents the healing. When one player
+lich casts it on another player lich, it restores 100 hit points instead.
+
+See also: BLACKMANTLE, HEAL, UNDEAD
+
+#0
+DARK-WRATH
+
+Usage: cast 'dark wrath'
+Duration: 5-12 rounds, based on caster level
+School of Magic: Enchantment
+Target(s): Self only
+Restrictions: Cannot be cast while fighting
+
+Dark wrath grants a +1 to +3 damage-roll bonus and a +3 to +5 bonus to Fortitude,
+Reflex, and Will saves. Both bonuses improve at caster levels 46 and 50. The spell
+cannot be renewed while it remains active.
+
+See also: SAVING THROWS, SPELLS
+
+#0
+UNHOLY-AURA
+
+Usage: cast 'unholy aura'
+Duration: 3 rounds before spell-duration modifiers
+School of Magic: Enchantment
+Target(s): Self only
+
+Unholy aura surrounds the caster with retaliatory flame under its own spell
+identity. It supplies the fire-shield state, so it cannot be combined with another
+effect that already provides that state.
+
+See also: FIRE-SHIELD, SPELLS
+
+#0
+CAMOUFLAGE
+
+Usage: cast 'camouflage'
+Duration: Until concealment is broken
+School of Magic: Illusion
+Target(s): Self only
+Restrictions: Cannot be cast while mounted
+
+Camouflage blends the caster into the surroundings, ends every fight involving the
+caster, and applies the hidden state. Actions that normally reveal a hidden character
+also end camouflage.
+
+See also: HIDE, SNEAK, SPELLS
+
 #34
 $~

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -36964,4 +36964,979 @@ See also: ELEMENTAL-WATER-EMBODIMENT, ELEMENTAL-FIRE-EMBODIMENT,
 ELEMENTAL-EARTH-EMBODIMENT, FLY, HASTE
 
 #0
+FARSEE SPELL-FARSEE
+
+Usage: cast 'farsee'
+Duration: Temporary
+School of Magic: Divination
+Target(s): Self only
+
+Farsee sharpens the caster's distant vision. While it lasts, the scan command
+can see as far as six rooms instead of its normal three-room range. The spell
+does not reveal anything that scan could not otherwise perceive.
+
+See also: SCAN, VISION, SPELLS
+
+#0
+REJUVENATE-MAJOR SPELL-REJUVENATE-MAJOR
+
+Usage: cast 'rejuvenate major' <target>
+Duration: Permanent
+School of Magic: Transmutation
+Target(s): Self or a consenting group member in the room
+
+Rejuvenate major permanently removes 1d3 years from the target's age. Another
+player must be grouped with the caster and must permit beneficial magic. The
+spell cannot reduce a character's age below the limits enforced by the game.
+
+See also: AGE, GROUP, REJUVENATE-MINOR
+
+#0
+REJUVENATE-MINOR SPELL-REJUVENATE-MINOR
+
+Usage: cast 'rejuvenate minor' <target>
+Duration: Temporary
+School of Magic: Transmutation
+Target(s): Self or a group member in the room
+
+Rejuvenate minor makes the target appear and feel younger for a limited time.
+It changes displayed age rather than the character's permanent birth date.
+
+See also: AGE, GROUP, REJUVENATE-MAJOR
+
+#0
+COMMAND-UNDEAD SPELL-COMMAND-UNDEAD
+
+Usage: cast 'command undead' <target>
+Duration: Temporary charm
+School of Magic: Necromancy
+Target(s): One undead mobile in the room
+
+Command undead attempts to bend an undead mobile to the caster's will. The
+target must be no higher than the caster's spell level and must pass the normal
+charm restrictions and saving throw. On success, it becomes a charmed follower.
+
+See also: CHARM, COMMAND-HORDE, FOLLOWERS, UNDEAD
+
+#0
+COMMAND-HORDE SPELL-COMMAND-HORDE
+
+Usage: cast 'command horde'
+Duration: Temporary charm
+School of Magic: Necromancy
+Target(s): Eligible undead mobiles in the caster's room
+
+Command horde attempts command undead against every eligible hostile undead
+mobile in the room. Creatures that are too powerful, protected from charm, or
+otherwise invalid are not brought under the caster's control.
+
+See also: CHARM, COMMAND-UNDEAD, FOLLOWERS, UNDEAD
+
+#0
+SLOW-POISON SPELL-SLOW-POISON
+
+Usage: cast 'slow poison' <target>
+Duration: Temporary
+School of Magic: Transmutation
+Target(s): One character in the room
+
+Slow poison steadies the target's body and halves the effective intensity of
+poisons for its duration. It delays their full effects; it does not remove the
+poison itself.
+
+See also: NEUTRALIZE-POISON, POISON, SPELLS
+
+#0
+COMPREHEND-LANGUAGES SPELL-COMPREHEND-LANGUAGES
+
+Usage: cast 'comprehend languages' <target>
+Duration: Temporary
+School of Magic: Divination
+Target(s): One character in the room
+
+Comprehend languages lets the target understand speech in unfamiliar
+languages. It does not teach those languages or grant the ability to speak
+them.
+
+See also: LANGUAGE, SPEAK, SPELLS
+
+#0
+FUMBLE SPELL-FUMBLE
+
+Usage: cast 'fumble' <target>
+Duration: Temporary
+School of Magic: Enchantment
+Target(s): One other character in the room
+
+Fumble drains the target's manual dexterity toward a score of 1 on a failed
+Will save. It cannot reduce an already lower Dexterity score further.
+
+See also: DEXTERITY, SAVING THROWS, STUMBLE
+
+#0
+STUMBLE SPELL-STUMBLE
+
+Usage: cast 'stumble' <target>
+Duration: Temporary
+School of Magic: Enchantment
+Target(s): One other character in the room
+
+Stumble ruins the target's balance on a failed Will save. The victim suffers a
+4-point penalty to armor class, Reflex saves, and initiative and becomes
+staggered for the spell's duration.
+
+See also: ARMOR-CLASS, FUMBLE, INITIATIVE, REFLEX
+
+#0
+ENERVATE SPELL-ENERVATE
+
+Usage: cast 'enervate' <target>
+Duration: Temporary
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Enervate drains the target's Constitution toward a score of 1 on a failed
+Fortitude save. It cannot reduce an already lower Constitution score further.
+
+See also: CONSTITUTION, ENERGY-DRAIN, FORTITUDE
+
+#0
+PROTECT-UNDEAD SPELL-PROTECT-UNDEAD
+
+Usage: cast 'protect undead' <target>
+Duration: Temporary
+School of Magic: Abjuration
+Target(s): One undead character in the room
+
+Protect undead places a dark ward around an undead target, granting 4 points
+of armor protection and a 2-point bonus to Will saves. Living targets cannot
+receive the spell.
+
+See also: PROTECTION-FROM-UNDEAD, UNDEAD, WILL
+
+#0
+PROTECTION-FROM-UNDEAD SPELL-PROTECTION-FROM-UNDEAD
+
+Usage: cast 'protection from undead' <target>
+Duration: Temporary
+School of Magic: Abjuration
+Target(s): One character in the room
+
+Protection from undead grants 2 points of armor protection, a 2-point Will
+save bonus, and reduces damage from undead attackers by 25 percent.
+
+See also: PROTECT-UNDEAD, UNDEAD, WILL
+
+#0
+ANCESTRAL-SHIELD SPELL-ANCESTRAL-SHIELD
+
+Usage: cast 'ancestral shield'
+Duration: Temporary
+School of Magic: Abjuration
+Target(s): The caster's group members in the room
+
+Ancestral shield gathers protective spirits around each nearby group member.
+While protected, a character takes 25 percent less damage from area spells.
+Overlapping quarter-reduction wards do not multiply their protection.
+
+See also: AREA SPELLS, GROUP, NATURES-BLESSING
+
+#0
+PROTECTION-FROM-ANIMALS SPELL-PROTECTION-FROM-ANIMALS
+
+Usage: cast 'protection from animals' <target>
+Duration: Temporary
+School of Magic: Abjuration
+Target(s): One character in the room
+
+Protection from animals grants 2 points of armor protection, a 2-point Reflex
+save bonus, and reduces damage from animal attackers by 25 percent.
+
+See also: ANIMALS, PROTECTION-FROM-UNDEAD, REFLEX
+
+#0
+PASS-WITHOUT-TRACE SPELL-PASS-WITHOUT-TRACE
+
+Usage: cast 'pass without trace'
+Duration: Temporary
+School of Magic: Transmutation
+Target(s): Self only
+
+Pass without trace prevents the caster from leaving tracks and greatly
+improves silent passage while moving. The effect ends normally when its
+duration expires.
+
+See also: HUNT, SNEAK, TRACK
+
+#0
+GREATER-REALM-OF-PROTECTION SPELL-GREATER-REALM-OF-PROTECTION
+
+Usage: cast 'greater realm of protection' <target>
+Duration: Temporary
+School of Magic: Abjuration
+Target(s): One character in the room
+
+Greater realm of protection surrounds the target with layered elemental
+wards. It grants level-scaled resistance to fire, cold, air, earth, acid, and
+electricity damage.
+
+See also: ENERGY-RESISTANCE, PROTECTION-FROM-ENERGY, RESIST-ENERGY
+
+#0
+FEIGN-DEATH SPELL-FEIGN-DEATH
+
+Usage: cast 'feign death' <target>
+Duration: Temporary
+School of Magic: Illusion
+Target(s): One character in the room
+
+Feign death ends all fights involving the target and leaves that character in
+a deathlike, sheltered state. The target remains alive and returns to normal
+when the illusion expires.
+
+See also: COMBAT, REFUGE, TRANQUILITY
+
+#0
+TRANQUILITY SPELL-TRANQUILITY
+
+Usage: cast 'tranquility'
+Duration: Temporary
+School of Magic: Enchantment
+Target(s): Eligible characters in the caster's room
+
+Tranquility ends eligible fights throughout the room and imposes a temporary
+docile state. The caster and grouped allies are included; normal area-target
+rules determine which other characters can be affected.
+
+See also: AREA SPELLS, COMBAT, FEIGN-DEATH
+
+#0
+AGILITY SPELL-AGILITY
+
+Usage: cast 'agility' <target>
+Duration: Temporary
+School of Magic: Transmutation
+Target(s): One character in the room
+
+Agility sharpens balance and reactions, granting a 4-point bonus to armor
+class, Reflex saves, and initiative for its duration.
+
+See also: ARMOR-CLASS, INITIATIVE, REFLEX
+
+#0
+NATURES-BLESSING SPELL-NATURES-BLESSING
+
+Usage: cast 'natures blessing'
+Duration: Temporary
+School of Magic: Abjuration
+Target(s): Self only
+
+Nature's blessing grants a level-scaled attack bonus and bonuses to Fortitude,
+Reflex, and Will saves. It also reduces area-spell damage by 25 percent;
+overlapping quarter-reduction wards do not multiply their protection.
+
+See also: ANCESTRAL-SHIELD, AREA SPELLS, SAVING THROWS
+
+#0
+SONG-OF-TRAVEL SPELL-SONG-OF-TRAVEL
+
+Usage: cast 'song of travel'
+Duration: Temporary
+School of Magic: Transmutation
+Target(s): The caster's group members in the room
+
+Song of travel restores movement to nearby group members, grants flight, and
+increases their travel speed for the spell's duration.
+
+See also: FLY, GROUP, MOVEMENT
+
+#0
+SANDBLAST SPELL-SANDBLAST
+
+Usage: cast 'sandblast' <target>
+Duration: Instantaneous damage; conditions are temporary
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Sandblast scours the target with earth damage. It can blind a sighted victim;
+casting it on a victim already blinded by the spell can also silence that
+victim. Normal spell resistance and saving throws apply.
+
+See also: BLINDNESS, EARTH, SILENCE
+
+#0
+FELL-FROST SPELL-FELL-FROST
+
+Usage: cast 'fell frost' <target>
+Duration: Instantaneous damage; conditions are temporary
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Fell frost deals heavy cold damage and can slow its victim. A target already
+slowed by fell frost can instead become frozen and unable to act. Normal spell
+resistance and saving throws apply.
+
+See also: COLD, FREEZE, SLOW
+
+#0
+NERVE-DANCE SPELL-NERVE-DANCE
+
+Usage: cast 'nerve dance' <target>
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Nerve dance wracks a living, corporeal, non-elemental target with negative
+energy. Undead, elementals, and creatures without a material body are not
+valid victims.
+
+See also: NEGATIVE-ENERGY, SPECTRAL-HAND, UNDEAD
+
+#0
+SPECTRAL-HAND SPELL-SPECTRAL-HAND
+
+Usage: cast 'spectral hand' <target>
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Spectral hand strikes one target with negative-energy spell damage. Normal
+spell resistance and saving throws apply.
+
+See also: NEGATIVE-ENERGY, NERVE-DANCE, TOUCH SPELLS
+
+#0
+RAIN-OF-BLOOD SPELL-RAIN-OF-BLOOD
+
+Usage: cast 'rain of blood'
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): Eligible enemies in the caster's room
+
+Rain of blood drenches eligible room enemies in unholy damage. Group members
+and other protected area targets are excluded by the normal area-spell rules.
+
+See also: AREA SPELLS, ROT, UNHOLY
+
+#0
+ROT SPELL-ROT
+
+Usage: cast 'rot'
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): Eligible living enemies in the caster's room
+
+Rot deals negative-energy damage throughout the room, but only to living,
+corporeal targets. Undead and immaterial creatures are unaffected.
+
+See also: AREA SPELLS, NEGATIVE-ENERGY, RAIN-OF-BLOOD
+
+#0
+ICE-TOMB SPELL-ICE-TOMB
+
+Usage: cast 'ice tomb' <target>
+Duration: Instantaneous damage; paralysis is temporary
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Ice tomb deals heavy cold damage. A badly wounded survivor can be sealed in
+ice and paralyzed if the secondary effect succeeds.
+
+See also: COLD, PARALYSIS, FELL-FROST
+
+#0
+CONSTRICTION SPELL-CONSTRICTION
+
+Usage: cast 'constriction' <target>
+Duration: Instantaneous damage; silence is temporary
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Constriction crushes the target with force damage, interrupts an active spell
+cast, and can briefly silence the victim.
+
+See also: CASTING, FORCE, SILENCE
+
+#0
+SANDSTORM SPELL-SANDSTORM
+
+Usage: cast 'sandstorm'
+Duration: Instantaneous damage; conditions are temporary
+School of Magic: Evocation
+Target(s): Eligible enemies in the caster's room
+
+Sandstorm blasts eligible room enemies with earth damage and can leave its
+victims blinded and staggered. Normal area-spell defenses apply.
+
+See also: AREA SPELLS, BLINDNESS, EARTH, STAGGERED
+
+#0
+BLACKLIGHT-BURST SPELL-BLACKLIGHT-BURST
+
+Usage: cast 'blacklight burst'
+Duration: Instantaneous damage; slow is temporary
+School of Magic: Necromancy
+Target(s): Eligible enemies in the caster's room
+
+Blacklight burst deals unholy area damage and can slow its victims. Undead
+take reduced damage from the burst.
+
+See also: AREA SPELLS, SLOW, UNHOLY, UNDEAD
+
+#0
+MINUTE-METEORS SPELL-MINUTE-METEORS
+
+Usage: cast 'minute meteors' <target>
+Duration: Instantaneous
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Minute meteors launches as many as five small fire projectiles at one target.
+Each projectile is resolved through the normal multi-projectile spell path.
+
+See also: FIRE, MAGIC-MISSILE, PROJECTILES
+
+#0
+THUNDER-LANCE SPELL-THUNDER-LANCE
+
+Usage: cast 'thunder lance' <target>
+Duration: Instantaneous
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Thunder lance drives electrical damage through one target. Its disruptive
+force also shatters lesser globes and energy wards protecting the victim.
+
+See also: ELECTRICITY, GLOBE-OF-INVULNERABILITY, PROTECTION-FROM-ENERGY
+
+#0
+SHADOW-BOLT SPELL-SHADOW-BOLT
+
+Usage: cast 'shadow bolt' <target>
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): One other character in the room
+
+Shadow bolt launches as many as five bolts of illusion damage at a single
+target. Each bolt is resolved through the normal multi-projectile spell path.
+
+See also: ILLUSION, MINUTE-METEORS, PROJECTILES
+
+#0
+SHADOW-BURST SPELL-SHADOW-BURST
+
+Usage: cast 'shadow burst'
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): Eligible enemies in the caster's room
+
+Shadow burst floods the room with damaging illusion, striking eligible enemies
+under the normal area-spell rules.
+
+See also: AREA SPELLS, SHADOW-BOLT, SHADOW-MAGIC
+
+#0
+SHADOW-MAGIC SPELL-SHADOW-MAGIC
+
+Usage: cast 'shadow magic' <target>
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): One other character in the room
+
+Shadow magic shapes raw illusion into a damaging single-target attack. Normal
+spell resistance and saving throws apply.
+
+See also: ILLUSION, SHADOW-BOLT, SHADOW-BURST
+
+#0
+PHANTASMAL-BLADES SPELL-PHANTASMAL-BLADES
+
+Usage: cast 'phantasmal blades'
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): Eligible enemies in the caster's room
+
+Phantasmal blades fills the room with illusory edges that deal slashing damage
+to eligible enemies.
+
+See also: AREA SPELLS, ILLUSION, SHADOW-BURST
+
+#0
+NEEDLE-SWARM SPELL-NEEDLE-SWARM
+
+Usage: cast 'needle swarm' <target>
+Duration: Instantaneous
+School of Magic: Conjuration
+Target(s): One other character in the room
+
+Needle swarm conjures a cloud of sharp needles that deals puncture damage to
+one target.
+
+See also: CONJURATION, PUNCTURE, SNAPPING-TEETH
+
+#0
+SNAPPING-TEETH SPELL-SNAPPING-TEETH
+
+Usage: cast 'snapping teeth' <target>
+Duration: Instantaneous
+School of Magic: Conjuration
+Target(s): One other character in the room
+
+Snapping teeth conjures biting jaws that deal slashing damage to one target.
+
+See also: CONJURATION, NEEDLE-SWARM, SLASHING
+
+#0
+BELTYNS-BURNING-BLOOD SPELL-BELTYNS-BURNING-BLOOD
+
+Usage: cast 'beltyns burning blood' <target>
+Duration: Instantaneous damage; burning is temporary
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Beltyns burning blood damages a living target. If the victim is already
+wounded and the secondary effect succeeds, the victim's blood ignites and
+continues burning for a limited time.
+
+See also: BLACKMANTLE, BURNING, NECROMANCY
+
+#0
+BLACKMANTLE SPELL-BLACKMANTLE
+
+Usage: cast 'blackmantle' <target>
+Duration: Temporary
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Blackmantle surrounds the victim with deathly magic, suppressing normal hit
+point regeneration and reducing incoming healing while the effect lasts.
+
+See also: BELTYNS-BURNING-BLOOD, HEALING, REGENERATION
+
+#0
+EARTHBLOOD SPELL-EARTHBLOOD
+
+Usage: cast 'earthblood' <target>
+Duration: Instantaneous damage; rigidity is temporary
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Earthblood deals earth damage and can solidify a living victim's body,
+briefly preventing movement.
+
+See also: EARTH, HOLD-PERSON, ROCK-TO-MUD
+
+#0
+SOUL-TEMPEST SPELL-SOUL-TEMPEST
+
+Usage: cast 'soul tempest'
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): Eligible enemies in the caster's room
+
+Soul tempest tears through eligible room enemies with force damage. Normal
+area-spell defenses apply.
+
+See also: AREA SPELLS, FORCE, NECROMANCY
+
+#0
+DUST-DEVIL SPELL-DUST-DEVIL
+
+Usage: cast 'dust devil' <target>
+Duration: Instantaneous
+School of Magic: Conjuration
+Target(s): One other character in the room
+
+Dust devil deals air damage and can wrench a droppable weapon from the
+target's grasp. Bound, cursed, or otherwise protected weapons remain held.
+
+See also: AIR, DISARM, WEAPONS
+
+#0
+SUFFOCATE SPELL-SUFFOCATE
+
+Usage: cast 'suffocate' <target>
+Duration: Instantaneous damage; silence is temporary
+School of Magic: Transmutation
+Target(s): One other character in the room
+
+Suffocate tears the air from the target's lungs, dealing air damage and
+briefly preventing speech and spellcasting if the secondary effect succeeds.
+
+See also: AIR, CONSTRICTION, SILENCE
+
+#0
+BLACKTHORNS SPELL-BLACKTHORNS
+
+Usage: cast 'blackthorns' <target>
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): One other character in the room
+
+Blackthorns assails one target with illusory thorns that deal puncture damage.
+
+See also: ILLUSION, NEEDLE-SWARM, PUNCTURE
+
+#0
+SHADECHILL SPELL-SHADECHILL
+
+Usage: cast 'shadechill' <target>
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): One other character in the room
+
+Shadechill wraps one target in illusory cold and deals cold damage.
+
+See also: COLD, ILLUSION, SHADOW-MAGIC
+
+#0
+AIR-BLAST SPELL-AIR-BLAST
+
+Usage: cast 'air blast' <target>
+Duration: Instantaneous
+School of Magic: Evocation
+Target(s): One other character in the room
+
+Air blast strikes one target with concentrated air damage.
+
+See also: AIR, CYCLONE, DUST-DEVIL
+
+#0
+SHADOW-FLUX SPELL-SHADOW-FLUX
+
+Usage: cast 'shadow flux' <target>
+Duration: Temporary
+School of Magic: Illusion
+Target(s): One other character in the room
+
+Shadow flux tears at the target's magical defenses, temporarily removing a
+large amount of spell resistance.
+
+See also: ILLUSION, SPELL-RESISTANCE, SPELLS
+
+#0
+POLTERGEIST SPELL-POLTERGEIST
+
+Usage: cast 'poltergeist'
+Duration: Instantaneous
+School of Magic: Necromancy
+Target(s): Random eligible enemies in the caster's room
+
+Poltergeist calls up dark forms that hurl three force strikes. Each strike
+selects a random eligible corporeal target in the room; no persistent creature
+is summoned.
+
+See also: AREA SPELLS, FORCE, SUMMONING
+
+#0
+MINOR-CREATION SPELL-MINOR-CREATION
+
+Usage: cast 'minor creation' <item>
+Duration: Until lost, destroyed, or the world resets
+School of Magic: Conjuration
+Target(s): One selected mundane object
+
+Minor creation forms one plain object in the caster's room without using a
+world prototype. Choices are bag, ration, raft, robe, barrel, club, staff,
+spear, dagger, shield, torch, box, paper, or quill. Created objects have no
+sale or rent value and cannot be retained through rent.
+
+See also: CONJURATION, CREATE-FOOD, OBJECTS
+
+#0
+VENTRILOQUATE SPELL-VENTRILOQUATE
+
+Usage: cast 'ventriloquate' <target> <speech>
+Duration: Instantaneous
+School of Magic: Illusion
+Target(s): One nearby character or object
+
+Ventriloquate throws the supplied speech toward a visible character or object
+in the room. Listeners hear the words as if that target spoke them, although a
+successful Will save reveals the magical echo. Deaf listeners hear nothing.
+
+See also: ILLUSION, SAY, WILL
+
+#0
+PRESERVE SPELL-PRESERVE
+
+Usage: cast 'preserve' <corpse>
+Duration: Extends the corpse timer
+School of Magic: Necromancy
+Target(s): One corpse in the room
+
+Preserve slows a corpse's decay by extending its remaining timer. Player
+corpses receive a larger extension than ordinary corpses.
+
+See also: CORPSE, CORPSE-GLAMOR, EMBALM
+
+#0
+WRAITHFORM SPELL-WRAITHFORM
+
+Usage: cast 'wraithform'
+Duration: Temporary
+School of Magic: Illusion
+Target(s): Self only
+
+Wraithform ends combat involving the caster and turns the caster immaterial
+without removing or discarding equipment. The body becomes solid again when
+the effect expires.
+
+See also: ETHEREAL, IMMATERIAL, PHASE-DOOR
+
+#0
+CREATE-SPRING SPELL-CREATE-SPRING
+
+Usage: cast 'create spring'
+Duration: Temporary object
+School of Magic: Conjuration
+Target(s): The caster's outdoor room
+
+Create spring causes a clear fountain of water to burst from open outdoor
+ground. Its capacity and lifetime scale with spell level. The spring has no
+sale or rent value and eventually decays.
+
+See also: DRINK, FOUNTAIN, WATER
+
+#0
+MOONWELL SPELL-MOONWELL
+
+Usage: cast 'moonwell' <player>
+Duration: Temporary portals
+School of Magic: Conjuration
+Target(s): One player elsewhere in the world
+
+Moonwell creates paired pools of silver light between the caster's room and
+the target player's room. Both locations must be distinct, valid mortal
+destinations on the material plane and must permit summoning and teleportation.
+
+See also: PORTAL, SUMMONING, TELEPORT
+
+#0
+EMBALM SPELL-EMBALM
+
+Usage: cast 'embalm' <corpse>
+Duration: Extends the corpse timer
+School of Magic: Necromancy
+Target(s): One corpse in the room
+
+Embalm greatly extends a corpse's remaining decay timer, preserving it longer
+than the preserve spell.
+
+See also: CORPSE, CORPSE-GLAMOR, PRESERVE
+
+#0
+AIRY-WATER SPELL-AIRY-WATER
+
+Usage: cast 'airy water'
+Duration: Temporary room effect
+School of Magic: Transmutation
+Target(s): The caster's underwater room
+
+Airy water makes an underwater room breathable for the duration. It changes
+the local environment rather than granting water breathing to one character.
+
+See also: ROOM SPELLS, UNDERWATER, WATER-BREATHING
+
+#0
+UNSEEN-SERVANT SPELL-UNSEEN-SERVANT
+
+Usage: cast 'unseen servant'
+Duration: Temporary
+School of Magic: Conjuration
+Target(s): Self only
+
+Unseen servant calls an invisible helper that temporarily increases the
+caster's carrying capacity.
+
+See also: CARRYING, CONJURATION, SUMMONING
+
+#0
+MISLEAD SPELL-MISLEAD
+
+Usage: cast 'mislead'
+Duration: Temporary
+School of Magic: Illusion
+Target(s): Self only
+
+Mislead wraps the caster in deceptive shadows, concealing the caster from
+pursuit and preventing ordinary tracking while the effect lasts.
+
+See also: ILLUSION, PASS-WITHOUT-TRACE, TRACK
+
+#0
+SEQUESTER SPELL-SEQUESTER
+
+Usage: cast 'sequester' <target>
+Duration: Temporary
+School of Magic: Illusion
+Target(s): One character in the room
+
+Sequester cuts the target off from distant magic. Teleportation and summoning
+effects cannot target the subject until the sequester ends.
+
+See also: DIMENSIONAL-ANCHOR, SUMMONING, TELEPORT
+
+#0
+DIMENSION-SHIFT SPELL-DIMENSION-SHIFT
+
+Usage: cast 'dimension shift'
+Duration: Temporary
+School of Magic: Conjuration
+Target(s): The caster and group members in the room
+
+Dimension shift ends combat for affected group members and folds them into a
+sheltered pocket beyond ordinary material reach. Dimensional locks and
+teleport wards can prevent a character from joining the shift.
+
+See also: DIMENSIONAL-ANCHOR, GROUP, IMMATERIAL
+
+#0
+SOUL-BIND SPELL-SOUL-BIND
+
+Usage: cast 'soul bind' <target>
+Duration: Temporary
+School of Magic: Necromancy
+Target(s): One other character in the room
+
+Soul bind anchors the victim on a failed save and prevents teleportation while
+the binding remains in place.
+
+See also: DIMENSIONAL-ANCHOR, NECROMANCY, TELEPORT
+
+#0
+DEATH-PACT SPELL-DEATH-PACT
+
+Usage: cast 'death pact'
+Duration: Temporary
+School of Magic: Necromancy
+Target(s): The caster's group
+
+Death pact lets affected group members remain standing below the normal death
+threshold, down to -120 hit points. It does not restore hit points and ends
+when its duration expires.
+
+See also: DEATH, GROUP, HIT-POINTS
+
+#0
+SPIRIT-WALK SPELL-SPIRIT-WALK
+
+Usage: cast 'spirit walk' <player>
+Duration: Instantaneous travel
+School of Magic: Conjuration
+Target(s): One player with a corpse in the world
+
+Spirit walk follows the path of a dead character to that player's corpse. A
+different target must be grouped with the caster. Teleport wards, invalid
+destinations, or a corpse already in the room prevent travel.
+
+See also: CORPSE, GROUP, TELEPORT
+
+#0
+ROCK-TO-MUD SPELL-ROCK-TO-MUD
+
+Usage: cast 'rock to mud' [room|earth elemental]
+Duration: Temporary terrain or instantaneous damage
+School of Magic: Transmutation
+Target(s): The room or one earth elemental in it
+
+Against an earth elemental, rock to mud deals earth damage with normal spell
+defenses. Otherwise it softens the room into difficult terrain until the
+effect expires or mud to rock removes it.
+
+See also: DIFFICULT-TERRAIN, EARTH, MUD-TO-ROCK
+
+#0
+MUD-TO-ROCK SPELL-MUD-TO-ROCK
+
+Usage: cast 'mud to rock' [room|allied earth elemental]
+Duration: Instantaneous
+School of Magic: Transmutation
+Target(s): The room or one allied earth elemental in it
+
+Mud to rock removes rock-to-mud terrain from the room. When directed at an
+allied earth elemental, it instead hardens that creature's form and restores
+hit points.
+
+See also: EARTH, HEALING, ROCK-TO-MUD
+
+#0
+PHANTOM-HEAL SPELL-PHANTOM-HEAL
+
+Usage: cast 'phantom heal' <target>
+Duration: Temporary vitality
+School of Magic: Illusion
+Target(s): Self or a group member in the room
+
+Phantom heal lends temporary vitality to a target below half health, up to the
+half-health mark. The granted hit points are removed when the illusion ends;
+the spell cannot stack with itself.
+
+See also: GROUP, HEALING, TEMPORARY-HIT-POINTS
+
+#0
+CURSE-ITEM SPELL-CURSE-ITEM
+
+Usage: cast 'curse item' <object>
+Duration: Permanent object alteration
+School of Magic: Enchantment
+Target(s): One object in the caster's inventory
+
+Curse item makes an inventory object impossible to drop. If the object is a
+weapon, the curse also weakens its damage die.
+
+See also: CURSE, OBJECTS, REMOVE-CURSE
+
+#0
+CORPSE-GLAMOR SPELL-CORPSE-GLAMOR
+
+Usage: cast 'corpse glamor' <corpse>
+Duration: Permanent object alteration
+School of Magic: Illusion
+Target(s): One corpse in the room
+
+Corpse glamor disguises a corpse's bulk and reduces its weight to one. It does
+not extend the corpse's decay timer.
+
+See also: CORPSE, EMBALM, PRESERVE
+
+#0
+SUN-SHADOW SPELL-SUN-SHADOW
+
+Usage: cast 'sun shadow'
+Duration: Temporary room effect
+School of Magic: Illusion
+Target(s): The caster's room
+
+Sun shadow veils the room in supernatural darkness until the effect expires.
+
+See also: DARKNESS, LIGHT, ROOM SPELLS
+
+#0
+EARTH-FOG SPELL-EARTH-FOG
+
+Usage: cast 'earth fog'
+Duration: Temporary room effect
+School of Magic: Conjuration
+Target(s): The caster's room
+
+Earth fog fills the room with obscuring earthen mist. The fog remains until
+its room effect expires or is otherwise removed.
+
+See also: FOG, OBSCURING-MIST, ROOM SPELLS
+
+#0
+FIRE-FOG SPELL-FIRE-FOG
+
+Usage: cast 'fire fog'
+Duration: Temporary room effect
+School of Magic: Evocation
+Target(s): The caster's room
+
+Fire fog fills the room with luminous fiery mist, temporarily illuminating
+the area until the room effect expires or is otherwise removed.
+
+See also: EARTH-FOG, LIGHT, ROOM SPELLS
+
+#0
 $~

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -36844,5 +36844,41 @@ beholders, dragons, and immaterial targets are immune.
 
 See also: GREASE, POSITION, REFLEX SAVES
 
+#0
+CALL-LYCANTHROPE
+
+Usage: cast 'call lycanthrope'
+Duration: Volatile; first charm check after 30 seconds
+School of Magic: Conjuration
+Target(s): No target
+
+Call lycanthrope opens a black door and brings through either the converted
+werewolf or weretiger summon. The creature's level is the caster's level minus
+10, with a minimum of 1 and a maximum of 40. Its hit points scale from that
+level and Constitution. A caster can control only one called lycanthrope.
+
+The creature is charmed and follows the caster. After 30 seconds, an idle
+lycanthrope returns through the door. A fighting lycanthrope tests the caster's
+Charisma: success maintains the charm for another 30 seconds, while failure
+breaks the charm and turns the creature against its former master.
+
+See also: CHARM, FOLLOWERS, SUMMONING
+
+#0
+TAZRIKS-FRENZIED-HOUND
+
+Usage: cast 'tazriks frenzied hound'
+Duration: Three combat pulses
+School of Magic: Conjuration
+Target(s): One randomly selected eligible enemy per pulse
+
+Tazrik's frenzied hound opens a temporary Abyssal vortex. Beginning one combat
+pulse after the spell resolves, the hound bites one random corporeal enemy in
+the stored room. It strikes once per combat pulse for three total strikes, then
+the vortex closes. Each bite uses level-scaled physical spell damage without a
+save or magic-resistance check. The spell never creates a persistent follower.
+
+See also: AREA SPELLS, FAITHFUL-HOUND, SUMMONING
+
 #34
 $~

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -36726,7 +36726,7 @@ log/perfmon-pre-copyover.txt with the complete current report. Only the newest s
 is retained; a failed snapshot leaves the prior complete file intact and does not stop
 the copyover.
 
-#0
+#34
 HEAL-UNDEAD
 
 Usage: cast 'heal undead' <target>
@@ -36880,5 +36880,88 @@ save or magic-resistance check. The spell never creates a persistent follower.
 
 See also: AREA SPELLS, FAITHFUL-HOUND, SUMMONING
 
-#34
+#0
+ELEMENTAL-WATER-EMBODIMENT SPELL-ELEMENTAL-WATER-EMBODIMENT
+
+Usage: cast 'elemental water embodiment' <target>
+Duration: Base 10, modified by the caster's spell-duration bonus
+School of Magic: Transmutation
+Target(s): One eligible player character in the room
+
+Elemental water embodiment transforms an eligible same-side player character.
+The target gains approximately 5 hit points per shared caster/target level,
+water breathing, 50 percent resistance to fire, poison, and acid, and 25
+percent additional height and weight. The hit-point bonus varies by up to five
+percent.
+
+The target must be unmounted and cannot already have an elemental embodiment.
+The caster can maintain only one elemental embodiment at a time. Removing or
+ending either side of the linked effect ends the transformation.
+
+See also: ELEMENTAL-FIRE-EMBODIMENT, ELEMENTAL-EARTH-EMBODIMENT,
+ELEMENTAL-AIR-EMBODIMENT, WATER-BREATHING
+
+#0
+ELEMENTAL-FIRE-EMBODIMENT SPELL-ELEMENTAL-FIRE-EMBODIMENT
+
+Usage: cast 'elemental fire embodiment' <target>
+Duration: Base 10, modified by the caster's spell-duration bonus
+School of Magic: Transmutation
+Target(s): One eligible player character in the room
+
+Elemental fire embodiment transforms an eligible same-side player character.
+The target gains approximately 7 hit points per shared caster/target level, +6
+natural armor, fire shield, haste, flight, 50 percent resistance to poison and
+fire, and 35 percent additional height and weight. The hit-point bonus varies
+by up to five percent.
+
+The target must be unmounted and cannot already have an elemental embodiment.
+The caster can maintain only one elemental embodiment at a time. Removing or
+ending either side of the linked effect ends the transformation.
+
+See also: ELEMENTAL-WATER-EMBODIMENT, ELEMENTAL-EARTH-EMBODIMENT,
+ELEMENTAL-AIR-EMBODIMENT, FIRE-SHIELD, HASTE
+
+#0
+ELEMENTAL-EARTH-EMBODIMENT SPELL-ELEMENTAL-EARTH-EMBODIMENT
+
+Usage: cast 'elemental earth embodiment' <target>
+Duration: Base 10, modified by the caster's spell-duration bonus
+School of Magic: Transmutation
+Target(s): One eligible player character in the room
+
+Elemental earth embodiment transforms an eligible same-side player character.
+The target gains approximately 7 hit points per shared caster/target level, 50
+percent resistance to poison and cold, and 50 percent additional height and
+weight. The hit-point bonus varies by up to five percent.
+
+The target must be unmounted and cannot already have an elemental embodiment.
+The caster can maintain only one elemental embodiment at a time. Removing or
+ending either side of the linked effect ends the transformation.
+
+See also: ELEMENTAL-WATER-EMBODIMENT, ELEMENTAL-FIRE-EMBODIMENT,
+ELEMENTAL-AIR-EMBODIMENT, COLD
+
+#0
+ELEMENTAL-AIR-EMBODIMENT SPELL-ELEMENTAL-AIR-EMBODIMENT
+
+Usage: cast 'elemental air embodiment' <target>
+Duration: Base 10, modified by the caster's spell-duration bonus
+School of Magic: Transmutation
+Target(s): One eligible player character in the room
+
+Elemental air embodiment transforms an eligible same-side player character.
+The target gains approximately 3 hit points per shared caster/target level, +5
+natural armor, haste, flight, 50 percent resistance to poison and acid, and 15
+percent additional height and weight. The hit-point bonus varies by up to five
+percent.
+
+The target must be unmounted and cannot already have an elemental embodiment.
+The caster can maintain only one elemental embodiment at a time. Removing or
+ending either side of the linked effect ends the transformation.
+
+See also: ELEMENTAL-WATER-EMBODIMENT, ELEMENTAL-FIRE-EMBODIMENT,
+ELEMENTAL-EARTH-EMBODIMENT, FLY, HASTE
+
+#0
 $~

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -36784,5 +36784,65 @@ also end camouflage.
 
 See also: HIDE, SNEAK, SPELLS
 
+#0
+CYCLONE
+
+Usage: cast 'cyclone'
+Duration: Instantaneous
+School of Magic: Evocation
+Target(s): Eligible enemies in the caster's room
+
+Cyclone strikes eligible room enemies with air damage. Normal spell saves and
+area-spell defenses apply. For a player caster, a zone wind speed of 25 or lower
+halves the spell's damage. If no current weather reading exists, the spell safely
+uses the low-wind result.
+
+See also: AREA SPELLS, WEATHER, WHIRLWIND
+
+#0
+LICH-TOUCH
+
+Usage: cast 'lich touch' <target>
+Duration: Instantaneous damage; secondary effects vary
+School of Magic: Necromancy
+Target(s): One character in the room
+
+Lich touch deals direct unholy damage without a save for the initial damage. Fire
+elementals take additional damage, a cold shield halves it, and a fire shield adds
+damage. A separate Fortitude save resists one point of Strength loss and slow.
+Cold shields make that secondary save harder, while fire elementals resist it more
+easily. Strength loss can accumulate. Dragons ignore the secondary effects.
+
+See also: COLD-SHIELD, FIRE-SHIELD, SLOW, STRENGTH
+
+#0
+LAVA-BURST
+
+Usage: cast 'lava burst'
+Duration: Instantaneous damage; burning lasts 5 rounds
+School of Magic: Evocation
+Target(s): Eligible enemies in the caster's room
+
+Lava burst explodes across the room for fire damage. A survivor who actually loses
+hit points and is not already burning catches fire for five rounds, taking the
+normal ongoing fire damage each combat heartbeat.
+
+See also: AREA SPELLS, FIRE, FIRE-STORM
+
+#0
+ICE-LAYER
+
+Usage: cast 'ice layer' <target>
+Duration: Instantaneous
+School of Magic: Evocation
+Target(s): One standing opponent in the room
+
+Ice layer coats a corporeal standing opponent in treacherous ice. On a failed
+Reflex save, the target takes 2d10 bludgeoning damage, falls to the sitting/prone
+position, and loses one combat pulse to action lag. Demons, devils, angels,
+beholders, dragons, and immaterial targets are immune.
+
+See also: GREASE, POSITION, REFLEX SAVES
+
 #34
 $~

--- a/scripts/world/tests/test_constants.py
+++ b/scripts/world/tests/test_constants.py
@@ -106,15 +106,19 @@ class ConstantsTests(unittest.TestCase):
     self.assertIn("POS_CRAWLING", positions[5]["aliases"])
     self.assertNotIn("MOB_DIRE_SPIDER", mob_macros)
 
-  def test_rol_death_flags_match_runtime_contract(self) -> None:
+  def test_rol_identity_flags_match_runtime_contract(self) -> None:
     entries = self.manifest["tables"]["mob"]["entries"]
-    self.assertEqual(126, len(entries))
+    self.assertEqual(128, len(entries))
     self.assertEqual("MOB_ROL_TOTEM_SPIRIT", entries[123]["macro"])
     self.assertEqual("RoL-Totem-Spirit", entries[123]["name"])
     self.assertEqual("MOB_ROL_BLACK_VAPOR_DEATH", entries[124]["macro"])
     self.assertEqual("RoL-Black-Vapor-Death", entries[124]["name"])
     self.assertEqual("MOB_ROL_ABYSS_FORGED", entries[125]["macro"])
     self.assertEqual("RoL-Abyss-Forged", entries[125]["name"])
+    self.assertEqual("MOB_ROL_BEHOLDER", entries[126]["macro"])
+    self.assertEqual("RoL-Beholder", entries[126]["name"])
+    self.assertEqual("MOB_ROL_LYCANTHROPE_SUMMON", entries[127]["macro"])
+    self.assertEqual("RoL-Lycanthrope-Summon", entries[127]["name"])
 
   def test_mobile_conversion_symbols_match_runtime_headers(self) -> None:
     symbols = self.manifest["symbols"]
@@ -149,7 +153,7 @@ class ConstantsTests(unittest.TestCase):
   def test_flag_above_31_round_trips_in_later_chunk(self) -> None:
     tokens = encode_bits({0, 41, 95, 126})
     self.assertEqual(("a", "j", "F", "E"), tokens)
-    decoded = decode_tokens(list(tokens), entry_count=127)
+    decoded = decode_tokens(list(tokens), entry_count=128)
     self.assertEqual({0, 41, 95, 126}, set(decoded.bits))
     self.assertEqual((), decoded.issues)
 
@@ -174,7 +178,7 @@ class ConstantsTests(unittest.TestCase):
     self.assertEqual(("a", "0", "0", "0"), encode_bits({0}))
 
   def test_high_local_decoder_bit_is_diagnosed(self) -> None:
-    decoded = decode_tokens(["G"], entry_count=127)
+    decoded = decode_tokens(["G"], entry_count=128)
     self.assertEqual("FLG002", decoded.issues[0].code)
 
   def test_all_invalid_flag_encoding_classes_are_diagnosed(self) -> None:

--- a/scripts/world/tests/test_docs_check.py
+++ b/scripts/world/tests/test_docs_check.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 
 from wtool_lib.constants import default_repo_root, load_manifest
@@ -67,6 +68,42 @@ class DocumentationCheckTests(unittest.TestCase):
     text, findings = _encoding_findings("fixture.md", "bad \N{RIGHTWARDS ARROW}\r\n".encode())
     self.assertIsNotNone(text)
     self.assertEqual({"DOC003", "DOC004"}, {finding.code for finding in findings})
+
+  def test_rol_spell_gap_inventory_has_flat_help_coverage(self) -> None:
+    gap_document = (
+        self.repo_root / "docs/ongoing-projects/ROL_SPELL_EQUIVALENCE_GAPS.md"
+    ).read_text(encoding="ascii")
+    inventory = gap_document.split(
+        "The complete inventory of all 89 implemented gaps remains below", 1
+    )[1].split("## RoL internal or stub registrations", 1)[0]
+    spell_names = [
+        name.strip()
+        for _, name in re.findall(
+            r"^\|\s*(\d+)\s*\|\s*([^|]+?)\s*\|", inventory, re.MULTILINE
+        )
+    ]
+
+    help_lines = (self.repo_root / "lib/text/help/help.hlp").read_text(
+        encoding="utf-8"
+    ).splitlines()
+    help_keywords: set[str] = set()
+    expect_header = True
+    for line in help_lines:
+      if expect_header:
+        if not line or line.startswith("#") or line == "$~":
+          continue
+        help_keywords.update(token.upper() for token in line.split())
+        expect_header = False
+      elif line.startswith("#"):
+        expect_header = True
+
+    expected_keywords = {
+        re.sub(r"[^A-Z0-9]+", "-", name.upper()).strip("-")
+        for name in spell_names
+    }
+    self.assertEqual(89, len(spell_names))
+    self.assertEqual(89, len(expected_keywords))
+    self.assertEqual(set(), expected_keywords - help_keywords)
 
 
 if __name__ == "__main__":

--- a/scripts/world/tests/test_rol_transform.py
+++ b/scripts/world/tests/test_rol_transform.py
@@ -988,6 +988,7 @@ class RolTransformTests(unittest.TestCase):
         "Y": ({117}, {11, 28}),
         "MH": ({118}, {28}),
         "Z": ({122}, set()),
+        "OB": ({126}, set()),
     }
     for race_code, (expected_actions, expected_affects) in cases.items():
       with self.subTest(race_code=race_code):
@@ -1764,6 +1765,10 @@ class RolTransformTests(unittest.TestCase):
     self.assertEqual(600, _SOURCE_SPELL_MAP[377][1])
     self.assertEqual(601, _SOURCE_SPELL_MAP[378][1])
     self.assertEqual(602, _SOURCE_SPELL_MAP[473][1])
+    self.assertEqual(603, _SOURCE_SPELL_MAP[90][1])
+    self.assertEqual(604, _SOURCE_SPELL_MAP[303][1])
+    self.assertEqual(605, _SOURCE_SPELL_MAP[487][1])
+    self.assertEqual(606, _SOURCE_SPELL_MAP[488][1])
     for source_spell, (source_name, target_spell) in _SOURCE_SPELL_MAP.items():
       with self.subTest(source_spell=source_spell, source_name=source_name):
         self.assertGreater(target_spell, 0)

--- a/scripts/world/tests/test_rol_transform.py
+++ b/scripts/world/tests/test_rol_transform.py
@@ -1759,6 +1759,11 @@ class RolTransformTests(unittest.TestCase):
         target_registry[spell_number] = name
 
     self.assertEqual(340, len(_SOURCE_SPELL_MAP))
+    self.assertEqual(599, _SOURCE_SPELL_MAP[233][1])
+    self.assertEqual(599, _SOURCE_SPELL_MAP[314][1])
+    self.assertEqual(600, _SOURCE_SPELL_MAP[377][1])
+    self.assertEqual(601, _SOURCE_SPELL_MAP[378][1])
+    self.assertEqual(602, _SOURCE_SPELL_MAP[473][1])
     for source_spell, (source_name, target_spell) in _SOURCE_SPELL_MAP.items():
       with self.subTest(source_spell=source_spell, source_name=source_name):
         self.assertGreater(target_spell, 0)

--- a/scripts/world/tests/test_rol_transform.py
+++ b/scripts/world/tests/test_rol_transform.py
@@ -1012,6 +1012,25 @@ class RolTransformTests(unittest.TestCase):
         self.assertTrue(expected_affects <= decode_tokens(mobile.affect_flags).bits)
         self.assertEqual("RoL Thief", mobile.spec_proc)
 
+  def test_call_lycanthrope_prototypes_preserve_their_summon_role(self) -> None:
+    for source_vnum in (525, 526):
+      with self.subTest(source_vnum=source_vnum):
+        source = self._source_record(
+            "mob",
+            (
+                f"#{source_vnum}\nlycanthrope~\na lycanthrope~\n"
+                "A lycanthrope waits here.~\n~\n"
+                "0 0 0 0 S\nL 0 0\n"
+                "20 0 0 1d1+0 1d1+0\n0 0\n131 131 0\n"
+            ).encode("ascii"),
+        )
+        emitted = emit_mobile(source, 2_000_000 + source_vnum)
+        path = self._target_path("mob", emitted.text)
+        result = parse_mobile_file(path, "mob/20001.mob", self.manifest, set())
+
+        self.assertTrue(result.complete)
+        self.assertIn(127, decode_tokens(result.records[0].action_flags).bits)
+
   def test_emitted_mobile_maps_all_action_dispositions_and_infers_primary_class(self) -> None:
     source_actions = (1, 4, 5, 13, 14, 16, 17, 19, 20, 21, 22, 23, 24, 26, 27, 29, 30, 32)
     action_mask = sum(1 << (flag - 1) for flag in source_actions)
@@ -1769,6 +1788,8 @@ class RolTransformTests(unittest.TestCase):
     self.assertEqual(604, _SOURCE_SPELL_MAP[303][1])
     self.assertEqual(605, _SOURCE_SPELL_MAP[487][1])
     self.assertEqual(606, _SOURCE_SPELL_MAP[488][1])
+    self.assertEqual(607, _SOURCE_SPELL_MAP[343][1])
+    self.assertEqual(608, _SOURCE_SPELL_MAP[376][1])
     for source_spell, (source_name, target_spell) in _SOURCE_SPELL_MAP.items():
       with self.subTest(source_spell=source_spell, source_name=source_name):
         self.assertGreater(target_spell, 0)

--- a/scripts/world/tests/test_rol_transform.py
+++ b/scripts/world/tests/test_rol_transform.py
@@ -28,6 +28,7 @@ from wtool_lib.rol_transform import (
     SOURCE_INSTRUMENT_SUBTYPE_MAP,
     SOURCE_SAVING_THROW_APPLIES,
     TARGET_APPLY_AC_NEW,
+    _NON_CASTABLE_SOURCE_SPELLS,
     _SOURCE_SPELL_MAP,
     convert_text,
     emit_mobile,
@@ -1750,6 +1751,19 @@ class RolTransformTests(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, "unmapped positive source spell 999"):
       emit_object(source, 2_000_200, _resolver)
 
+  def test_emitted_magic_item_rejects_non_castable_source_spell_id(self) -> None:
+    source = self._source_record(
+        "obj",
+        b"#200\nwand~\na wand~\nA wand is here.~\n~\n"
+        b"3 0 1\n20 2 2 291\n1 1 0\n0\n0\n",
+    )
+
+    with self.assertRaisesRegex(
+        ValueError,
+        r"non-castable source spell ID 291 \(elemental embodiment maintain\)",
+    ):
+      emit_object(source, 2_000_200, _resolver)
+
   def test_spell_map_targets_registered_luminari_spells(self) -> None:
     spell_header = (self.root / "src/magic/spells.h").read_text(encoding="ascii")
     num_spells_match = re.search(
@@ -1778,7 +1792,12 @@ class RolTransformTests(unittest.TestCase):
       if 0 < spell_number < num_spells:
         target_registry[spell_number] = name
 
-    self.assertEqual(340, len(_SOURCE_SPELL_MAP))
+    self.assertEqual(331, len(_SOURCE_SPELL_MAP))
+    self.assertEqual(
+        {64, 93, 291, 292, 293, 294, 361, 374, 498},
+        set(_NON_CASTABLE_SOURCE_SPELLS),
+    )
+    self.assertFalse(set(_SOURCE_SPELL_MAP) & set(_NON_CASTABLE_SOURCE_SPELLS))
     self.assertEqual(599, _SOURCE_SPELL_MAP[233][1])
     self.assertEqual(599, _SOURCE_SPELL_MAP[314][1])
     self.assertEqual(600, _SOURCE_SPELL_MAP[377][1])
@@ -1790,6 +1809,10 @@ class RolTransformTests(unittest.TestCase):
     self.assertEqual(606, _SOURCE_SPELL_MAP[488][1])
     self.assertEqual(607, _SOURCE_SPELL_MAP[343][1])
     self.assertEqual(608, _SOURCE_SPELL_MAP[376][1])
+    self.assertEqual(609, _SOURCE_SPELL_MAP[482][1])
+    self.assertEqual(610, _SOURCE_SPELL_MAP[483][1])
+    self.assertEqual(611, _SOURCE_SPELL_MAP[484][1])
+    self.assertEqual(612, _SOURCE_SPELL_MAP[485][1])
     for source_spell, (source_name, target_spell) in _SOURCE_SPELL_MAP.items():
       with self.subTest(source_spell=source_spell, source_name=source_name):
         self.assertGreater(target_spell, 0)
@@ -1867,12 +1890,19 @@ class RolTransformTests(unittest.TestCase):
     self.assertEqual(335, len(source_spell_constants))
     self.assertEqual(117, len(referenced_source_spells))
     self.assertEqual(340, len(required_source_spells))
-    self.assertEqual(required_source_spells, set(_SOURCE_SPELL_MAP))
+    self.assertFalse(referenced_source_spells & set(_NON_CASTABLE_SOURCE_SPELLS))
+    self.assertEqual(
+        required_source_spells,
+        set(_SOURCE_SPELL_MAP) | set(_NON_CASTABLE_SOURCE_SPELLS),
+    )
     self.assertEqual({2: 71, 3: 80, 4: 109, 10: 251}, source_type_counts)
     self.assertEqual(511, len(emitted_records))
     self.assertEqual(734, len(expected_spell_slots))
     for source_spell, source_name in source_registry.items():
-      self.assertEqual(source_name, _SOURCE_SPELL_MAP[source_spell][0])
+      if source_spell in _NON_CASTABLE_SOURCE_SPELLS:
+        self.assertEqual(source_name, _NON_CASTABLE_SOURCE_SPELLS[source_spell])
+      else:
+        self.assertEqual(source_name, _SOURCE_SPELL_MAP[source_spell][0])
 
     path = self._target_path("obj", "".join(emitted_records))
     result = parse_object_file(path, "obj/26000.obj", self.manifest, set())

--- a/scripts/world/wtool_constants.json
+++ b/scripts/world/wtool_constants.json
@@ -164,7 +164,7 @@
     },
     "NUM_SPELLS": {
       "source": "src/magic/spells.h:NUM_SPELLS",
-      "value": 599
+      "value": 609
     },
     "NUM_SUB_RACES": {
       "source": "src/structs.h:NUM_SUB_RACES",
@@ -2889,6 +2889,20 @@
           "index": 125,
           "macro": "MOB_ROL_ABYSS_FORGED",
           "name": "RoL-Abyss-Forged",
+          "reserved": false
+        },
+        {
+          "aliases": [],
+          "index": 126,
+          "macro": "MOB_ROL_BEHOLDER",
+          "name": "RoL-Beholder",
+          "reserved": false
+        },
+        {
+          "aliases": [],
+          "index": 127,
+          "macro": "MOB_ROL_LYCANTHROPE_SUMMON",
+          "name": "RoL-Lycanthrope-Summon",
           "reserved": false
         }
       ],

--- a/scripts/world/wtool_constants.json
+++ b/scripts/world/wtool_constants.json
@@ -164,7 +164,7 @@
     },
     "NUM_SPELLS": {
       "source": "src/magic/spells.h:NUM_SPELLS",
-      "value": 609
+      "value": 613
     },
     "NUM_SUB_RACES": {
       "source": "src/structs.h:NUM_SUB_RACES",

--- a/scripts/world/wtool_lib/rol_phase8.py
+++ b/scripts/world/wtool_lib/rol_phase8.py
@@ -193,7 +193,7 @@ def _mechanics_markers(world) -> list[dict[str, Any]]:
       add("room", room.vnum, room.spec_proc)
   for mobile in world.mobiles:
     action_bits = decode_tokens(mobile.action_flags).bits
-    for bit in sorted(action_bits & set(range(105, 126))):
+    for bit in sorted(action_bits & set(range(105, 128))):
       add("mobile", mobile.vnum, f"mob_rol_flag_{bit}")
     if 4 in decode_tokens(mobile.affect2_flags).bits:
       add("mobile", mobile.vnum, "rol_docile")

--- a/scripts/world/wtool_lib/rol_transform.py
+++ b/scripts/world/wtool_lib/rol_transform.py
@@ -159,7 +159,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     87: ("dexterity", 104),  # grace
     88: ("rejuvenate minor", 530),  # rejuvenate minor
     89: ("age", 531),  # age
-    90: ("cyclone", 308),  # whirlwind
+    90: ("cyclone", 603),  # cyclone
     91: ("bigbys clenched fist", 188),  # clenched fist
     92: ("conjure elemental", 299),  # elemental swarm
     93: ("xxxvitalize mana", 440),  # restoration
@@ -251,7 +251,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     299: ("rain of blood", 548),  # rain of blood
     301: ("embalm", 315),  # embalm
     302: ("rot", 549),  # rot
-    303: ("lich touch", 396),  # grave touch
+    303: ("lich touch", 604),  # lich touch
     304: ("life drain", 25),  # energy drain
     305: ("ice tomb", 550),  # ice tomb
     306: ("locate remains", 31),  # locate object
@@ -392,8 +392,8 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     484: ("elemental earth embodiment", 488),  # geniekind
     485: ("elemental air embodiment", 488),  # geniekind
     486: ("ice spear", 82),  # ice dagger
-    487: ("lava burst", 293),  # fire storm
-    488: ("ice layer", 80),  # grease
+    487: ("lava burst", 605),  # lava burst
+    488: ("ice layer", 606),  # ice layer
     489: ("whirlwind", 308),  # whirlwind
     492: ("shadow flux", 590),  # shadow flux
     493: ("dimensional fold", 216),  # portal
@@ -630,7 +630,8 @@ MOB_AUTOMATIC_RACE_AFFECTS = {
 # Retain its identity for source mechanics whose immunity lists distinguish
 # angels from other outsiders.
 MOB_SOURCE_RACE_IDENTITY_ACTIONS = {
-    "Z": frozenset({122}), # RACE_ANGEL
+    "Z": frozenset({122}),  # RACE_ANGEL
+    "OB": frozenset({126}),  # RACE_BEHOLDER
 }
 
 

--- a/scripts/world/wtool_lib/rol_transform.py
+++ b/scripts/world/wtool_lib/rol_transform.py
@@ -289,7 +289,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     340: ("find familiar", 90),  # summon creature i
     341: ("unseen servant", 557),  # unseen servant
     342: ("call mount", 460),  # summon mount
-    343: ("call lycanthrope", 164),  # summon creature vi
+    343: ("call lycanthrope", 607),  # call lycanthrope
     344: ("control fiend", 466),  # control summoned creature
     345: ("minor horde", 268),  # summon swarm
     346: ("evards tentacles", 464),  # black tentacles
@@ -319,7 +319,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     371: ("death pact", 567),  # death pact
     372: ("abi wither", 191),  # horrid wilting
     374: ("special proc effect", 514),  # arcane mark
-    376: ("tazriks frenzied hound", 156),  # faithful hound
+    376: ("tazriks frenzied hound", 608),  # tazriks frenzied hound
     377: ("dark wrath", 600),  # dark wrath
     378: ("unholy aura", 601),  # unholy aura
     380: ("needle swarm", 568),  # needle swarm
@@ -632,6 +632,13 @@ MOB_AUTOMATIC_RACE_AFFECTS = {
 MOB_SOURCE_RACE_IDENTITY_ACTIONS = {
     "Z": frozenset({122}),  # RACE_ANGEL
     "OB": frozenset({126}),  # RACE_BEHOLDER
+}
+
+# Call lycanthrope chooses only the two source prototypes named by its live
+# handler. Preserve that role independently of their broader lycanthrope race.
+MOB_SOURCE_VNUM_IDENTITY_ACTIONS = {
+    525: frozenset({127}),
+    526: frozenset({127}),
 }
 
 
@@ -1918,6 +1925,7 @@ def emit_mobile(
   automatic_actions, automatic_affects = mobile_automatic_race_flags(record)
   target_actions.update(automatic_actions)
   target_actions.update(MOB_SOURCE_RACE_IDENTITY_ACTIONS.get(race_code, frozenset()))
+  target_actions.update(MOB_SOURCE_VNUM_IDENTITY_ACTIONS.get(record.vnum, frozenset()))
   target_affects = _mapped_bits(source_affects, MOB_AFFECT_MAP)
   target_affects.update(automatic_affects)
   target_affects.update(required_affect_bits)

--- a/scripts/world/wtool_lib/rol_transform.py
+++ b/scripts/world/wtool_lib/rol_transform.py
@@ -232,7 +232,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     230: ("protect undead", 541),  # protect undead
     231: ("protection from undead", 542),  # protection from undead
     232: ("command horde", 543),  # command horde
-    233: ("heal undead", 85),  # negative energy ray
+    233: ("heal undead", 599),  # heal undead
     235: ("create spring", 544),  # create spring
     236: ("barkskin", 263),  # barkskin
     237: ("moonwell", 545),  # moonwell
@@ -262,7 +262,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     311: ("animate spectre", 192),  # greater animation
     312: ("animate wraith", 192),  # greater animation
     313: ("animate ghoul", 192),  # greater animation
-    314: ("heal lich", 85),  # negative energy ray
+    314: ("heal lich", 599),  # handled by heal undead
     315: ("darkness breath", 93),  # darkness
     316: ("venom", 33),  # poison
     317: ("mage flame", 253),  # produce flame
@@ -320,8 +320,8 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     372: ("abi wither", 191),  # horrid wilting
     374: ("special proc effect", 514),  # arcane mark
     376: ("tazriks frenzied hound", 156),  # faithful hound
-    377: ("dark wrath", 436),  # divine power
-    378: ("unholy aura", 132),  # fire shield
+    377: ("dark wrath", 600),  # dark wrath
+    378: ("unholy aura", 601),  # unholy aura
     380: ("needle swarm", 568),  # needle swarm
     381: ("snapping teeth", 569),  # snapping teeth
     382: ("monster summoning", 204),  # summon creature ix
@@ -378,7 +378,7 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     470: ("feign death", 584),  # feign death
     471: ("tranquility", 585),  # tranquility
     472: ("deathbolt", 298),  # finger of death
-    473: ("camouflage", 29),  # invisibility
+    473: ("camouflage", 602),  # camouflage
     474: ("scarlet outline", 247),  # faerie fire
     475: ("phantom heal", 586),  # phantom heal
     476: ("shadechill", 587),  # shadechill

--- a/scripts/world/wtool_lib/rol_transform.py
+++ b/scripts/world/wtool_lib/rol_transform.py
@@ -81,8 +81,23 @@ _SOURCE_LIQUID_MAP = {
     27: 21, # curative liquid -> herbal remedy
     28: 10, # eggnog -> milk
 }
-# Complete over live SPELL_CREATE IDs, positive SPELL_* values, and populated
-# magic-item spell IDs in the active source corpus.
+# Source affect and maintenance identities that cannot legally occupy a
+# castable world-data spell slot.
+_NON_CASTABLE_SOURCE_SPELLS: dict[int, str] = {
+    64: "xxxrecharger",
+    93: "xxxvitalize mana",
+    291: "elemental embodiment maintain",
+    292: "elemental embodiment maintain",
+    293: "elemental embodiment maintain",
+    294: "elemental embodiment maintain",
+    361: "simulacrum",
+    374: "special proc effect",
+    498: "elemental embodiment maintain",
+}
+
+# Complete over castable live SPELL_CREATE IDs, positive SPELL_* values, and
+# populated magic-item spell IDs in the active source corpus. Internal IDs are
+# accounted for separately above and fail closed if used as castable spells.
 _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     1: ("armor", 84),  # mage armor
     2: ("teleport", 2),  # teleport
@@ -138,7 +153,6 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     60: ("lightning breath", 30),  # lightning bolt
     62: ("farsee", 528),  # farsee
     63: ("fear", 391),  # cause fear
-    64: ("xxxrecharger", 24),  # enchant item
     65: ("vitality", 103),  # false life
     66: ("cure serious", 221),  # cure serious
     71: ("full harm", 27),  # harm
@@ -162,7 +176,6 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     90: ("cyclone", 603),  # cyclone
     91: ("bigbys clenched fist", 188),  # clenched fist
     92: ("conjure elemental", 299),  # elemental swarm
-    93: ("xxxvitalize mana", 440),  # restoration
     94: ("relocate", 2),  # teleport
     100: ("protection from good", 75),  # protection from good
     101: ("animate skeleton", 45),  # animate dead
@@ -241,10 +254,6 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     241: ("missile shield", 456),  # protection from arrows
     274: ("undead melee proc", 396),  # grave touch
     276: ("undead spell proc", 25),  # energy drain
-    291: ("elemental embodiment maintain", 488),  # geniekind
-    292: ("elemental embodiment maintain", 488),  # geniekind
-    293: ("elemental embodiment maintain", 488),  # geniekind
-    294: ("elemental embodiment maintain", 488),  # geniekind
     296: ("pain touch", 151),  # symbol of pain
     297: ("nerve dance", 546),  # nerve dance
     298: ("spectral hand", 547),  # spectral hand
@@ -307,7 +316,6 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     358: ("mirror image", 55),  # mirror image
     359: ("dimension shift", 563),  # dimension shift
     360: ("change self", 77),  # polymorph self
-    361: ("simulacrum", 9),  # clone
     362: ("shadow magic", 564),  # shadow magic
     363: ("shadow walk", 392),  # shadow walk
     364: ("phantom steed", 108),  # phantom steed
@@ -318,7 +326,6 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     370: ("soul bind", 566),  # soul bind
     371: ("death pact", 567),  # death pact
     372: ("abi wither", 191),  # horrid wilting
-    374: ("special proc effect", 514),  # arcane mark
     376: ("tazriks frenzied hound", 608),  # tazriks frenzied hound
     377: ("dark wrath", 600),  # dark wrath
     378: ("unholy aura", 601),  # unholy aura
@@ -387,10 +394,10 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     479: ("air blast", 589),  # air blast
     480: ("blizzard sphere", 162),  # freezing sphere
     481: ("earth darts", 525),  # splinter storm
-    482: ("elemental water embodiment", 488),  # geniekind
-    483: ("elemental fire embodiment", 488),  # geniekind
-    484: ("elemental earth embodiment", 488),  # geniekind
-    485: ("elemental air embodiment", 488),  # geniekind
+    482: ("elemental water embodiment", 609),
+    483: ("elemental fire embodiment", 610),
+    484: ("elemental earth embodiment", 611),
+    485: ("elemental air embodiment", 612),
     486: ("ice spear", 82),  # ice dagger
     487: ("lava burst", 605),  # lava burst
     488: ("ice layer", 606),  # ice layer
@@ -401,7 +408,6 @@ _SOURCE_SPELL_MAP: dict[int, tuple[str, int]] = {
     495: ("beautify", 127),  # charisma
     496: ("summon elemental kin", 299),  # elemental swarm
     497: ("elemental ward", 433),  # protection from energy
-    498: ("elemental embodiment maintain", 488),  # geniekind
     499: ("divine blessing", 401),  # divine favor
     501: ("miracle", 28),  # heal
     502: ("ball of lightning", 71),  # ball of lightning
@@ -451,8 +457,8 @@ _SOURCE_QUEST_REWARD_MAP: dict[int, tuple[str, int | None]] = {
     438: ("ancestral shield", 89),
     465: ("scry remains", 294),
     477: ("nightmare", 154),
-    483: ("elemental fire embodiment", 132),
-    484: ("elemental earth embodiment", 56),
+    483: ("elemental fire embodiment", 610),
+    484: ("elemental earth embodiment", 611),
     504: ("time stop", 213),
     517: ("phantasmal tendrils", 174),
     521: ("song of recovery", 440),
@@ -2277,6 +2283,12 @@ def _object_values(
     source_spell = values[slot]
     if source_spell <= 0:
       continue
+    non_castable_name = _NON_CASTABLE_SOURCE_SPELLS.get(source_spell)
+    if non_castable_name is not None:
+      raise ValueError(
+          f"non-castable source spell ID {source_spell} ({non_castable_name}) "
+          f"in magic-item slot {slot} for source object {record.vnum}"
+      )
     mapped = _SOURCE_SPELL_MAP.get(source_spell)
     if mapped is None:
       raise ValueError(

--- a/sql/components/dynamic_descriptions_deployment.sql
+++ b/sql/components/dynamic_descriptions_deployment.sql
@@ -311,6 +311,7 @@ CREATE TABLE IF NOT EXISTS weather_cache (
     y_coord INT NOT NULL,
     weather_value INT NOT NULL,  -- 0-255 wilderness weather value
     weather_type ENUM('clear', 'cloudy', 'rainy', 'stormy', 'lightning') NOT NULL,
+    wind_speed INT DEFAULT 5,
     cached_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     expires_at TIMESTAMP NOT NULL,
 

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -6417,6 +6417,7 @@ ACMD(do_hide)
 
   if (AFF_FLAGGED(ch, AFF_HIDE))
   {
+    remove_spell_camouflage(ch);
     REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_HIDE);
     send_to_char(ch, "You step out of the shadows...\r\n");
     return;

--- a/src/combat/fight.c
+++ b/src/combat/fight.c
@@ -413,6 +413,8 @@ void appear(struct char_data *ch, bool forced)
   if (affected_by_spell(ch, SPELL_INVISIBLE))
     affect_from_char(ch, SPELL_INVISIBLE);
 
+  remove_spell_camouflage(ch);
+
   if (AFF_FLAGGED(ch, AFF_SNEAK))
   {
     REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_SNEAK);

--- a/src/constants.c
+++ b/src/constants.c
@@ -1245,6 +1245,7 @@ const char *action_bits[] = {"<spec>", // 0
                              "RoL-Black-Vapor-Death",
                              "RoL-Abyss-Forged",
                              "RoL-Beholder",
+                             "RoL-Lycanthrope-Summon",
                              "\n"};
 CHECK_TABLE_SIZE(action_bits, NUM_MOB_FLAGS + 1);
 

--- a/src/constants.c
+++ b/src/constants.c
@@ -1244,6 +1244,7 @@ const char *action_bits[] = {"<spec>", // 0
                              "RoL-Totem-Spirit",
                              "RoL-Black-Vapor-Death",
                              "RoL-Abyss-Forged",
+                             "RoL-Beholder",
                              "\n"};
 CHECK_TABLE_SIZE(action_bits, NUM_MOB_FLAGS + 1);
 

--- a/src/db_init.c
+++ b/src/db_init.c
@@ -653,6 +653,13 @@ void init_wilderness_resource_tables(void)
     return;
   }
 
+  if (mysql_query_safe(
+          conn, "ALTER TABLE weather_cache ADD COLUMN IF NOT EXISTS wind_speed INT DEFAULT 5"))
+  {
+    log("SYSERR: Failed to add weather_cache.wind_speed: %s", mysql_error(conn));
+    return;
+  }
+
   /* room_description_settings - Per-room customization options */
   const char *create_room_description_settings =
       "CREATE TABLE IF NOT EXISTS room_description_settings ("

--- a/src/handler.c
+++ b/src/handler.c
@@ -1622,6 +1622,12 @@ void affect_from_char(struct char_data *ch, int spell)
 {
   struct affected_type *hjp = NULL, *next = NULL;
 
+  if (rol_elemental_embodiment_affect_is_transient(spell))
+  {
+    remove_rol_elemental_embodiment_affect(ch, spell);
+    return;
+  }
+
   for (hjp = ch->affected; hjp; hjp = next)
   {
     next = hjp->next;
@@ -3057,6 +3063,7 @@ void extract_char_final(struct char_data *ch)
                                (enum perf_entity_reason)ch->perf_create_reason);
 
   mobile_activity_forget_character(ch);
+  remove_all_rol_elemental_embodiments(ch);
 
   PERF_prof_sect_init(&pr_last_attacker, "extract.last_attacker");
   PERF_prof_sect_enter(pr_last_attacker);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -5989,6 +5989,7 @@ void command_interpreter(struct char_data *ch, char *argument)
   else if (AFF_FLAGGED(ch, AFF_HIDE) && !AFF_FLAGGED(ch, AFF_SNEAK) &&
            !is_abbrev(complete_cmd_info[cmd].command, "sneak"))
   {
+    remove_spell_camouflage(ch);
     REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_HIDE);
     send_to_char(ch, "You slowly step out of the shadows... (command removed hide, try sneaking "
                      "before hiding)\r\n");
@@ -6071,12 +6072,14 @@ void command_interpreter(struct char_data *ch, char *argument)
            !is_abbrev(complete_cmd_info[cmd].command, "wearlocations") &&
            !is_abbrev(complete_cmd_info[cmd].command, "attackqueue"))
   {
+    remove_spell_camouflage(ch);
     REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_HIDE);
     send_to_char(ch, "You step out of the shadows...  (command removed hide)\r\n");
   }
   else if (AFF_FLAGGED(ch, AFF_HIDE) && AFF_FLAGGED(ch, AFF_SNEAK) &&
            is_abbrev(complete_cmd_info[cmd].command, "cast") && !HAS_FEAT(ch, FEAT_MAGICAL_AMBUSH))
   {
+    remove_spell_camouflage(ch);
     REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_HIDE);
     send_to_char(ch, "You step out of the shadows...  (attempting to cast without 'magical ambush' "
                      "removes hidden status)\r\n");

--- a/src/magic/magic.c
+++ b/src/magic/magic.c
@@ -43,6 +43,7 @@
 #include "character/perks.h"
 #include "bardic_performance.h"
 #include "perfmon.h"
+#include "mysql.h"
 
 // external
 extern struct raff_node *raff_list;
@@ -50,6 +51,46 @@ extern struct raff_node *raff_list;
 static int paralyzing_touch_duration(void)
 {
   return dice(1, 4) + 1;
+}
+
+static int cyclone_damage_percent(bool player_caster, int wind_speed)
+{
+  return player_caster && wind_speed <= 25 ? 50 : 100;
+}
+
+static bool is_fire_elemental_target(struct char_data *victim)
+{
+  if (victim == NULL)
+    return FALSE;
+
+  return (IS_ELEMENTAL(victim) && HAS_SUBRACE(victim, SUBRACE_FIRE)) ||
+         GET_RACE(victim) == RACE_SMALL_FIRE_ELEMENTAL ||
+         GET_RACE(victim) == RACE_MEDIUM_FIRE_ELEMENTAL ||
+         GET_RACE(victim) == RACE_LARGE_FIRE_ELEMENTAL ||
+         GET_RACE(victim) == RACE_HUGE_FIRE_ELEMENTAL ||
+         GET_RACE(victim) == RACE_GARGANTUAN_FIRE_ELEMENTAL ||
+         GET_RACE(victim) == RACE_COLOSSAL_FIRE_ELEMENTAL;
+}
+
+static int adjust_lich_touch_damage(struct char_data *victim, int damage)
+{
+  if (victim == NULL || damage <= 0)
+    return MAX(0, damage);
+
+  if (is_fire_elemental_target(victim))
+    damage += damage / 4;
+  if (AFF_FLAGGED(victim, AFF_CSHIELD))
+    damage /= 2;
+  if (AFF_FLAGGED(victim, AFF_FSHIELD))
+    damage += 50;
+
+  return MAX(0, damage);
+}
+
+static bool lava_burst_should_ignite(int damage_result, int hit_before, int hit_after,
+                                     bool already_burning)
+{
+  return damage_result != -1 && hit_after < hit_before && !already_burning;
 }
 
 static bool is_necromancer_touch_ability(int spellnum)
@@ -111,6 +152,22 @@ int test_get_last_savingthrow_challenge(void)
 int test_paralyzing_touch_duration(void)
 {
   return paralyzing_touch_duration();
+}
+
+int test_cyclone_damage_percent(bool player_caster, int wind_speed)
+{
+  return cyclone_damage_percent(player_caster, wind_speed);
+}
+
+int test_adjust_lich_touch_damage(struct char_data *victim, int damage)
+{
+  return adjust_lich_touch_damage(victim, damage);
+}
+
+bool test_lava_burst_should_ignite(int damage_result, int hit_before, int hit_after,
+                                   bool already_burning)
+{
+  return lava_burst_should_ignite(damage_result, hit_before, hit_after, already_burning);
 }
 
 int test_resolve_affect_cast_level(struct char_data *ch, int spellnum, int supplied_level,
@@ -521,6 +578,7 @@ static bool spell_has_ability_penalty(int spellnum)
   case SPELL_POISON:
   case SPELL_ENFEEBLEMENT:
   case SPELL_RAY_OF_ENFEEBLEMENT:
+  case SPELL_LICH_TOUCH:
   case PSIONIC_DECELERATION:
   case PSIONIC_DEMORALIZE:
   case MOB_ABILITY_CORRUPTION:
@@ -1612,13 +1670,13 @@ void mag_loops(int level, struct char_data *ch, struct char_data *victim, struct
 // default    ->  magic resistance
 // returns damage, -1 if dead
 
-int mag_damage(int level, struct char_data *ch, struct char_data *victim,
-               struct obj_data *wpn __attribute__((unused)), int spellnum, int metamagic,
-               int savetype, int casttype)
+static int mag_damage_scaled(int level, struct char_data *ch, struct char_data *victim,
+                             struct obj_data *wpn __attribute__((unused)), int spellnum,
+                             int metamagic, int savetype, int casttype, int damage_percent)
 {
   int dam = 0, element = 0, num_dice = 0, save = savetype, size_dice = 0, min_dice_roll = 0,
       bonus = 0, mag_resist = TRUE, spell_school = NOSCHOOL, save_negates = FALSE,
-      mag_resist_bonus = 0, dc_mod = 0, crescendo_sonic_dam = 0, result;
+      mag_resist_bonus = 0, dc_mod = 0, crescendo_sonic_dam = 0, result, hit_before = 0;
   bool apply_crescendo;
   char desc[200];
 
@@ -1926,6 +1984,31 @@ int mag_damage(int level, struct char_data *ch, struct char_data *victim,
     num_dice = MIN(18, MAX(1, level));
     size_dice = 8;
     bonus = level / 2;
+    break;
+
+  case SPELL_CYCLONE:
+    save = SAVING_REFL;
+    element = DAM_AIR;
+    num_dice = MIN(40, MAX(1, level));
+    size_dice = 12;
+    bonus = 0;
+    break;
+
+  case SPELL_LICH_TOUCH:
+    /* The source save gates the debuffs, not the initial touch damage. */
+    save = -1;
+    element = DAM_UNHOLY;
+    num_dice = MIN(50, MAX(1, level));
+    size_dice = 16;
+    bonus = 0;
+    break;
+
+  case SPELL_LAVA_BURST:
+    save = SAVING_REFL;
+    element = DAM_FIRE;
+    num_dice = MIN(45, MAX(1, level));
+    size_dice = 13;
+    bonus = 0;
     break;
 
   case SPELL_DUST_DEVIL:
@@ -3759,6 +3842,13 @@ int mag_damage(int level, struct char_data *ch, struct char_data *victim,
     }
   }
 
+  if (spellnum == SPELL_LICH_TOUCH)
+    dam = adjust_lich_touch_damage(victim, dam);
+
+  damage_percent = MAX(0, MIN(100, damage_percent));
+  if (damage_percent != 100)
+    dam = dam * damage_percent / 100;
+
   if (spellnum == SPELL_CIRCLE_OF_DEATH && !IS_LIVING(victim))
   {
     act("You ignore the spell affect, as it only affects the living.", TRUE, ch, 0, victim,
@@ -4081,7 +4171,23 @@ int mag_damage(int level, struct char_data *ch, struct char_data *victim,
       crescendo_sonic_dam = dice(GET_CRESCENDO_DICE(ch), 6);
     }
 
+    hit_before = GET_HIT(victim);
     result = damage(ch, victim, dam, spellnum, element, FALSE);
+
+    if (spellnum == SPELL_LAVA_BURST && result != -1 &&
+        lava_burst_should_ignite(result, hit_before, GET_HIT(victim),
+                                 AFF_FLAGGED(victim, AFF_ON_FIRE)))
+    {
+      struct affected_type burning;
+
+      new_affect(&burning);
+      burning.spell = SPELL_LAVA_BURST;
+      burning.duration = 5;
+      SET_BIT_AR(burning.bitvector, AFF_ON_FIRE);
+      affect_to_char(victim, &burning);
+      send_to_char(victim, "Molten lava clings to you and continues to burn!\r\n");
+      act("Molten lava clings to $n and continues to burn!", FALSE, victim, NULL, NULL, TO_ROOM);
+    }
 
     if (spellnum == SPELL_THUNDER_LANCE && result != -1)
     {
@@ -4248,6 +4354,12 @@ int mag_damage(int level, struct char_data *ch, struct char_data *victim,
 
     return result;
   }
+}
+
+int mag_damage(int level, struct char_data *ch, struct char_data *victim, struct obj_data *wpn,
+               int spellnum, int metamagic, int savetype, int casttype)
+{
+  return mag_damage_scaled(level, ch, victim, wpn, spellnum, metamagic, savetype, casttype, 100);
 }
 /* Affect durations are combat rounds and update once per PULSE_VIOLENCE. */
 
@@ -10734,6 +10846,33 @@ void mag_affects_full(int level, struct char_data *ch, struct char_data *victim,
     to_vict = "Your movements slow beneath the black light!";
     break;
 
+  case SPELL_LICH_TOUCH:
+    if (IS_DRAGON(victim))
+      return;
+
+    misc_bonus = -1;
+    if (AFF_FLAGGED(victim, AFF_CSHIELD))
+      misc_bonus -= 2;
+    if (is_fire_elemental_target(victim))
+      misc_bonus++;
+    if (mag_resistance(ch, victim, 0) ||
+        savingthrow(ch, victim, SAVING_FORT, misc_bonus, casttype, level, NECROMANCY))
+      return;
+
+    af[0].location = APPLY_STR;
+    af[0].modifier = -1;
+    af[0].duration = 2;
+    accum_duration = TRUE;
+    if (!AFF_FLAGGED(victim, AFF_SLOW))
+    {
+      af[1].spell = SPELL_SLOW;
+      af[1].duration = MAX(1, level >> 4);
+      SET_BIT_AR(af[1].bitvector, AFF_SLOW);
+    }
+    to_room = "$n shivers as $s strength and movements ebb away!";
+    to_vict = "A deathly touch saps your strength and slows your movements!";
+    break;
+
   case SPELL_BELTYNS_BURNING_BLOOD:
     if (!can_bleed(victim) || GET_HIT(victim) >= GET_MAX_HIT(victim) ||
         mag_resistance(ch, victim, 0) ||
@@ -11662,10 +11801,13 @@ void mag_areas(int level, struct char_data *ch, struct obj_data *obj, int spelln
   struct char_data *tch = NULL, *next_tch = NULL;
   const char *to_char = NULL, *to_room = NULL;
   int isEffect = FALSE, is_eff_and_dam = FALSE, is_uneffect = FALSE;
-  int temp_meta = 0, temp_class = GET_CASTING_CLASS(ch);
+  int temp_meta = 0, temp_class, damage_percent = 100, wind_speed = 5;
+  zone_rnum zone;
 
   if (ch == NULL)
     return;
+
+  temp_class = GET_CASTING_CLASS(ch);
 
   /* to add spells just add the message here plus an entry in mag_damage for
    * the damaging part of the spell.   */
@@ -11715,6 +11857,29 @@ void mag_areas(int level, struct char_data *ch, struct obj_data *obj, int spelln
   case SPELL_SOUL_TEMPEST:
     to_char = "You call forth a tempest of howling spirits!";
     to_room = "$n calls forth a tempest of howling spirits!";
+    break;
+  case SPELL_CYCLONE:
+    to_char = "You call down a fierce cyclone upon the area!";
+    to_room = "$n calls down a fierce cyclone upon the area!";
+    if (!IS_NPC(ch) && IN_ROOM(ch) != NOWHERE)
+    {
+      zone = GET_ROOM_ZONE(IN_ROOM(ch));
+      if (zone != NOWHERE && zone <= top_of_zone_table)
+        wind_speed = get_cached_zone_wind_speed(zone_table[zone].number, 5);
+      damage_percent = cyclone_damage_percent(true, wind_speed);
+      if (damage_percent < 100)
+      {
+        if (OUTSIDE(ch))
+          send_to_char(ch, "The lack of wind reduces the cyclone's force.\r\n");
+        else
+          send_to_char(ch, "Being indoors reduces the cyclone's force.\r\n");
+      }
+    }
+    break;
+  case SPELL_LAVA_BURST:
+    /* RoL invokes its merge hook here, but its merge table has no lava-burst pairing. */
+    to_char = "The area explodes in a massive burst of red-hot lava!";
+    to_room = "The area explodes in a massive burst of red-hot lava around $n!";
     break;
   case WARLOCK_CHILLING_TENTACLES:
     to_char = "You call forth many writhing, frost-covered tentacles from the ground!";
@@ -12096,7 +12261,10 @@ void mag_areas(int level, struct char_data *ch, struct obj_data *obj, int spelln
       {
         metamagic = temp_meta;
         GET_CASTING_CLASS(ch) = temp_class;
-        mag_damage(level, ch, tch, obj, spellnum, metamagic, 1, casttype);
+        if (spellnum == SPELL_CYCLONE)
+          mag_damage_scaled(level, ch, tch, obj, spellnum, metamagic, 1, casttype, damage_percent);
+        else
+          mag_damage(level, ch, tch, obj, spellnum, metamagic, 1, casttype);
 
         /* Add meteor swarm impact effects after damage is dealt */
         if (spellnum == SPELL_METEOR_SWARM &&

--- a/src/magic/magic.c
+++ b/src/magic/magic.c
@@ -2011,6 +2011,16 @@ static int mag_damage_scaled(int level, struct char_data *ch, struct char_data *
     bonus = 0;
     break;
 
+  case SPELL_TAZRIKS_FRENZIED_HOUND:
+    /* The source hound's bite has neither a save nor a magic-resistance check. */
+    save = -1;
+    mag_resist = FALSE;
+    element = DAM_PUNCTURE;
+    num_dice = MIN(40, MAX(1, level));
+    size_dice = 12;
+    bonus = 0;
+    break;
+
   case SPELL_DUST_DEVIL:
     save = SAVING_REFL;
     element = DAM_AIR;

--- a/src/magic/spell_parser.c
+++ b/src/magic/spell_parser.c
@@ -1127,6 +1127,18 @@ SAVING_WILL here...  */
     case SPELL_TAZRIKS_FRENZIED_HOUND:
       MANUAL_SPELL(spell_tazriks_frenzied_hound);
       break;
+    case SPELL_ELEMENTAL_WATER_EMBODIMENT:
+      MANUAL_SPELL(spell_elemental_water_embodiment);
+      break;
+    case SPELL_ELEMENTAL_FIRE_EMBODIMENT:
+      MANUAL_SPELL(spell_elemental_fire_embodiment);
+      break;
+    case SPELL_ELEMENTAL_EARTH_EMBODIMENT:
+      MANUAL_SPELL(spell_elemental_earth_embodiment);
+      break;
+    case SPELL_ELEMENTAL_AIR_EMBODIMENT:
+      MANUAL_SPELL(spell_elemental_air_embodiment);
+      break;
     case SPELL_GIRD_ALLIES:
       MANUAL_SPELL(spell_gird_allies);
       break;
@@ -6042,6 +6054,8 @@ void mag_assign_spells(void)
           "The manscorpion venom leaves your bloodstream.");
   affecto(AFFECT_ROL_BARBAZU_BERSERK, "RoL Barbazu berserk",
           "Your bloodlust-filled rage subsides.");
+  affecto(AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN, "RoL elemental embodiment link",
+          "Your elemental embodiment link dissolves.");
 
   affecto(SKILL_BLEEDING_ATTACK, "bleeding attack", "The bleeding from the attack stops.");
   affecto(SKILL_CRIPPLING_STRIKE, "crippling strike", "Your movement is no longer crippled.");
@@ -6457,6 +6471,18 @@ spello(SPELL_IDENTIFY, "!UNUSED!", 0, 0, 0, 0,
          MAG_MANUAL, NULL, 2, 0, CONJURATION, FALSE);
   spello(SPELL_TAZRIKS_FRENZIED_HOUND, "tazriks frenzied hound", 0, 0, 0, POS_FIGHTING, TAR_IGNORE,
          TRUE, MAG_MANUAL, NULL, 3, 13, CONJURATION, FALSE);
+  spello(SPELL_ELEMENTAL_WATER_EMBODIMENT, "elemental water embodiment", 0, 0, 0, POS_FIGHTING,
+         TAR_CHAR_ROOM, FALSE, MAG_MANUAL, "Your flowing water embodiment recedes.", 4, 0,
+         TRANSMUTATION, FALSE);
+  spello(SPELL_ELEMENTAL_FIRE_EMBODIMENT, "elemental fire embodiment", 0, 0, 0, POS_FIGHTING,
+         TAR_CHAR_ROOM, FALSE, MAG_MANUAL, "Your burning fire embodiment gutters out.", 4, 0,
+         TRANSMUTATION, FALSE);
+  spello(SPELL_ELEMENTAL_EARTH_EMBODIMENT, "elemental earth embodiment", 0, 0, 0, POS_FIGHTING,
+         TAR_CHAR_ROOM, FALSE, MAG_MANUAL, "Your hardened earth embodiment crumbles away.", 4, 0,
+         TRANSMUTATION, FALSE);
+  spello(SPELL_ELEMENTAL_AIR_EMBODIMENT, "elemental air embodiment", 0, 0, 0, POS_FIGHTING,
+         TAR_CHAR_ROOM, FALSE, MAG_MANUAL, "Your swirling air embodiment settles.", 4, 0,
+         TRANSMUTATION, FALSE);
 
   /* Declaration of skills - this assigns categories and also will set it up
    * so that immortals can use these skills by default.  The min level to use

--- a/src/magic/spell_parser.c
+++ b/src/magic/spell_parser.c
@@ -1118,6 +1118,9 @@ SAVING_WILL here...  */
     case SPELL_CAMOUFLAGE:
       MANUAL_SPELL(spell_camouflage);
       break;
+    case SPELL_ICE_LAYER:
+      MANUAL_SPELL(spell_ice_layer);
+      break;
     case SPELL_GIRD_ALLIES:
       MANUAL_SPELL(spell_gird_allies);
       break;
@@ -6434,6 +6437,16 @@ spello(SPELL_IDENTIFY, "!UNUSED!", 0, 0, 0, 0,
          "The unholy flames around you gutter out.", 10, 10, ENCHANTMENT, FALSE);
   spello(SPELL_CAMOUFLAGE, "camouflage", 0, 0, 0, POS_FIGHTING, TAR_SELF_ONLY, FALSE, MAG_MANUAL,
          "Your camouflage falls away.", 7, 7, ILLUSION, FALSE);
+  spello(SPELL_CYCLONE, "cyclone", 0, 0, 0, POS_FIGHTING, TAR_IGNORE, TRUE, MAG_AREAS, NULL, 2, 13,
+         EVOCATION, FALSE);
+  spello(SPELL_LICH_TOUCH, "lich touch", 0, 0, 0, POS_FIGHTING, TAR_CHAR_ROOM | TAR_FIGHT_VICT,
+         TRUE, MAG_DAMAGE | MAG_AFFECTS, "The weakness left by the lich touch fades.", 2, 16,
+         NECROMANCY, FALSE);
+  spello(SPELL_LAVA_BURST, "lava burst", 0, 0, 0, POS_FIGHTING, TAR_IGNORE, TRUE, MAG_AREAS,
+         "The clinging lava finally cools.", 2, 14, EVOCATION, FALSE);
+  spello(SPELL_ICE_LAYER, "ice layer", 0, 0, 0, POS_FIGHTING,
+         TAR_CHAR_ROOM | TAR_FIGHT_VICT | TAR_NOT_SELF, TRUE, MAG_MANUAL, NULL, 1, 1, EVOCATION,
+         FALSE);
 
   /* Declaration of skills - this assigns categories and also will set it up
    * so that immortals can use these skills by default.  The min level to use

--- a/src/magic/spell_parser.c
+++ b/src/magic/spell_parser.c
@@ -1106,6 +1106,18 @@ SAVING_WILL here...  */
     case SPELL_PHANTOM_HEAL:
       MANUAL_SPELL(spell_phantom_heal);
       break;
+    case SPELL_HEAL_UNDEAD:
+      MANUAL_SPELL(spell_heal_undead);
+      break;
+    case SPELL_DARK_WRATH:
+      MANUAL_SPELL(spell_dark_wrath);
+      break;
+    case SPELL_UNHOLY_AURA:
+      MANUAL_SPELL(spell_unholy_aura);
+      break;
+    case SPELL_CAMOUFLAGE:
+      MANUAL_SPELL(spell_camouflage);
+      break;
     case SPELL_GIRD_ALLIES:
       MANUAL_SPELL(spell_gird_allies);
       break;
@@ -6414,6 +6426,14 @@ spello(SPELL_IDENTIFY, "!UNUSED!", 0, 0, 0, 0,
          "The earthen fog settles out of the air.", 2, 2, CONJURATION, FALSE);
   spello(SPELL_FIRE_FOG, "fire fog", 0, 0, 0, POS_FIGHTING, TAR_IGNORE, FALSE, MAG_ROOM,
          "The fiery fog dims and dissipates.", 2, 2, EVOCATION, FALSE);
+  spello(SPELL_HEAL_UNDEAD, "heal undead", 0, 0, 0, POS_FIGHTING, TAR_CHAR_ROOM, FALSE, MAG_MANUAL,
+         NULL, 5, 5, NECROMANCY, FALSE);
+  spello(SPELL_DARK_WRATH, "dark wrath", 0, 0, 0, POS_STANDING, TAR_SELF_ONLY, FALSE, MAG_MANUAL,
+         "Your god's dark favor leaves you.", 9, 9, ENCHANTMENT, FALSE);
+  spello(SPELL_UNHOLY_AURA, "unholy aura", 0, 0, 0, POS_FIGHTING, TAR_SELF_ONLY, FALSE, MAG_MANUAL,
+         "The unholy flames around you gutter out.", 10, 10, ENCHANTMENT, FALSE);
+  spello(SPELL_CAMOUFLAGE, "camouflage", 0, 0, 0, POS_FIGHTING, TAR_SELF_ONLY, FALSE, MAG_MANUAL,
+         "Your camouflage falls away.", 7, 7, ILLUSION, FALSE);
 
   /* Declaration of skills - this assigns categories and also will set it up
    * so that immortals can use these skills by default.  The min level to use

--- a/src/magic/spell_parser.c
+++ b/src/magic/spell_parser.c
@@ -1121,6 +1121,12 @@ SAVING_WILL here...  */
     case SPELL_ICE_LAYER:
       MANUAL_SPELL(spell_ice_layer);
       break;
+    case SPELL_CALL_LYCANTHROPE:
+      MANUAL_SPELL(spell_call_lycanthrope);
+      break;
+    case SPELL_TAZRIKS_FRENZIED_HOUND:
+      MANUAL_SPELL(spell_tazriks_frenzied_hound);
+      break;
     case SPELL_GIRD_ALLIES:
       MANUAL_SPELL(spell_gird_allies);
       break;
@@ -6447,6 +6453,10 @@ spello(SPELL_IDENTIFY, "!UNUSED!", 0, 0, 0, 0,
   spello(SPELL_ICE_LAYER, "ice layer", 0, 0, 0, POS_FIGHTING,
          TAR_CHAR_ROOM | TAR_FIGHT_VICT | TAR_NOT_SELF, TRUE, MAG_MANUAL, NULL, 1, 1, EVOCATION,
          FALSE);
+  spello(SPELL_CALL_LYCANTHROPE, "call lycanthrope", 0, 0, 0, POS_FIGHTING, TAR_IGNORE, FALSE,
+         MAG_MANUAL, NULL, 2, 0, CONJURATION, FALSE);
+  spello(SPELL_TAZRIKS_FRENZIED_HOUND, "tazriks frenzied hound", 0, 0, 0, POS_FIGHTING, TAR_IGNORE,
+         TRUE, MAG_MANUAL, NULL, 3, 13, CONJURATION, FALSE);
 
   /* Declaration of skills - this assigns categories and also will set it up
    * so that immortals can use these skills by default.  The min level to use

--- a/src/magic/spells.c
+++ b/src/magic/spells.c
@@ -479,9 +479,24 @@ void effect_charm(struct char_data *ch, struct char_data *victim, int spellnum, 
 
 /* TODO:  add strength/etc to affection struct, that'd help a lot especially
    here */
+static struct affected_type *first_dispellable_affect(struct char_data *ch)
+{
+  struct affected_type *af;
+
+  if (ch == NULL)
+    return NULL;
+
+  for (af = ch->affected; af != NULL; af = af->next)
+    if (!rol_elemental_embodiment_affect_is_transient(af->spell))
+      return af;
+
+  return NULL;
+}
+
 void perform_dispel(struct char_data *ch, struct char_data *vict, struct obj_data *obj,
                     int spellnum)
 {
+  struct affected_type *af;
   int i = 0, attempt = 0, challenge = 0, num_dispels = 0, msg = FALSE;
   bool wildshape = false;
 
@@ -526,11 +541,11 @@ void perform_dispel(struct char_data *ch, struct char_data *vict, struct obj_dat
   {
     send_to_char(ch, "You dispel all your own magic!\r\n");
     act("$n dispels all $s magic!", FALSE, ch, 0, 0, TO_ROOM);
-    while (ch->affected)
+    while ((af = first_dispellable_affect(ch)) != NULL)
     {
-      if (get_wearoff(ch->affected->spell))
-        send_to_char(ch, "%s\r\n", get_wearoff(ch->affected->spell));
-      affect_remove(ch, ch->affected);
+      if (get_wearoff(af->spell))
+        send_to_char(ch, "%s\r\n", get_wearoff(af->spell));
+      affect_remove(ch, af);
     }
     if (AFF_FLAGGED(ch, AFF_WILD_SHAPE))
       wildshape = true;
@@ -538,6 +553,8 @@ void perform_dispel(struct char_data *ch, struct char_data *vict, struct obj_dat
       AFF_FLAGS(ch)[i] = 0;
     if (wildshape)
       SET_BIT_AR(AFF_FLAGS(ch), AFF_WILD_SHAPE);
+    if (ch->affected != NULL)
+      affect_total(ch);
     return;
   }
   else
@@ -553,16 +570,16 @@ void perform_dispel(struct char_data *ch, struct char_data *vict, struct obj_dat
       {
         if (attempt >= challenge)
         { // successful
-          if (vict->affected)
+          if ((af = first_dispellable_affect(vict)) != NULL)
           {
-            if (vict->affected[0].spell == WARLOCK_RETRIBUTIVE_INVISIBILITY)
+            if (af->spell == WARLOCK_RETRIBUTIVE_INVISIBILITY)
             {
               // this spell explodes.
               mag_areas(GET_WARLOCK_LEVEL(vict), vict, NULL, WARLOCK_RETRIBUTIVE_INVISIBILITY, 0,
                         SAVING_FORT, CAST_INNATE);
             }
             msg = TRUE;
-            affect_remove(vict, vict->affected);
+            affect_remove(vict, af);
             if (spellnum == WARLOCK_VORACIOUS_DISPELLING)
             {
               damage(ch, vict, CASTER_LEVEL(ch) / 2, WARLOCK_VORACIOUS_DISPELLING, DAM_FORCE, 0);
@@ -596,8 +613,8 @@ void perform_dispel(struct char_data *ch, struct char_data *vict, struct obj_dat
       { // successful
         send_to_char(ch, "You successfuly dispel some magic!\r\n");
         act("$n dispels some of $N's magic!", FALSE, ch, 0, vict, TO_ROOM);
-        if (vict->affected)
-          affect_remove(vict, vict->affected);
+        if ((af = first_dispellable_affect(vict)) != NULL)
+          affect_remove(vict, af);
       }
       else
       { // failed
@@ -5980,6 +5997,356 @@ ASPELL(spell_tazriks_frenzied_hound)
   NEW_EVENT(eROL_TAZRIKS_FRENZIED_HOUND, ch, state, PULSE_VIOLENCE);
 }
 
+#define ROL_ELEMENTAL_MAX_RESISTANCES 3
+#define ROL_ELEMENTAL_MAX_FLAGS 3
+#define ROL_ELEMENTAL_PROTECTION 50
+
+struct rol_elemental_embodiment_profile
+{
+  int spellnum;
+  int hp_factor;
+  int armor_bonus;
+  int size_percent;
+  int resistance_count;
+  int resistances[ROL_ELEMENTAL_MAX_RESISTANCES];
+  int flag_count;
+  int flags[ROL_ELEMENTAL_MAX_FLAGS];
+  const char *victim_message;
+  const char *room_message;
+};
+
+static bool get_rol_elemental_embodiment_profile(int spellnum,
+                                                 struct rol_elemental_embodiment_profile *profile)
+{
+  if (profile == NULL)
+    return false;
+
+  memset(profile, 0, sizeof(*profile));
+  profile->spellnum = spellnum;
+
+  switch (spellnum)
+  {
+  case SPELL_ELEMENTAL_WATER_EMBODIMENT:
+    profile->hp_factor = 5;
+    profile->size_percent = 25;
+    profile->resistance_count = 3;
+    profile->resistances[0] = APPLY_RES_FIRE;
+    profile->resistances[1] = APPLY_RES_POISON;
+    profile->resistances[2] = APPLY_RES_ACID;
+    profile->flag_count = 1;
+    profile->flags[0] = AFF_WATER_BREATH;
+    profile->victim_message =
+        "Your body begins to flow and liquefy as you embody elemental water.\r\n";
+    profile->room_message = "$n's body flows and liquefies into an embodiment of water.";
+    return true;
+  case SPELL_ELEMENTAL_FIRE_EMBODIMENT:
+    profile->hp_factor = 7;
+    profile->armor_bonus = 6;
+    profile->size_percent = 35;
+    profile->resistance_count = 2;
+    profile->resistances[0] = APPLY_RES_POISON;
+    profile->resistances[1] = APPLY_RES_FIRE;
+    profile->flag_count = 3;
+    profile->flags[0] = AFF_FSHIELD;
+    profile->flags[1] = AFF_HASTE;
+    profile->flags[2] = AFF_FLYING;
+    profile->victim_message =
+        "Your body begins to smolder and burn as you embody elemental fire.\r\n";
+    profile->room_message = "$n's body smolders and burns into an embodiment of fire.";
+    return true;
+  case SPELL_ELEMENTAL_EARTH_EMBODIMENT:
+    /* The live RoL handler uses the fire factor of seven; its declared earth factor is unused. */
+    profile->hp_factor = 7;
+    profile->size_percent = 50;
+    profile->resistance_count = 2;
+    profile->resistances[0] = APPLY_RES_POISON;
+    profile->resistances[1] = APPLY_RES_COLD;
+    profile->victim_message =
+        "Your body begins to harden and solidify as you embody elemental earth.\r\n";
+    profile->room_message = "$n's body hardens and solidifies into an embodiment of earth.";
+    return true;
+  case SPELL_ELEMENTAL_AIR_EMBODIMENT:
+    profile->hp_factor = 3;
+    profile->armor_bonus = 5;
+    profile->size_percent = 15;
+    profile->resistance_count = 2;
+    profile->resistances[0] = APPLY_RES_POISON;
+    profile->resistances[1] = APPLY_RES_ACID;
+    profile->flag_count = 2;
+    profile->flags[0] = AFF_HASTE;
+    profile->flags[1] = AFF_FLYING;
+    profile->victim_message =
+        "Your body begins to swirl and waver as you embody elemental air.\r\n";
+    profile->room_message = "$n's body swirls and wavers into an embodiment of air.";
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool rol_elemental_embodiment_spell(int spellnum)
+{
+  struct rol_elemental_embodiment_profile profile;
+
+  return get_rol_elemental_embodiment_profile(spellnum, &profile);
+}
+
+bool rol_elemental_embodiment_affect_is_transient(int spellnum)
+{
+  return spellnum == AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN ||
+         rol_elemental_embodiment_spell(spellnum);
+}
+
+bool rol_elemental_embodiment_active(struct char_data *ch)
+{
+  if (ch == NULL)
+    return false;
+
+  return affected_by_spell(ch, SPELL_ELEMENTAL_WATER_EMBODIMENT) ||
+         affected_by_spell(ch, SPELL_ELEMENTAL_FIRE_EMBODIMENT) ||
+         affected_by_spell(ch, SPELL_ELEMENTAL_EARTH_EMBODIMENT) ||
+         affected_by_spell(ch, SPELL_ELEMENTAL_AIR_EMBODIMENT);
+}
+
+static bool rol_elemental_embodiment_same_side(struct char_data *ch, struct char_data *victim)
+{
+  if (ch == NULL || victim == NULL)
+    return false;
+  if (IS_NPC(ch) || IS_NPC(victim) || GET_LEVEL(ch) >= LVL_IMMORT || are_grouped(ch, victim))
+    return true;
+
+  return !((rol_race_is_good(GET_RACE(ch)) && rol_race_is_evil(GET_RACE(victim))) ||
+           (rol_race_is_evil(GET_RACE(ch)) && rol_race_is_good(GET_RACE(victim))));
+}
+
+static int rol_elemental_embodiment_hp_bonus(struct char_data *ch, struct char_data *victim,
+                                             int factor)
+{
+  int base;
+  int bonus;
+  int variance;
+
+  base = MAX(0, MIN(GET_LEVEL(ch), GET_LEVEL(victim)) * factor);
+  variance = base * 5 / 100;
+  bonus = base + rand_number(-variance, variance);
+
+  if (GET_MAX_HIT(victim) > 30000 || bonus > 30000 - GET_MAX_HIT(victim))
+    return 0;
+
+  return MAX(0, bonus);
+}
+
+static int rol_elemental_embodiment_size_bonus(int current, int percent)
+{
+  if (current <= 0 || percent <= 0)
+    return 0;
+
+  return MIN(UCHAR_MAX - current, current * percent / 100);
+}
+
+static void apply_rol_elemental_embodiment_affect(struct char_data *victim, int spellnum,
+                                                  int duration, int location, int modifier,
+                                                  int bonus_type, const int *flags, int flag_count,
+                                                  long caster_id)
+{
+  struct affected_type af;
+  int index;
+
+  new_affect(&af);
+  af.spell = spellnum;
+  af.duration = duration;
+  af.location = location;
+  af.modifier = modifier;
+  af.bonus_type = bonus_type;
+  for (index = 0; index < flag_count; index++)
+    SET_BIT_AR(af.bitvector, flags[index]);
+  affect_to_char_source(victim, &af, caster_id);
+}
+
+static void apply_rol_elemental_embodiment(struct char_data *ch, struct char_data *victim,
+                                           int spellnum)
+{
+  struct rol_elemental_embodiment_profile profile;
+  struct affected_type maintenance;
+  long caster_id;
+  long victim_id;
+  int duration;
+  int height_bonus;
+  int hp_bonus;
+  int index;
+  int weight_bonus;
+
+  if (!get_rol_elemental_embodiment_profile(spellnum, &profile))
+    return;
+  if (ch == NULL || victim == NULL)
+    return;
+  if (IS_NPC(victim))
+  {
+    send_to_char(ch, "You cannot cast this spell on NPCs.\r\n");
+    return;
+  }
+  if (!rol_elemental_embodiment_same_side(ch, victim))
+  {
+    send_to_char(ch, "That person is not worthy of your spell.\r\n");
+    return;
+  }
+  if (affected_by_spell(ch, AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN))
+  {
+    send_to_char(ch, "You are already maintaining an elemental embodiment!\r\n");
+    return;
+  }
+  if (rol_elemental_embodiment_active(victim) || GET_ELEMENTAL_EMBODIMENT_TIMER(victim) > 0)
+  {
+    send_to_char(ch, "That person is already embodying an elemental force!\r\n");
+    return;
+  }
+  if (RIDING(victim) != NULL)
+  {
+    send_to_char(ch, "That person needs to dismount first!\r\n");
+    return;
+  }
+
+  caster_id = char_script_id(ch);
+  victim_id = char_script_id(victim);
+  duration = MAX(1, 10 * get_spell_duration_bonus(ch) / 100);
+  hp_bonus = rol_elemental_embodiment_hp_bonus(ch, victim, profile.hp_factor);
+  height_bonus = rol_elemental_embodiment_size_bonus(GET_HEIGHT(victim), profile.size_percent);
+  weight_bonus = rol_elemental_embodiment_size_bonus(GET_WEIGHT(victim), profile.size_percent);
+
+  affect_batch_begin(victim);
+  apply_rol_elemental_embodiment_affect(victim, spellnum, duration, APPLY_HIT, hp_bonus,
+                                        BONUS_TYPE_UNIVERSAL, NULL, 0, caster_id);
+  apply_rol_elemental_embodiment_affect(
+      victim, spellnum, duration, profile.armor_bonus > 0 ? APPLY_AC_NEW : APPLY_NONE,
+      profile.armor_bonus, BONUS_TYPE_NATURALARMOR, profile.flags, profile.flag_count, caster_id);
+  for (index = 0; index < profile.resistance_count; index++)
+    apply_rol_elemental_embodiment_affect(victim, spellnum, duration, profile.resistances[index],
+                                          ROL_ELEMENTAL_PROTECTION, BONUS_TYPE_ENHANCEMENT, NULL, 0,
+                                          caster_id);
+  if (height_bonus > 0)
+    apply_rol_elemental_embodiment_affect(victim, spellnum, duration, APPLY_CHAR_HEIGHT,
+                                          height_bonus, BONUS_TYPE_UNIVERSAL, NULL, 0, caster_id);
+  if (weight_bonus > 0)
+    apply_rol_elemental_embodiment_affect(victim, spellnum, duration, APPLY_CHAR_WEIGHT,
+                                          weight_bonus, BONUS_TYPE_UNIVERSAL, NULL, 0, caster_id);
+  affect_batch_end(victim);
+
+  GET_HIT(victim) = MIN(GET_MAX_HIT(victim), GET_HIT(victim) + hp_bonus);
+
+  new_affect(&maintenance);
+  maintenance.spell = AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN;
+  maintenance.duration = duration;
+  maintenance.specific = spellnum;
+  affect_to_char_source(ch, &maintenance, victim_id);
+
+  send_to_char(victim, "%s", profile.victim_message);
+  if (IN_ROOM(victim) != NOWHERE)
+    act(profile.room_message, FALSE, victim, NULL, NULL, TO_ROOM);
+}
+
+ASPELL(spell_elemental_water_embodiment)
+{
+  apply_rol_elemental_embodiment(ch, victim, SPELL_ELEMENTAL_WATER_EMBODIMENT);
+}
+
+ASPELL(spell_elemental_fire_embodiment)
+{
+  apply_rol_elemental_embodiment(ch, victim, SPELL_ELEMENTAL_FIRE_EMBODIMENT);
+}
+
+ASPELL(spell_elemental_earth_embodiment)
+{
+  apply_rol_elemental_embodiment(ch, victim, SPELL_ELEMENTAL_EARTH_EMBODIMENT);
+}
+
+ASPELL(spell_elemental_air_embodiment)
+{
+  apply_rol_elemental_embodiment(ch, victim, SPELL_ELEMENTAL_AIR_EMBODIMENT);
+}
+
+static void remove_rol_elemental_embodiment_components(struct char_data *ch, int spellnum,
+                                                       long source_id, int specific)
+{
+  struct affected_type *af;
+  struct affected_type *next;
+
+  if (ch == NULL)
+    return;
+
+  for (af = ch->affected; af != NULL; af = next)
+  {
+    next = af->next;
+    if (af->spell != spellnum)
+      continue;
+    if (source_id > 0 && af->source_id != source_id)
+      continue;
+    if (specific > 0 && af->specific != specific)
+      continue;
+    affect_remove(ch, af);
+  }
+}
+
+void remove_rol_elemental_embodiment_affect(struct char_data *ch, int spellnum)
+{
+  struct affected_type *af;
+  struct char_data *counterpart;
+  long counterpart_id = 0;
+  long own_id;
+  int maintained_spell = 0;
+  int target_spell;
+
+  if (ch == NULL || !rol_elemental_embodiment_affect_is_transient(spellnum))
+    return;
+
+  own_id = char_script_id(ch);
+  for (af = ch->affected; af != NULL; af = af->next)
+  {
+    if (af->spell != spellnum)
+      continue;
+    counterpart_id = af->source_id;
+    maintained_spell = af->specific;
+    break;
+  }
+
+  remove_rol_elemental_embodiment_components(ch, spellnum, 0, 0);
+  if (rol_elemental_embodiment_spell(spellnum))
+  {
+    counterpart = find_char(counterpart_id);
+    remove_rol_elemental_embodiment_components(
+        counterpart, AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN, own_id, spellnum);
+    GET_HIT(ch) = MIN(GET_HIT(ch), GET_MAX_HIT(ch));
+    return;
+  }
+
+  counterpart = find_char(counterpart_id);
+  if (counterpart == NULL)
+    return;
+  if (rol_elemental_embodiment_spell(maintained_spell))
+  {
+    remove_rol_elemental_embodiment_components(counterpart, maintained_spell, own_id, 0);
+  }
+  else
+  {
+    for (target_spell = SPELL_ELEMENTAL_WATER_EMBODIMENT;
+         target_spell <= SPELL_ELEMENTAL_AIR_EMBODIMENT; target_spell++)
+      remove_rol_elemental_embodiment_components(counterpart, target_spell, own_id, 0);
+  }
+  GET_HIT(counterpart) = MIN(GET_HIT(counterpart), GET_MAX_HIT(counterpart));
+}
+
+void remove_all_rol_elemental_embodiments(struct char_data *ch)
+{
+  int spellnum;
+
+  if (ch == NULL)
+    return;
+
+  remove_rol_elemental_embodiment_affect(ch, AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN);
+  for (spellnum = SPELL_ELEMENTAL_WATER_EMBODIMENT; spellnum <= SPELL_ELEMENTAL_AIR_EMBODIMENT;
+       spellnum++)
+    remove_rol_elemental_embodiment_affect(ch, spellnum);
+}
+
 #ifdef LUMINARI_CUTEST
 int test_call_lycanthrope_level(int caster_level)
 {
@@ -5994,6 +6361,11 @@ int test_call_lycanthrope_charm_save_target(int charisma)
 bool test_tazriks_event_state(const char *state, room_vnum *room, int *strike)
 {
   return tazriks_event_state(state, room, strike);
+}
+
+bool test_rol_elemental_embodiment_same_side(struct char_data *ch, struct char_data *victim)
+{
+  return rol_elemental_embodiment_same_side(ch, victim);
 }
 #endif
 
@@ -6023,6 +6395,9 @@ int adjust_damage_for_creature_wards(struct char_data *attacker, struct char_dat
 }
 
 #undef NO_AFFECT_FLAG
+#undef ROL_ELEMENTAL_MAX_RESISTANCES
+#undef ROL_ELEMENTAL_MAX_FLAGS
+#undef ROL_ELEMENTAL_PROTECTION
 
 #undef ZOCMD
 

--- a/src/magic/spells.c
+++ b/src/magic/spells.c
@@ -5732,6 +5732,271 @@ ASPELL(spell_ice_layer)
   WAIT_STATE(victim, PULSE_VIOLENCE);
 }
 
+static int call_lycanthrope_level(int caster_level)
+{
+  return MIN(40, MAX(1, caster_level - 10));
+}
+
+static int call_lycanthrope_charm_save_target(int charisma)
+{
+  return MIN(20, MAX(1, charisma - 2));
+}
+
+static mob_vnum random_call_lycanthrope_vnum(void)
+{
+  mob_rnum index;
+  mob_vnum selected = NOBODY;
+  int candidates = 0;
+
+  if (mob_proto == NULL || mob_index == NULL)
+    return NOBODY;
+
+  for (index = 0; index <= top_of_mobt; index++)
+  {
+    if (!MOB_FLAGGED(&mob_proto[index], MOB_ROL_LYCANTHROPE_SUMMON))
+      continue;
+
+    candidates++;
+    if (rand_number(1, candidates) == 1)
+      selected = mob_index[index].vnum;
+  }
+
+  return selected;
+}
+
+EVENTFUNC(event_rol_call_lycanthrope_charm)
+{
+  struct mud_event_data *event;
+  struct char_data *master;
+  struct char_data *mob;
+
+  if (event_obj == NULL)
+    return 0;
+
+  event = (struct mud_event_data *)event_obj;
+  mob = (struct char_data *)event->pStruct;
+  if (mob == NULL || !IS_NPC(mob) || !MOB_FLAGGED(mob, MOB_ROL_LYCANTHROPE_SUMMON) ||
+      !AFF_FLAGGED(mob, AFF_CHARM) || mob->master == NULL)
+    return 0;
+
+  master = mob->master;
+  if (FIGHTING(mob) == NULL)
+  {
+    if (IN_ROOM(mob) != NOWHERE)
+      act("$n slips back through a black door as the charm expires.", FALSE, mob, NULL, NULL,
+          TO_ROOM);
+    stop_follower(mob);
+    extract_char(mob);
+    return 0;
+  }
+
+  if (rand_number(1, 20) < call_lycanthrope_charm_save_target(GET_CHA(master)))
+    return 30 * PASSES_PER_SEC;
+
+  stop_follower(mob);
+  act("$n breaks free of the charm and turns on you with a furious snarl!", FALSE, mob, NULL,
+      master, TO_VICT);
+  act("$n breaks free of the charm and turns on $N with a furious snarl!", FALSE, mob, NULL, master,
+      TO_NOTVICT);
+  end_fights_with(mob);
+  if (IN_ROOM(mob) != NOWHERE && IN_ROOM(mob) == IN_ROOM(master))
+    hit(mob, master, TYPE_UNDEFINED, DAM_RESERVED_DBC, 0, FALSE);
+
+  return 0;
+}
+
+ASPELL(spell_call_lycanthrope)
+{
+  struct char_data *mob;
+  mob_vnum mob_vnum;
+  int hit_points;
+  int mob_level;
+
+  if (ch == NULL || IN_ROOM(ch) == NOWHERE)
+    return;
+  if (!can_add_follower_by_flag(ch, MOB_ROL_LYCANTHROPE_SUMMON))
+  {
+    send_to_char(ch, "You cannot control more than one lycanthrope at a time!\r\n");
+    return;
+  }
+
+  mob_vnum = random_call_lycanthrope_vnum();
+  if (mob_vnum == NOBODY ||
+      (mob = read_mobile_reason(mob_vnum, VIRTUAL, PERF_ENTITY_SPELL_SUMMON)) == NULL)
+  {
+    log("SYSERR: spell_call_lycanthrope could not find a converted summon prototype");
+    send_to_char(ch, "No lycanthrope answers your call. Please report this to staff.\r\n");
+    return;
+  }
+
+  if (ZONE_FLAGGED(GET_ROOM_ZONE(IN_ROOM(ch)), ZONE_WILDERNESS))
+  {
+    X_LOC(mob) = world[IN_ROOM(ch)].coords[0];
+    Y_LOC(mob) = world[IN_ROOM(ch)].coords[1];
+  }
+  char_to_room(mob, IN_ROOM(ch));
+  IS_CARRYING_W(mob) = 0;
+  IS_CARRYING_N(mob) = 0;
+  GET_GOLD(mob) = 0;
+
+  while (mob->affected != NULL)
+    affect_remove(mob, mob->affected);
+
+  mob_level = call_lycanthrope_level(GET_LEVEL(ch));
+  GET_LEVEL(mob) = mob_level;
+  autoroll_mob(mob, TRUE, TRUE);
+  hit_points = MAX(1, dice(mob_level, 20) + GET_CON_BONUS(mob) * mob_level);
+  GET_REAL_MAX_HIT(mob) = GET_MAX_HIT(mob) = GET_HIT(mob) = hit_points;
+
+  act("A black door opens in space and $N leaps through!", FALSE, ch, NULL, mob, TO_ROOM);
+  act("A black door opens in space and $N leaps through!", FALSE, ch, NULL, mob, TO_CHAR);
+  SET_BIT_AR(AFF_FLAGS(mob), AFF_CHARM);
+  load_mtrigger(mob);
+  add_follower(mob, ch);
+  if (!GROUP(mob) && GROUP(ch) && GROUP_LEADER(GROUP(ch)) == ch)
+    join_group(mob, GROUP(ch));
+  NEW_EVENT(eROL_CALL_LYCANTHROPE_CHARM, mob, NULL, 30 * PASSES_PER_SEC);
+}
+
+static bool tazriks_event_state(const char *state, room_vnum *room, int *strike)
+{
+  int parsed_room;
+  int parsed_strike;
+  char trailing;
+
+  if (state == NULL || sscanf(state, "%d %d %c", &parsed_room, &parsed_strike, &trailing) != 2 ||
+      parsed_room < 0 || parsed_strike < 0 || parsed_strike > 2)
+    return false;
+
+  if (room != NULL)
+    *room = (room_vnum)parsed_room;
+  if (strike != NULL)
+    *strike = parsed_strike;
+  return true;
+}
+
+static void tazriks_hound_disappears(room_rnum room)
+{
+  if (room != NOWHERE)
+    send_to_room(room, "The hellhound disappears in a puff of acrid black smoke.\r\n");
+}
+
+EVENTFUNC(event_rol_tazriks_frenzied_hound)
+{
+  struct mud_event_data *event;
+  struct char_data *caster;
+  struct char_data *target;
+  room_vnum stored_vnum;
+  room_rnum room;
+  char state[64];
+  char *next_state;
+  int eligible = 0;
+  int selected;
+  int strike;
+
+  if (event_obj == NULL)
+    return 0;
+
+  event = (struct mud_event_data *)event_obj;
+  caster = (struct char_data *)event->pStruct;
+  if (!tazriks_event_state(event->sVariables, &stored_vnum, &strike) ||
+      (room = real_room(stored_vnum)) == NOWHERE)
+    return 0;
+  if (caster == NULL || IN_ROOM(caster) == NOWHERE)
+  {
+    tazriks_hound_disappears(room);
+    return 0;
+  }
+
+  for (target = world[room].people; target; target = target->next_in_room)
+    if (target != caster && !IS_INCORPOREAL(target) &&
+        aoeOK(caster, target, SPELL_TAZRIKS_FRENZIED_HOUND))
+      eligible++;
+
+  if (eligible == 0)
+  {
+    tazriks_hound_disappears(room);
+    return 0;
+  }
+
+  selected = rand_number(1, eligible);
+  for (target = world[room].people; target; target = target->next_in_room)
+  {
+    if (target == caster || IS_INCORPOREAL(target) ||
+        !aoeOK(caster, target, SPELL_TAZRIKS_FRENZIED_HOUND))
+      continue;
+    if (--selected == 0)
+      break;
+  }
+
+  if (target == NULL)
+  {
+    tazriks_hound_disappears(room);
+    return 0;
+  }
+
+  send_to_char(caster, "The frenzied hound lunges from the vortex at %s!\r\n", GET_NAME(target));
+  act("A slavering hellhound lunges from the vortex and tears into you!", FALSE, target, NULL, NULL,
+      TO_CHAR);
+  act("A slavering hellhound lunges from the vortex and tears into $n!", FALSE, target, NULL, NULL,
+      TO_ROOM);
+  mag_damage(GET_LEVEL(caster), caster, target, NULL, SPELL_TAZRIKS_FRENZIED_HOUND, 0, -1,
+             CAST_SPELL);
+
+  if (strike >= 2)
+  {
+    tazriks_hound_disappears(room);
+    return 0;
+  }
+  if (IN_ROOM(caster) == NOWHERE)
+  {
+    tazriks_hound_disappears(room);
+    return 0;
+  }
+
+  snprintf(state, sizeof(state), "%d %d", world[IN_ROOM(caster)].number, strike + 1);
+  next_state = strdup(state);
+  if (next_state == NULL)
+  {
+    log("SYSERR: event_rol_tazriks_frenzied_hound could not update event state");
+    tazriks_hound_disappears(room);
+    return 0;
+  }
+  free(event->sVariables);
+  event->sVariables = next_state;
+  return PULSE_VIOLENCE;
+}
+
+ASPELL(spell_tazriks_frenzied_hound)
+{
+  char state[64];
+
+  if (ch == NULL || IN_ROOM(ch) == NOWHERE)
+    return;
+
+  send_to_room(IN_ROOM(ch),
+               "A vortex to the Abyss opens in midair. From it springs a slavering hellhound!\r\n");
+  snprintf(state, sizeof(state), "%d 0", world[IN_ROOM(ch)].number);
+  NEW_EVENT(eROL_TAZRIKS_FRENZIED_HOUND, ch, state, PULSE_VIOLENCE);
+}
+
+#ifdef LUMINARI_CUTEST
+int test_call_lycanthrope_level(int caster_level)
+{
+  return call_lycanthrope_level(caster_level);
+}
+
+int test_call_lycanthrope_charm_save_target(int charisma)
+{
+  return call_lycanthrope_charm_save_target(charisma);
+}
+
+bool test_tazriks_event_state(const char *state, room_vnum *room, int *strike)
+{
+  return tazriks_event_state(state, room, strike);
+}
+#endif
+
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage)
 {
   if (victim == NULL || damage <= 0)

--- a/src/magic/spells.c
+++ b/src/magic/spells.c
@@ -4450,7 +4450,7 @@ static void apply_spell_effect(struct char_data *victim, int spellnum, int durat
 
   new_affect(&af);
   af.spell = spellnum;
-  af.duration = MAX(1, duration);
+  af.duration = duration < 0 ? -1 : MAX(1, duration);
   af.location = location;
   af.modifier = modifier;
   if (affect_flag > AFF_DONTUSE)
@@ -5534,6 +5534,149 @@ ASPELL(spell_phantom_heal)
                "points.\r\n",
                amount);
   act("A healthy illusion settles over $n's wounds.", FALSE, victim, NULL, NULL, TO_ROOM);
+}
+
+ASPELL(spell_heal_undead)
+{
+  int amount;
+
+  if (ch == NULL || victim == NULL)
+    return;
+  if (!IS_UNDEAD(victim))
+  {
+    if (victim == ch)
+      send_to_char(ch, "You are not undead.\r\n");
+    else
+      send_to_char(ch, "%s is not undead.\r\n", GET_NAME(victim));
+    return;
+  }
+  if (AFF_FLAGGED(victim, AFF_BLACKMANTLE))
+  {
+    send_to_char(ch, "The black mantle smothers your healing magic.\r\n");
+    return;
+  }
+
+  if (!IS_NPC(ch) && !IS_NPC(victim) && IS_LICH(ch) && IS_LICH(victim))
+    amount = 100;
+  else
+    amount = dice(4, MAX(1, level));
+
+  amount = MIN(amount, MAX(0, GET_MAX_HIT(victim) - GET_HIT(victim)));
+  if (amount <= 0)
+  {
+    if (victim == ch)
+      send_to_char(ch, "You are already at full strength.\r\n");
+    else
+      send_to_char(ch, "%s is already at full strength.\r\n", GET_NAME(victim));
+    return;
+  }
+
+  GET_HIT(victim) += amount;
+  update_pos(victim);
+  send_to_char(victim, "Dark power knits your undead form together, restoring %d hit points.\r\n",
+               amount);
+  if (victim != ch)
+    send_to_char(ch, "You restore %d hit points to %s's undead form.\r\n", amount,
+                 GET_NAME(victim));
+}
+
+ASPELL(spell_dark_wrath)
+{
+  int damage_bonus;
+  int duration;
+  int save_bonus;
+
+  if (ch == NULL)
+    return;
+  if (FIGHTING(ch) != NULL)
+  {
+    send_to_char(ch, "You cannot invite dark wrath while already fighting.\r\n");
+    return;
+  }
+  if (affected_by_spell(ch, SPELL_DARK_WRATH))
+  {
+    send_to_char(ch, "Dark wrath already empowers you.\r\n");
+    return;
+  }
+
+  if (level < 46)
+  {
+    duration = rand_number(5, 8);
+    damage_bonus = 1;
+    save_bonus = 3;
+  }
+  else if (level < 50)
+  {
+    duration = rand_number(7, 10);
+    damage_bonus = 2;
+    save_bonus = 4;
+  }
+  else
+  {
+    duration = rand_number(9, 12);
+    damage_bonus = 3;
+    save_bonus = 5;
+  }
+
+  apply_spell_effect(ch, SPELL_DARK_WRATH, duration, APPLY_DAMROLL, damage_bonus, NO_AFFECT_FLAG,
+                     NO_AFFECT_FLAG);
+  apply_spell_effect(ch, SPELL_DARK_WRATH, duration, APPLY_SAVING_FORT, save_bonus, NO_AFFECT_FLAG,
+                     NO_AFFECT_FLAG);
+  apply_spell_effect(ch, SPELL_DARK_WRATH, duration, APPLY_SAVING_REFL, save_bonus, NO_AFFECT_FLAG,
+                     NO_AFFECT_FLAG);
+  apply_spell_effect(ch, SPELL_DARK_WRATH, duration, APPLY_SAVING_WILL, save_bonus, NO_AFFECT_FLAG,
+                     NO_AFFECT_FLAG);
+  send_to_char(ch, "Your god smiles upon your destructive soul.\r\n");
+}
+
+ASPELL(spell_unholy_aura)
+{
+  int duration;
+
+  if (ch == NULL)
+    return;
+  if (AFF_FLAGGED(ch, AFF_FSHIELD))
+  {
+    send_to_char(ch, "Flames already surround you.\r\n");
+    return;
+  }
+
+  duration = MAX(1, 3 * get_spell_duration_bonus(ch) / 100);
+  apply_spell_effect(ch, SPELL_UNHOLY_AURA, duration, APPLY_NONE, 0, AFF_FSHIELD, NO_AFFECT_FLAG);
+  send_to_char(ch, "Unholy flames flare into an aura around you.\r\n");
+  if (IN_ROOM(ch) != NOWHERE)
+    act("Unholy flames flare into an aura around $n.", FALSE, ch, NULL, NULL, TO_ROOM);
+}
+
+void remove_spell_camouflage(struct char_data *ch)
+{
+  if (ch == NULL)
+    return;
+
+  if (affected_by_spell(ch, SPELL_CAMOUFLAGE))
+    affect_from_char(ch, SPELL_CAMOUFLAGE);
+}
+
+ASPELL(spell_camouflage)
+{
+  if (ch == NULL)
+    return;
+  if (AFF_FLAGGED(ch, AFF_HIDE))
+  {
+    send_to_char(ch, "You are already hidden from view.\r\n");
+    return;
+  }
+  if (RIDING(ch) != NULL)
+  {
+    send_to_char(ch, "You cannot blend into the surroundings while mounted.\r\n");
+    return;
+  }
+
+  end_fights_with(ch);
+  apply_spell_effect(ch, SPELL_CAMOUFLAGE, -1, APPLY_NONE, 0, AFF_HIDE, NO_AFFECT_FLAG);
+  send_to_char(ch, "Your appearance shifts until you blend into the surroundings.\r\n");
+  if (IN_ROOM(ch) != NOWHERE)
+    act("$n's appearance shifts and blends into the surroundings.", FALSE, ch, NULL, NULL, TO_ROOM);
 }
 
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage)

--- a/src/magic/spells.c
+++ b/src/magic/spells.c
@@ -5679,6 +5679,59 @@ ASPELL(spell_camouflage)
     act("$n's appearance shifts and blends into the surroundings.", FALSE, ch, NULL, NULL, TO_ROOM);
 }
 
+static bool ice_layer_target_is_immune(struct char_data *victim)
+{
+  if (victim == NULL)
+    return true;
+
+  if (IS_INCORPOREAL(victim) || IS_DRAGON(victim) || HAS_SUBRACE(victim, SUBRACE_ANGEL))
+    return true;
+
+  return IS_NPC(victim) &&
+         (MOB_FLAGGED(victim, MOB_ROL_DEMON) || MOB_FLAGGED(victim, MOB_ROL_DEVIL) ||
+          MOB_FLAGGED(victim, MOB_ROL_ANGEL) || MOB_FLAGGED(victim, MOB_ROL_BEHOLDER));
+}
+
+#ifdef LUMINARI_CUTEST
+bool test_ice_layer_target_is_immune(struct char_data *victim)
+{
+  return ice_layer_target_is_immune(victim);
+}
+#endif
+
+ASPELL(spell_ice_layer)
+{
+  if (ch == NULL || victim == NULL)
+    return;
+  if (GET_POS(victim) <= POS_SITTING)
+  {
+    send_to_char(ch, "%s is already on the ground.\r\n", GET_NAME(victim));
+    return;
+  }
+  if (ice_layer_target_is_immune(victim))
+  {
+    send_to_char(ch, "The ice melts harmlessly beneath %s.\r\n", GET_NAME(victim));
+    return;
+  }
+
+  act("You conjure a sheet of slippery ice beneath $N!", FALSE, ch, NULL, victim, TO_CHAR);
+  act("$n conjures a sheet of slippery ice beneath you!", FALSE, ch, NULL, victim, TO_VICT);
+  act("$n conjures a sheet of slippery ice beneath $N!", FALSE, ch, NULL, victim, TO_NOTVICT);
+  if (savingthrow(ch, victim, SAVING_REFL, -1, casttype, level, EVOCATION))
+  {
+    act("$n slips, but manages to retain $s balance.", FALSE, victim, NULL, NULL, TO_ROOM);
+    send_to_char(victim, "You slip, but manage to retain your balance.\r\n");
+    return;
+  }
+
+  act("$n flails wildly and crashes to the ground!", FALSE, victim, NULL, NULL, TO_ROOM);
+  send_to_char(victim, "You flail wildly and crash to the ground!\r\n");
+  if (damage(ch, victim, dice(2, 10), SPELL_ICE_LAYER, DAM_BLUDGEON, FALSE) < 0)
+    return;
+  change_position(victim, POS_SITTING);
+  WAIT_STATE(victim, PULSE_VIOLENCE);
+}
+
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage)
 {
   if (victim == NULL || damage <= 0)

--- a/src/magic/spells.h
+++ b/src/magic/spells.h
@@ -683,9 +683,13 @@
 #define SPELL_SUN_SHADOW 596
 #define SPELL_EARTH_FOG 597
 #define SPELL_FIRE_FOG 598
+#define SPELL_HEAL_UNDEAD 599
+#define SPELL_DARK_WRATH 600
+#define SPELL_UNHOLY_AURA 601
+#define SPELL_CAMOUFLAGE 602
 
 /** Total Number of defined spells  */
-#define NUM_SPELLS 599
+#define NUM_SPELLS 603
 #define LAST_SPELL_DEFINE NUM_SPELLS + 1
 
 #define MAX_SPELL_AFFECTS 6 /* change if more needed */
@@ -1897,6 +1901,12 @@ ASPELL(spell_spirit_walk);
 ASPELL(spell_rock_to_mud);
 ASPELL(spell_mud_to_rock);
 ASPELL(spell_phantom_heal);
+ASPELL(spell_heal_undead);
+ASPELL(spell_dark_wrath);
+ASPELL(spell_unholy_aura);
+ASPELL(spell_camouflage);
+
+void remove_spell_camouflage(struct char_data *ch);
 
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage);
 int adjust_damage_for_creature_wards(struct char_data *attacker, struct char_data *victim,

--- a/src/magic/spells.h
+++ b/src/magic/spells.h
@@ -691,9 +691,11 @@
 #define SPELL_LICH_TOUCH 604
 #define SPELL_LAVA_BURST 605
 #define SPELL_ICE_LAYER 606
+#define SPELL_CALL_LYCANTHROPE 607
+#define SPELL_TAZRIKS_FRENZIED_HOUND 608
 
 /** Total Number of defined spells  */
-#define NUM_SPELLS 607
+#define NUM_SPELLS 609
 #define LAST_SPELL_DEFINE NUM_SPELLS + 1
 
 #define MAX_SPELL_AFFECTS 6 /* change if more needed */
@@ -1910,6 +1912,8 @@ ASPELL(spell_dark_wrath);
 ASPELL(spell_unholy_aura);
 ASPELL(spell_camouflage);
 ASPELL(spell_ice_layer);
+ASPELL(spell_call_lycanthrope);
+ASPELL(spell_tazriks_frenzied_hound);
 
 void remove_spell_camouflage(struct char_data *ch);
 
@@ -1919,6 +1923,9 @@ int test_adjust_lich_touch_damage(struct char_data *victim, int damage);
 bool test_ice_layer_target_is_immune(struct char_data *victim);
 bool test_lava_burst_should_ignite(int damage_result, int hit_before, int hit_after,
                                    bool already_burning);
+int test_call_lycanthrope_level(int caster_level);
+int test_call_lycanthrope_charm_save_target(int charisma);
+bool test_tazriks_event_state(const char *state, room_vnum *room, int *strike);
 #endif
 
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage);

--- a/src/magic/spells.h
+++ b/src/magic/spells.h
@@ -687,9 +687,13 @@
 #define SPELL_DARK_WRATH 600
 #define SPELL_UNHOLY_AURA 601
 #define SPELL_CAMOUFLAGE 602
+#define SPELL_CYCLONE 603
+#define SPELL_LICH_TOUCH 604
+#define SPELL_LAVA_BURST 605
+#define SPELL_ICE_LAYER 606
 
 /** Total Number of defined spells  */
-#define NUM_SPELLS 603
+#define NUM_SPELLS 607
 #define LAST_SPELL_DEFINE NUM_SPELLS + 1
 
 #define MAX_SPELL_AFFECTS 6 /* change if more needed */
@@ -1905,8 +1909,17 @@ ASPELL(spell_heal_undead);
 ASPELL(spell_dark_wrath);
 ASPELL(spell_unholy_aura);
 ASPELL(spell_camouflage);
+ASPELL(spell_ice_layer);
 
 void remove_spell_camouflage(struct char_data *ch);
+
+#ifdef LUMINARI_CUTEST
+int test_cyclone_damage_percent(bool player_caster, int wind_speed);
+int test_adjust_lich_touch_damage(struct char_data *victim, int damage);
+bool test_ice_layer_target_is_immune(struct char_data *victim);
+bool test_lava_burst_should_ignite(int damage_result, int hit_before, int hit_after,
+                                   bool already_burning);
+#endif
 
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage);
 int adjust_damage_for_creature_wards(struct char_data *attacker, struct char_data *victim,

--- a/src/magic/spells.h
+++ b/src/magic/spells.h
@@ -693,9 +693,13 @@
 #define SPELL_ICE_LAYER 606
 #define SPELL_CALL_LYCANTHROPE 607
 #define SPELL_TAZRIKS_FRENZIED_HOUND 608
+#define SPELL_ELEMENTAL_WATER_EMBODIMENT 609
+#define SPELL_ELEMENTAL_FIRE_EMBODIMENT 610
+#define SPELL_ELEMENTAL_EARTH_EMBODIMENT 611
+#define SPELL_ELEMENTAL_AIR_EMBODIMENT 612
 
 /** Total Number of defined spells  */
-#define NUM_SPELLS 609
+#define NUM_SPELLS 613
 #define LAST_SPELL_DEFINE NUM_SPELLS + 1
 
 #define MAX_SPELL_AFFECTS 6 /* change if more needed */
@@ -851,6 +855,7 @@
 #define AFFECT_ROL_UNDEAD_SPELL_DRAIN 1338
 #define AFFECT_ROL_MANSCORPION_VENOM 1339
 #define AFFECT_ROL_BARBAZU_BERSERK 1340
+#define AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN 1341
 
 // 1470 to 1493 are poisons with room saved for more poisons up to 1498
 
@@ -1914,8 +1919,16 @@ ASPELL(spell_camouflage);
 ASPELL(spell_ice_layer);
 ASPELL(spell_call_lycanthrope);
 ASPELL(spell_tazriks_frenzied_hound);
+ASPELL(spell_elemental_water_embodiment);
+ASPELL(spell_elemental_fire_embodiment);
+ASPELL(spell_elemental_earth_embodiment);
+ASPELL(spell_elemental_air_embodiment);
 
 void remove_spell_camouflage(struct char_data *ch);
+bool rol_elemental_embodiment_affect_is_transient(int spellnum);
+bool rol_elemental_embodiment_active(struct char_data *ch);
+void remove_rol_elemental_embodiment_affect(struct char_data *ch, int spellnum);
+void remove_all_rol_elemental_embodiments(struct char_data *ch);
 
 #ifdef LUMINARI_CUTEST
 int test_cyclone_damage_percent(bool player_caster, int wind_speed);
@@ -1926,6 +1939,7 @@ bool test_lava_burst_should_ignite(int damage_result, int hit_before, int hit_af
 int test_call_lycanthrope_level(int caster_level);
 int test_call_lycanthrope_charm_save_target(int charisma);
 bool test_tazriks_event_state(const char *state, room_vnum *room, int *strike);
+bool test_rol_elemental_embodiment_same_side(struct char_data *ch, struct char_data *victim);
 #endif
 
 int adjust_area_damage_for_spell_wards(struct char_data *victim, int damage);

--- a/src/mud_event.h
+++ b/src/mud_event.h
@@ -262,6 +262,8 @@ typedef enum
   eROL_SPIDERHAUNT_MAGGOTS,     /* Converted Spiderhaunt delayed maggot sensation */
   eDRAGON_ATTACK_COOLDOWN,      /* Shared short cooldown for innate dragon attacks */
   eROL_CALM,                    /* Calm feat daily use cooldown */
+  eROL_CALL_LYCANTHROPE_CHARM,  /* Converted call-lycanthrope charm check */
+  eROL_TAZRIKS_FRENZIED_HOUND,  /* Converted Tazrik's hound recurring strike */
   eMUD_EVENT_COUNT
 } event_id;
 
@@ -347,4 +349,6 @@ EVENTFUNC(event_aqueous_orb);
 EVENTFUNC(event_device_progress);
 EVENTFUNC(event_device_creation);
 EVENTFUNC(event_device_repair);
+EVENTFUNC(event_rol_call_lycanthrope_charm);
+EVENTFUNC(event_rol_tazriks_frenzied_hound);
 #endif /* _MUD_EVENT_H_ */

--- a/src/mud_event_list.c
+++ b/src/mud_event_list.c
@@ -49,6 +49,8 @@ extern EVENTFUNC(event_rol_barbazu_bloodloss);
 extern EVENTFUNC(event_rol_drow_decay);
 extern EVENTFUNC(event_rol_deaths_head_seed);
 extern EVENTFUNC(event_rol_spiderhaunt_maggots);
+extern EVENTFUNC(event_rol_call_lycanthrope_charm);
+extern EVENTFUNC(event_rol_tazriks_frenzied_hound);
 
 /* The mud_event_index[] with extended data for table-driven handling
  * Format: {name, func, type, completion_msg, recovery_msg, feat, daily_uses} */
@@ -528,6 +530,10 @@ struct mud_event_list mud_event_index[] = {
     {"Dragon Attack Cooldown", event_countdown, EVENT_CHAR, NULL, NULL, FEAT_UNDEFINED, 0},
     {"Calm Cooldown", event_daily_use_cooldown, EVENT_CHAR, NULL,
      "One of your calm uses has recovered.", FEAT_CALM, 0},
+    {"RoL Call Lycanthrope Charm", event_rol_call_lycanthrope_charm, EVENT_CHAR, NULL, NULL,
+     FEAT_UNDEFINED, 0},
+    {"RoL Tazrik's Frenzied Hound", event_rol_tazriks_frenzied_hound, EVENT_CHAR, NULL, NULL,
+     FEAT_UNDEFINED, 0},
 };
 
 /* Expose registry count for validation */

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -739,6 +739,45 @@ void mysql_pool_free_result(MYSQL_RES *result)
   }
 }
 
+int get_cached_zone_wind_speed(zone_vnum zone, int fallback)
+{
+  MYSQL_RES *result = NULL;
+  MYSQL_ROW row;
+  char query[256];
+  char *end = NULL;
+  long wind_speed;
+  bool invalid;
+
+  if (!mysql_available || mysql_pool == NULL || !mysql_pool->initialized)
+    return fallback;
+
+  snprintf(query, sizeof(query),
+           "SELECT wind_speed FROM weather_cache WHERE zone_vnum = %d "
+           "ORDER BY (expires_at > CURRENT_TIMESTAMP) DESC, cached_at DESC LIMIT 1",
+           (int)zone);
+  if (mysql_pool_query(query, &result) != 0 || result == NULL)
+  {
+    mysql_pool_free_result(result);
+    return fallback;
+  }
+
+  row = mysql_fetch_row(result);
+  if (row == NULL || row[0] == NULL)
+  {
+    mysql_pool_free_result(result);
+    return fallback;
+  }
+
+  errno = 0;
+  wind_speed = strtol(row[0], &end, 10);
+  invalid = errno != 0 || end == row[0] || *end != '\0' || wind_speed < 0 || wind_speed > INT_MAX;
+  mysql_pool_free_result(result);
+  if (invalid)
+    return fallback;
+
+  return (int)wind_speed;
+}
+
 /* ========================================================================== */
 /* End of Connection Pool Implementation                                      */
 /* ========================================================================== */

--- a/src/mysql.h
+++ b/src/mysql.h
@@ -114,6 +114,7 @@ void mysql_test_clear_query_failure(void);
 /* Pool-aware query functions - automatically acquire/release connections */
 int mysql_pool_query(const char *query, MYSQL_RES **result);
 void mysql_pool_free_result(MYSQL_RES *result);
+int get_cached_zone_wind_speed(zone_vnum zone, int fallback);
 
 /* String escaping for SQL injection prevention */
 char *mysql_escape_string_alloc(MYSQL *mysql_conn, const char *str);

--- a/src/players.c
+++ b/src/players.c
@@ -3949,7 +3949,7 @@ bool save_char_checked(struct char_data *ch, int mode)
     for (i = 0; i < MAX_AFFECT; i++)
     {
       aff = &tmp_aff[i];
-      if (aff->spell)
+      if (aff->spell && !rol_elemental_embodiment_affect_is_transient(aff->spell))
         BUFFER_WRITE("%d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", aff->spell, aff->duration,
                      aff->modifier, aff->location, aff->bitvector[0], aff->bitvector[1],
                      aff->bitvector[2], aff->bitvector[3], aff->bonus_type, aff->specific,
@@ -4850,6 +4850,8 @@ static void load_affects(FILE *fl, struct char_data *ch, int affect_file_version
         /* Equipment-derived artifact passives and bonuses are restored dynamically on equip */
         continue;
       }
+      if (rol_elemental_embodiment_affect_is_transient(af.spell))
+        continue;
       affect_to_char(ch, &af);
       i++;
     }
@@ -6066,6 +6068,8 @@ static char *serialize_pet_runtime_state(struct char_data *pet)
   affect_count = 0;
   for (af = pet->affected; af; af = af->next)
   {
+    if (rol_elemental_embodiment_affect_is_transient(af->spell))
+      continue;
     if (affect_count >= MAX_AFFECT)
       break;
     PET_STATE_APPEND("A %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n", af->spell, af->duration,
@@ -6331,6 +6335,8 @@ static void apply_pet_runtime_state(struct char_data *pet, const struct pet_runt
   for (i = state->affect_count - 1; i >= 0; i--)
   {
     af = state->affects[i];
+    if (rol_elemental_embodiment_affect_is_transient(af.spell))
+      continue;
     af.next = NULL;
     affect_to_char(pet, &af);
   }

--- a/src/structs.h
+++ b/src/structs.h
@@ -1171,31 +1171,32 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define MOB_NO_BLOCK_BYPASS                                                                        \
   102                 /**< Prevents Ghost perk and similar abilities from bypassing mob blocking */
 #define MOB_GOLEM 103 /**< Mob is a constructed golem (for follower tracking) */
-#define MOB_NOTELEPORT 104            /**< Mob cannot be teleported */
-#define MOB_ROL_NICE_THIEF 105        /**< RoL: caught theft does not provoke retaliation */
-#define MOB_ROL_STAY_SECTOR 106       /**< RoL: random movement remains in the same sector */
-#define MOB_ROL_DELAY_HUNTER 107      /**< RoL: become a hunter after taking material damage */
-#define MOB_ROL_ARCHER 108            /**< RoL: fire a ranged weapon into an adjacent room */
-#define MOB_ROL_HAS_PS 109            /**< RoL: psionic mobile behavior role */
-#define MOB_ROL_HAS_CL 110            /**< RoL: divine-caster mobile behavior role */
-#define MOB_ROL_HAS_MU 111            /**< RoL: arcane-caster mobile behavior role */
-#define MOB_ROL_HAS_TH 112            /**< RoL: rogue mobile behavior role */
-#define MOB_ROL_HAS_WA 113            /**< RoL: warrior mobile behavior role */
-#define MOB_ROL_AGGR_RACE_EVIL 114    /**< RoL: aggressive toward evil source races */
-#define MOB_ROL_AGGR_RACE_GOOD 115    /**< RoL: aggressive toward good source races */
-#define MOB_ROL_DEMON 116             /**< RoL: implicit standard demon behavior */
-#define MOB_ROL_DEVIL 117             /**< RoL: implicit standard devil behavior */
-#define MOB_ROL_UMBERHULK 118         /**< RoL: implicit standard umber-hulk behavior */
-#define MOB_ROL_FADE_FAMILIAR 119     /**< RoL: familiar fades without a corpse */
-#define MOB_ROL_FADE_MOUNT 120        /**< RoL: conjured mount fades without a corpse */
-#define MOB_ROL_FADE_MONSTER 121      /**< RoL: conjured monster fades without a corpse */
-#define MOB_ROL_ANGEL 122             /**< RoL: preserves source angel identity */
-#define MOB_ROL_TOTEM_SPIRIT 123      /**< RoL: shaman totem spirit fades without a corpse */
-#define MOB_ROL_BLACK_VAPOR_DEATH 124 /**< RoL: undead uses Bloodstone's death message */
-#define MOB_ROL_ABYSS_FORGED 125      /**< RoL: wielded abyss-forged weapons dissolve on death */
-#define MOB_ROL_BEHOLDER 126          /**< RoL: preserves source beholder identity */
+#define MOB_NOTELEPORT 104             /**< Mob cannot be teleported */
+#define MOB_ROL_NICE_THIEF 105         /**< RoL: caught theft does not provoke retaliation */
+#define MOB_ROL_STAY_SECTOR 106        /**< RoL: random movement remains in the same sector */
+#define MOB_ROL_DELAY_HUNTER 107       /**< RoL: become a hunter after taking material damage */
+#define MOB_ROL_ARCHER 108             /**< RoL: fire a ranged weapon into an adjacent room */
+#define MOB_ROL_HAS_PS 109             /**< RoL: psionic mobile behavior role */
+#define MOB_ROL_HAS_CL 110             /**< RoL: divine-caster mobile behavior role */
+#define MOB_ROL_HAS_MU 111             /**< RoL: arcane-caster mobile behavior role */
+#define MOB_ROL_HAS_TH 112             /**< RoL: rogue mobile behavior role */
+#define MOB_ROL_HAS_WA 113             /**< RoL: warrior mobile behavior role */
+#define MOB_ROL_AGGR_RACE_EVIL 114     /**< RoL: aggressive toward evil source races */
+#define MOB_ROL_AGGR_RACE_GOOD 115     /**< RoL: aggressive toward good source races */
+#define MOB_ROL_DEMON 116              /**< RoL: implicit standard demon behavior */
+#define MOB_ROL_DEVIL 117              /**< RoL: implicit standard devil behavior */
+#define MOB_ROL_UMBERHULK 118          /**< RoL: implicit standard umber-hulk behavior */
+#define MOB_ROL_FADE_FAMILIAR 119      /**< RoL: familiar fades without a corpse */
+#define MOB_ROL_FADE_MOUNT 120         /**< RoL: conjured mount fades without a corpse */
+#define MOB_ROL_FADE_MONSTER 121       /**< RoL: conjured monster fades without a corpse */
+#define MOB_ROL_ANGEL 122              /**< RoL: preserves source angel identity */
+#define MOB_ROL_TOTEM_SPIRIT 123       /**< RoL: shaman totem spirit fades without a corpse */
+#define MOB_ROL_BLACK_VAPOR_DEATH 124  /**< RoL: undead uses Bloodstone's death message */
+#define MOB_ROL_ABYSS_FORGED 125       /**< RoL: wielded abyss-forged weapons dissolve on death */
+#define MOB_ROL_BEHOLDER 126           /**< RoL: preserves source beholder identity */
+#define MOB_ROL_LYCANTHROPE_SUMMON 127 /**< RoL: call lycanthrope summon prototype */
 /**********************/
-#define NUM_MOB_FLAGS 127
+#define NUM_MOB_FLAGS 128
 /**********************/
 /**********************/
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -1193,8 +1193,9 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define MOB_ROL_TOTEM_SPIRIT 123      /**< RoL: shaman totem spirit fades without a corpse */
 #define MOB_ROL_BLACK_VAPOR_DEATH 124 /**< RoL: undead uses Bloodstone's death message */
 #define MOB_ROL_ABYSS_FORGED 125      /**< RoL: wielded abyss-forged weapons dissolve on death */
+#define MOB_ROL_BEHOLDER 126          /**< RoL: preserves source beholder identity */
 /**********************/
-#define NUM_MOB_FLAGS 126
+#define NUM_MOB_FLAGS 127
 /**********************/
 /**********************/
 

--- a/unittests/CuTest/test_unassigned_spells.c
+++ b/unittests/CuTest/test_unassigned_spells.c
@@ -111,6 +111,13 @@ static const struct spell_registration_expectation remaining_support_spells[] = 
     {SPELL_CAMOUFLAGE, MAG_MANUAL},
 };
 
+static const struct spell_registration_expectation damage_control_spells[] = {
+    {SPELL_CYCLONE, MAG_AREAS},
+    {SPELL_LICH_TOUCH, MAG_DAMAGE | MAG_AFFECTS},
+    {SPELL_LAVA_BURST, MAG_AREAS},
+    {SPELL_ICE_LAYER, MAG_MANUAL},
+};
+
 static void add_test_affect(struct char_data *ch, int spellnum, int location, int modifier)
 {
   struct affected_type af;
@@ -231,6 +238,79 @@ void TestRemainingSupportSpellsAreNativeAndUnassigned(CuTest *tc)
     for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
       CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
   }
+}
+
+void TestDamageControlSpellsAreNativeAndUnassigned(CuTest *tc)
+{
+  size_t index;
+  int class_num;
+  int domain_num;
+  int spellnum;
+
+  mag_assign_spells();
+
+  for (index = 0; index < sizeof(damage_control_spells) / sizeof(damage_control_spells[0]); index++)
+  {
+    spellnum = damage_control_spells[index].spellnum;
+    CuAssertTrue(tc, spell_info[spellnum].name != NULL);
+    CuAssertTrue(tc, spell_info[spellnum].name != unused_spellname);
+    CuAssertIntEquals(tc, damage_control_spells[index].routines, spell_info[spellnum].routines);
+
+    for (class_num = 0; class_num < NUM_CLASSES; class_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].min_level[class_num]);
+    for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
+  }
+}
+
+void TestCycloneUsesSourceWindThresholdOnlyForPlayerCasters(CuTest *tc)
+{
+  CuAssertIntEquals(tc, 50, test_cyclone_damage_percent(true, 25));
+  CuAssertIntEquals(tc, 100, test_cyclone_damage_percent(true, 26));
+  CuAssertIntEquals(tc, 100, test_cyclone_damage_percent(false, 0));
+}
+
+void TestLichTouchPreservesElementalAndShieldDamageInteractions(CuTest *tc)
+{
+  struct char_data victim;
+
+  clear_char(&victim);
+  SET_BIT_AR(MOB_FLAGS(&victim), MOB_ISNPC);
+  GET_REAL_RACE(&victim) = RACE_TYPE_ELEMENTAL;
+  GET_SUBRACE(&victim, 0) = SUBRACE_FIRE;
+
+  CuAssertIntEquals(tc, 125, test_adjust_lich_touch_damage(&victim, 100));
+  SET_BIT_AR(AFF_FLAGS(&victim), AFF_CSHIELD);
+  CuAssertIntEquals(tc, 62, test_adjust_lich_touch_damage(&victim, 100));
+  SET_BIT_AR(AFF_FLAGS(&victim), AFF_FSHIELD);
+  CuAssertIntEquals(tc, 112, test_adjust_lich_touch_damage(&victim, 100));
+}
+
+void TestIceLayerRecognizesPreservedSourceImmunities(CuTest *tc)
+{
+  struct char_data victim;
+
+  clear_char(&victim);
+  SET_BIT_AR(MOB_FLAGS(&victim), MOB_ISNPC);
+  GET_REAL_RACE(&victim) = RACE_TYPE_HUMANOID;
+  CuAssertTrue(tc, !test_ice_layer_target_is_immune(&victim));
+
+  SET_BIT_AR(MOB_FLAGS(&victim), MOB_ROL_BEHOLDER);
+  CuAssertTrue(tc, test_ice_layer_target_is_immune(&victim));
+  REMOVE_BIT_AR(MOB_FLAGS(&victim), MOB_ROL_BEHOLDER);
+  SET_BIT_AR(MOB_FLAGS(&victim), MOB_ROL_DEMON);
+  CuAssertTrue(tc, test_ice_layer_target_is_immune(&victim));
+  REMOVE_BIT_AR(MOB_FLAGS(&victim), MOB_ROL_DEMON);
+  GET_REAL_RACE(&victim) = RACE_TYPE_DRAGON;
+  CuAssertTrue(tc, test_ice_layer_target_is_immune(&victim));
+}
+
+void TestLavaBurstIgnitesOnlySuccessfullyDamagedSurvivors(CuTest *tc)
+{
+  CuAssertTrue(tc, test_lava_burst_should_ignite(0, 100, 75, false));
+  CuAssertTrue(tc, !test_lava_burst_should_ignite(-1, 100, 0, false));
+  CuAssertTrue(tc, !test_lava_burst_should_ignite(0, 100, 100, false));
+  CuAssertTrue(tc, !test_lava_burst_should_ignite(0, 100, 75, true));
 }
 
 void TestHealUndeadPreservesLichAndBlackmantleRules(CuTest *tc)

--- a/unittests/CuTest/test_unassigned_spells.c
+++ b/unittests/CuTest/test_unassigned_spells.c
@@ -11,6 +11,7 @@
 #include "../../src/handler.h"
 #include "../../src/magic/domains_schools.h"
 #include "../../src/magic/spells.h"
+#include "../../src/mud_event.h"
 
 #include <string.h>
 
@@ -116,6 +117,11 @@ static const struct spell_registration_expectation damage_control_spells[] = {
     {SPELL_LICH_TOUCH, MAG_DAMAGE | MAG_AFFECTS},
     {SPELL_LAVA_BURST, MAG_AREAS},
     {SPELL_ICE_LAYER, MAG_MANUAL},
+};
+
+static const struct spell_registration_expectation summon_event_spells[] = {
+    {SPELL_CALL_LYCANTHROPE, MAG_MANUAL},
+    {SPELL_TAZRIKS_FRENZIED_HOUND, MAG_MANUAL},
 };
 
 static void add_test_affect(struct char_data *ch, int spellnum, int location, int modifier)
@@ -261,6 +267,61 @@ void TestDamageControlSpellsAreNativeAndUnassigned(CuTest *tc)
     for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
       CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
   }
+}
+
+void TestSummonEventSpellsAreNativeAndUnassigned(CuTest *tc)
+{
+  size_t index;
+  int class_num;
+  int domain_num;
+  int spellnum;
+
+  mag_assign_spells();
+
+  for (index = 0; index < sizeof(summon_event_spells) / sizeof(summon_event_spells[0]); index++)
+  {
+    spellnum = summon_event_spells[index].spellnum;
+    CuAssertTrue(tc, spell_info[spellnum].name != NULL);
+    CuAssertTrue(tc, spell_info[spellnum].name != unused_spellname);
+    CuAssertIntEquals(tc, summon_event_spells[index].routines, spell_info[spellnum].routines);
+
+    for (class_num = 0; class_num < NUM_CLASSES; class_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].min_level[class_num]);
+    for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
+  }
+}
+
+void TestCallLycanthropePreservesLevelAndCharmCheckBounds(CuTest *tc)
+{
+  CuAssertIntEquals(tc, 1, test_call_lycanthrope_level(1));
+  CuAssertIntEquals(tc, 20, test_call_lycanthrope_level(30));
+  CuAssertIntEquals(tc, 40, test_call_lycanthrope_level(75));
+  CuAssertIntEquals(tc, 1, test_call_lycanthrope_charm_save_target(1));
+  CuAssertIntEquals(tc, 8, test_call_lycanthrope_charm_save_target(10));
+  CuAssertIntEquals(tc, 20, test_call_lycanthrope_charm_save_target(30));
+}
+
+void TestTazriksEventStateAllowsExactlyThreeStrikeIndices(CuTest *tc)
+{
+  room_vnum room = 0;
+  int strike = -1;
+
+  CuAssertTrue(tc, test_tazriks_event_state("2000123 0", &room, &strike));
+  CuAssertIntEquals(tc, 2000123, room);
+  CuAssertIntEquals(tc, 0, strike);
+  CuAssertTrue(tc, test_tazriks_event_state("2000123 2", &room, &strike));
+  CuAssertIntEquals(tc, 2, strike);
+  CuAssertTrue(tc, !test_tazriks_event_state("2000123 3", &room, &strike));
+  CuAssertTrue(tc, !test_tazriks_event_state("not event state", &room, &strike));
+}
+
+void TestSummonEventRegistryUsesDedicatedHandlers(CuTest *tc)
+{
+  CuAssertTrue(tc, mud_event_index[eROL_CALL_LYCANTHROPE_CHARM].func ==
+                       event_rol_call_lycanthrope_charm);
+  CuAssertTrue(tc, mud_event_index[eROL_TAZRIKS_FRENZIED_HOUND].func ==
+                       event_rol_tazriks_frenzied_hound);
 }
 
 void TestCycloneUsesSourceWindThresholdOnlyForPlayerCasters(CuTest *tc)

--- a/unittests/CuTest/test_unassigned_spells.c
+++ b/unittests/CuTest/test_unassigned_spells.c
@@ -8,6 +8,7 @@
 #include "../../src/utils.h"
 #include "../../src/character/evolutions.h"
 #include "../../src/combat/fight.h"
+#include "../../src/dgscript/dg_scripts.h"
 #include "../../src/handler.h"
 #include "../../src/magic/domains_schools.h"
 #include "../../src/magic/spells.h"
@@ -122,6 +123,60 @@ static const struct spell_registration_expectation damage_control_spells[] = {
 static const struct spell_registration_expectation summon_event_spells[] = {
     {SPELL_CALL_LYCANTHROPE, MAG_MANUAL},
     {SPELL_TAZRIKS_FRENZIED_HOUND, MAG_MANUAL},
+};
+
+static const struct spell_registration_expectation elemental_embodiment_spells[] = {
+    {SPELL_ELEMENTAL_WATER_EMBODIMENT, MAG_MANUAL},
+    {SPELL_ELEMENTAL_FIRE_EMBODIMENT, MAG_MANUAL},
+    {SPELL_ELEMENTAL_EARTH_EMBODIMENT, MAG_MANUAL},
+    {SPELL_ELEMENTAL_AIR_EMBODIMENT, MAG_MANUAL},
+};
+
+struct elemental_embodiment_expectation
+{
+  int spellnum;
+  int hp_factor;
+  int armor_bonus;
+  int size_percent;
+  int resistance_count;
+  int resistances[3];
+  int flag_count;
+  int flags[3];
+};
+
+static const struct elemental_embodiment_expectation elemental_embodiment_effects[] = {
+    {SPELL_ELEMENTAL_WATER_EMBODIMENT,
+     5,
+     0,
+     25,
+     3,
+     {APPLY_RES_FIRE, APPLY_RES_POISON, APPLY_RES_ACID},
+     1,
+     {AFF_WATER_BREATH, 0, 0}},
+    {SPELL_ELEMENTAL_FIRE_EMBODIMENT,
+     7,
+     6,
+     35,
+     2,
+     {APPLY_RES_POISON, APPLY_RES_FIRE, 0},
+     3,
+     {AFF_FSHIELD, AFF_HASTE, AFF_FLYING}},
+    {SPELL_ELEMENTAL_EARTH_EMBODIMENT,
+     7,
+     0,
+     50,
+     2,
+     {APPLY_RES_POISON, APPLY_RES_COLD, 0},
+     0,
+     {0, 0, 0}},
+    {SPELL_ELEMENTAL_AIR_EMBODIMENT,
+     3,
+     5,
+     15,
+     2,
+     {APPLY_RES_POISON, APPLY_RES_ACID, 0},
+     2,
+     {AFF_HASTE, AFF_FLYING, 0}},
 };
 
 static void add_test_affect(struct char_data *ch, int spellnum, int location, int modifier)
@@ -292,6 +347,32 @@ void TestSummonEventSpellsAreNativeAndUnassigned(CuTest *tc)
   }
 }
 
+void TestElementalEmbodimentSpellsAreNativeAndUnassigned(CuTest *tc)
+{
+  size_t index;
+  int class_num;
+  int domain_num;
+  int spellnum;
+
+  mag_assign_spells();
+
+  for (index = 0;
+       index < sizeof(elemental_embodiment_spells) / sizeof(elemental_embodiment_spells[0]);
+       index++)
+  {
+    spellnum = elemental_embodiment_spells[index].spellnum;
+    CuAssertTrue(tc, spell_info[spellnum].name != NULL);
+    CuAssertTrue(tc, spell_info[spellnum].name != unused_spellname);
+    CuAssertIntEquals(tc, elemental_embodiment_spells[index].routines,
+                      spell_info[spellnum].routines);
+
+    for (class_num = 0; class_num < NUM_CLASSES; class_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].min_level[class_num]);
+    for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
+  }
+}
+
 void TestCallLycanthropePreservesLevelAndCharmCheckBounds(CuTest *tc)
 {
   CuAssertIntEquals(tc, 1, test_call_lycanthrope_level(1));
@@ -322,6 +403,154 @@ void TestSummonEventRegistryUsesDedicatedHandlers(CuTest *tc)
                        event_rol_call_lycanthrope_charm);
   CuAssertTrue(tc, mud_event_index[eROL_TAZRIKS_FRENZIED_HOUND].func ==
                        event_rol_tazriks_frenzied_hound);
+}
+
+void TestElementalEmbodimentsPreserveProfilesAndLinkedCleanup(CuTest *tc)
+{
+  struct affected_type *af;
+  struct char_data caster;
+  struct char_data target;
+  struct player_special_data caster_specials;
+  struct player_special_data target_specials;
+  const struct elemental_embodiment_expectation *expected;
+  long caster_id;
+  long target_id;
+  size_t index;
+  int base_hp;
+  int flag_index;
+  int resistance_index;
+  int variance;
+
+  for (index = 0;
+       index < sizeof(elemental_embodiment_effects) / sizeof(elemental_embodiment_effects[0]);
+       index++)
+  {
+    expected = &elemental_embodiment_effects[index];
+    clear_char(&caster);
+    clear_char(&target);
+    memset(&caster_specials, 0, sizeof(caster_specials));
+    memset(&target_specials, 0, sizeof(target_specials));
+    caster.player_specials = &caster_specials;
+    target.player_specials = &target_specials;
+    caster.player.name = "elementalist";
+    target.player.name = "subject";
+    GET_LEVEL(&caster) = 20;
+    GET_LEVEL(&target) = 10;
+    GET_REAL_RACE(&caster) = RACE_HUMAN;
+    GET_REAL_RACE(&target) = RACE_HUMAN;
+    GET_REAL_MAX_HIT(&target) = GET_MAX_HIT(&target) = 500;
+    GET_HIT(&target) = 100;
+    GET_HEIGHT(&target) = 100;
+    GET_WEIGHT(&target) = 100;
+
+    switch (expected->spellnum)
+    {
+    case SPELL_ELEMENTAL_WATER_EMBODIMENT:
+      spell_elemental_water_embodiment(20, &caster, &target, NULL, CAST_SPELL);
+      break;
+    case SPELL_ELEMENTAL_FIRE_EMBODIMENT:
+      spell_elemental_fire_embodiment(20, &caster, &target, NULL, CAST_SPELL);
+      break;
+    case SPELL_ELEMENTAL_EARTH_EMBODIMENT:
+      spell_elemental_earth_embodiment(20, &caster, &target, NULL, CAST_SPELL);
+      break;
+    case SPELL_ELEMENTAL_AIR_EMBODIMENT:
+      spell_elemental_air_embodiment(20, &caster, &target, NULL, CAST_SPELL);
+      break;
+    }
+
+    caster_id = GET_ID(&caster);
+    target_id = GET_ID(&target);
+    CuAssertTrue(tc, caster_id > 0);
+    CuAssertTrue(tc, target_id > 0);
+    CuAssertTrue(tc, rol_elemental_embodiment_active(&target));
+
+    af = find_test_affect(&target, expected->spellnum, APPLY_HIT);
+    CuAssertPtrNotNull(tc, af);
+    base_hp = 10 * expected->hp_factor;
+    variance = base_hp * 5 / 100;
+    CuAssertTrue(tc, af->modifier >= base_hp - variance);
+    CuAssertTrue(tc, af->modifier <= base_hp + variance);
+    CuAssertIntEquals(tc, 10, af->duration);
+    CuAssertTrue(tc, af->source_id == caster_id);
+    CuAssertIntEquals(tc, 100 + af->modifier, GET_HIT(&target));
+
+    af = find_test_affect(&target, expected->spellnum, APPLY_CHAR_HEIGHT);
+    CuAssertPtrNotNull(tc, af);
+    CuAssertIntEquals(tc, expected->size_percent, af->modifier);
+    af = find_test_affect(&target, expected->spellnum, APPLY_CHAR_WEIGHT);
+    CuAssertPtrNotNull(tc, af);
+    CuAssertIntEquals(tc, expected->size_percent, af->modifier);
+
+    if (expected->armor_bonus > 0)
+    {
+      af = find_test_affect(&target, expected->spellnum, APPLY_AC_NEW);
+      CuAssertPtrNotNull(tc, af);
+      CuAssertIntEquals(tc, expected->armor_bonus, af->modifier);
+      CuAssertIntEquals(tc, BONUS_TYPE_NATURALARMOR, af->bonus_type);
+    }
+    else
+    {
+      CuAssertPtrEquals(tc, NULL, find_test_affect(&target, expected->spellnum, APPLY_AC_NEW));
+    }
+
+    for (resistance_index = 0; resistance_index < expected->resistance_count; resistance_index++)
+    {
+      af = find_test_affect(&target, expected->spellnum, expected->resistances[resistance_index]);
+      CuAssertPtrNotNull(tc, af);
+      CuAssertIntEquals(tc, 50, af->modifier);
+    }
+    for (flag_index = 0; flag_index < expected->flag_count; flag_index++)
+      CuAssertTrue(tc, AFF_FLAGGED(&target, expected->flags[flag_index]));
+
+    af = find_test_affect(&caster, AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN, APPLY_NONE);
+    CuAssertPtrNotNull(tc, af);
+    CuAssertIntEquals(tc, expected->spellnum, af->specific);
+    CuAssertTrue(tc, af->source_id == target_id);
+
+    if (index % 2 == 0)
+      affect_from_char(&caster, AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN);
+    else
+      affect_from_char(&target, expected->spellnum);
+    CuAssertTrue(tc, !rol_elemental_embodiment_active(&target));
+    CuAssertTrue(tc, !affected_by_spell(&caster, AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN));
+    CuAssertIntEquals(tc, 100, GET_HEIGHT(&target));
+    CuAssertIntEquals(tc, 100, GET_WEIGHT(&target));
+
+    remove_from_lookup_table(caster_id);
+    remove_from_lookup_table(target_id);
+  }
+}
+
+void TestElementalEmbodimentSharedEligibilityAndTransientIdentity(CuTest *tc)
+{
+  struct char_data caster;
+  struct char_data target;
+  struct player_special_data caster_specials;
+  struct player_special_data target_specials;
+
+  clear_char(&caster);
+  clear_char(&target);
+  memset(&caster_specials, 0, sizeof(caster_specials));
+  memset(&target_specials, 0, sizeof(target_specials));
+  caster.player_specials = &caster_specials;
+  target.player_specials = &target_specials;
+  GET_LEVEL(&caster) = 20;
+  GET_LEVEL(&target) = 20;
+  GET_REAL_RACE(&caster) = RACE_HUMAN;
+  GET_REAL_RACE(&target) = RACE_DROW;
+
+  CuAssertTrue(tc, !test_rol_elemental_embodiment_same_side(&caster, &target));
+  GET_LEVEL(&caster) = LVL_IMMORT;
+  CuAssertTrue(tc, test_rol_elemental_embodiment_same_side(&caster, &target));
+
+  CuAssertTrue(tc, rol_elemental_embodiment_affect_is_transient(SPELL_ELEMENTAL_WATER_EMBODIMENT));
+  CuAssertTrue(tc, rol_elemental_embodiment_affect_is_transient(SPELL_ELEMENTAL_FIRE_EMBODIMENT));
+  CuAssertTrue(tc, rol_elemental_embodiment_affect_is_transient(SPELL_ELEMENTAL_EARTH_EMBODIMENT));
+  CuAssertTrue(tc, rol_elemental_embodiment_affect_is_transient(SPELL_ELEMENTAL_AIR_EMBODIMENT));
+  CuAssertTrue(
+      tc, rol_elemental_embodiment_affect_is_transient(AFFECT_ROL_ELEMENTAL_EMBODIMENT_MAINTAIN));
+  CuAssertTrue(tc, !rol_elemental_embodiment_affect_is_transient(SPELL_GENIEKIND));
 }
 
 void TestCycloneUsesSourceWindThresholdOnlyForPlayerCasters(CuTest *tc)

--- a/unittests/CuTest/test_unassigned_spells.c
+++ b/unittests/CuTest/test_unassigned_spells.c
@@ -104,6 +104,13 @@ static const struct spell_registration_expectation utility_spells[] = {
     {SPELL_FIRE_FOG, MAG_ROOM},
 };
 
+static const struct spell_registration_expectation remaining_support_spells[] = {
+    {SPELL_HEAL_UNDEAD, MAG_MANUAL},
+    {SPELL_DARK_WRATH, MAG_MANUAL},
+    {SPELL_UNHOLY_AURA, MAG_MANUAL},
+    {SPELL_CAMOUFLAGE, MAG_MANUAL},
+};
+
 static void add_test_affect(struct char_data *ch, int spellnum, int location, int modifier)
 {
   struct affected_type af;
@@ -120,6 +127,17 @@ static void remove_test_affects(struct char_data *ch)
 {
   while (ch->affected != NULL)
     affect_remove_no_total(ch, ch->affected);
+}
+
+static struct affected_type *find_test_affect(struct char_data *ch, int spellnum, int location)
+{
+  struct affected_type *af;
+
+  for (af = ch->affected; af != NULL; af = af->next)
+    if (af->spell == spellnum && af->location == location)
+      return af;
+
+  return NULL;
 }
 
 void TestFoundationalSpellsAreRegisteredWithoutClassAssignments(CuTest *tc)
@@ -189,6 +207,122 @@ void TestUtilitySpellsUseNativeRoutinesWithoutClassAssignments(CuTest *tc)
     for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
       CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
   }
+}
+
+void TestRemainingSupportSpellsAreNativeAndUnassigned(CuTest *tc)
+{
+  size_t index;
+  int class_num;
+  int domain_num;
+  int spellnum;
+
+  mag_assign_spells();
+
+  for (index = 0; index < sizeof(remaining_support_spells) / sizeof(remaining_support_spells[0]);
+       index++)
+  {
+    spellnum = remaining_support_spells[index].spellnum;
+    CuAssertTrue(tc, spell_info[spellnum].name != NULL);
+    CuAssertTrue(tc, spell_info[spellnum].name != unused_spellname);
+    CuAssertIntEquals(tc, remaining_support_spells[index].routines, spell_info[spellnum].routines);
+
+    for (class_num = 0; class_num < NUM_CLASSES; class_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].min_level[class_num]);
+    for (domain_num = 0; domain_num < NUM_DOMAINS; domain_num++)
+      CuAssertIntEquals(tc, LVL_IMMORT, spell_info[spellnum].domain[domain_num]);
+  }
+}
+
+void TestHealUndeadPreservesLichAndBlackmantleRules(CuTest *tc)
+{
+  struct char_data caster;
+  struct char_data target;
+  struct player_special_data caster_specials;
+  struct player_special_data target_specials;
+
+  clear_char(&caster);
+  clear_char(&target);
+  memset(&caster_specials, 0, sizeof(caster_specials));
+  memset(&target_specials, 0, sizeof(target_specials));
+  caster.player_specials = &caster_specials;
+  target.player_specials = &target_specials;
+  GET_REAL_RACE(&caster) = RACE_LICH;
+  GET_REAL_RACE(&target) = RACE_LICH;
+  GET_MAX_HIT(&target) = 500;
+  GET_HIT(&target) = 100;
+
+  spell_heal_undead(30, &caster, &target, NULL, CAST_SPELL);
+  CuAssertIntEquals(tc, 200, GET_HIT(&target));
+
+  SET_BIT_AR(AFF_FLAGS(&target), AFF_BLACKMANTLE);
+  spell_heal_undead(30, &caster, &target, NULL, CAST_SPELL);
+  CuAssertIntEquals(tc, 200, GET_HIT(&target));
+}
+
+void TestDarkWrathAppliesSourceBonusesToAllSpellSaves(CuTest *tc)
+{
+  struct affected_type *af;
+  struct char_data ch;
+  struct player_special_data specials;
+
+  clear_char(&ch);
+  memset(&specials, 0, sizeof(specials));
+  ch.player_specials = &specials;
+
+  spell_dark_wrath(45, &ch, &ch, NULL, CAST_SPELL);
+
+  af = find_test_affect(&ch, SPELL_DARK_WRATH, APPLY_DAMROLL);
+  CuAssertPtrNotNull(tc, af);
+  CuAssertIntEquals(tc, 1, af->modifier);
+  CuAssertTrue(tc, af->duration >= 5 && af->duration <= 8);
+  af = find_test_affect(&ch, SPELL_DARK_WRATH, APPLY_SAVING_FORT);
+  CuAssertPtrNotNull(tc, af);
+  CuAssertIntEquals(tc, 3, af->modifier);
+  af = find_test_affect(&ch, SPELL_DARK_WRATH, APPLY_SAVING_REFL);
+  CuAssertPtrNotNull(tc, af);
+  CuAssertIntEquals(tc, 3, af->modifier);
+  af = find_test_affect(&ch, SPELL_DARK_WRATH, APPLY_SAVING_WILL);
+  CuAssertPtrNotNull(tc, af);
+  CuAssertIntEquals(tc, 3, af->modifier);
+
+  remove_test_affects(&ch);
+}
+
+void TestUnholyAuraKeepsItsOwnFireShieldAffect(CuTest *tc)
+{
+  struct affected_type *af;
+  struct char_data ch;
+  struct player_special_data specials;
+
+  clear_char(&ch);
+  memset(&specials, 0, sizeof(specials));
+  ch.player_specials = &specials;
+
+  spell_unholy_aura(30, &ch, &ch, NULL, CAST_SPELL);
+  af = find_test_affect(&ch, SPELL_UNHOLY_AURA, APPLY_NONE);
+  CuAssertPtrNotNull(tc, af);
+  CuAssertIntEquals(tc, 3, af->duration);
+  CuAssertTrue(tc, AFF_FLAGGED(&ch, AFF_FSHIELD));
+
+  remove_test_affects(&ch);
+}
+
+void TestCamouflageHasDistinctStateAndBreaksCleanly(CuTest *tc)
+{
+  struct char_data ch;
+  struct player_special_data specials;
+
+  clear_char(&ch);
+  memset(&specials, 0, sizeof(specials));
+  ch.player_specials = &specials;
+
+  spell_camouflage(30, &ch, &ch, NULL, CAST_SPELL);
+  CuAssertTrue(tc, affected_by_spell(&ch, SPELL_CAMOUFLAGE));
+  CuAssertTrue(tc, AFF_FLAGGED(&ch, AFF_HIDE));
+
+  remove_spell_camouflage(&ch);
+  CuAssertTrue(tc, !affected_by_spell(&ch, SPELL_CAMOUFLAGE));
+  CuAssertTrue(tc, !AFF_FLAGGED(&ch, AFF_HIDE));
 }
 
 void TestUnseenServantAddsOnlyItsStoredCarryCapacity(CuTest *tc)


### PR DESCRIPTION
## What changed

- Implement all 89 player-facing RoL spell-equivalence gaps as distinct native LuminariMUD spells.
- Preserve traced behavior for undead support, concealment, environmental damage, control, volatile summons, recurring events, and linked elemental embodiments.
- Route all converted source spells to native targets while rejecting nine internal, maintenance, stub, and proc-only identities in castable item slots.
- Add production-linked CuTest coverage, source-backed converter coverage, generated-constant updates, and supporting world-data/schema changes.
- Complete canonical flat-file and development-database help coverage for all 89 spells, with a regression test protecting the inventory.
- Mark the gap audit complete in the ongoing-project document.

## Why

The RoL conversion audit identified spells whose prior loose substitutes did not preserve their primary gameplay behavior. This branch closes every player-facing gap and makes unsupported internal identities fail closed instead of silently converting to unrelated spells.

## Validation

- Warning-free GNU C23 build and successful `make install`
- 880/880 production-linked CuTests under the documented isolated settings
- 496 world-tool tests passed (36 environment-dependent skips)
- 132 source-backed RoL transformer tests passed (2 optional-pilot skips)
- Documentation tests, generated-constants synchronization, and diff checks passed
- All 89 flat-file help entries byte-match their development-database entries and have searchable keywords
- Commit and push hooks passed, including the build verification hook
