### PR TITLE
[codex] Complete RoL race equivalence and racial anatomy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1178,6 +1178,7 @@ option(BUILD_TESTS "Build production-linked unit tests" OFF)
 set(CUTEST_TEST_SOURCES
     unittests/CuTest/test_syntax_check_boot.c
     unittests/CuTest/test_web_onboarding.c
+    unittests/CuTest/test_race_equivalence.c
     unittests/CuTest/test_i3_client_production.c
     unittests/CuTest/test_msdp_production.c
     unittests/CuTest/test_necromancer.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -344,6 +344,7 @@ bsd_snprintf_fallback_test_LDADD = -lm
 cutest_SOURCES = \
 	unittests/CuTest/test_syntax_check_boot.c \
 	unittests/CuTest/test_web_onboarding.c \
+	unittests/CuTest/test_race_equivalence.c \
 	unittests/CuTest/test_i3_client_production.c \
 	unittests/CuTest/test_msdp_production.c \
 	unittests/CuTest/test_necromancer.c \
@@ -403,6 +404,7 @@ cutest_test_files = \
 	unittests/CuTest/test_bounds_checking.c \
 	unittests/CuTest/test_help_sync.c \
 	unittests/CuTest/test_web_onboarding.c \
+	unittests/CuTest/test_race_equivalence.c \
 	unittests/CuTest/test_i3_client_production.c \
 	unittests/CuTest/test_msdp_production.c \
 	unittests/CuTest/test_necromancer.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -796,6 +796,11 @@ EXTRA_DIST = \
 	sql/components/help_command_sweep_entries.sql \
 	sql/components/help_dg_damage_trigger.sql \
 	sql/components/help_rol_feat_entries.sql \
+	sql/components/help_race_half_illithid_entries.sql \
+	sql/components/help_race_half_ogre_entries.sql \
+	sql/components/help_race_myconid_entries.sql \
+	sql/components/help_race_wemic_entries.sql \
+	sql/components/help_race_yuan_ti_entries.sql \
 	sql/components/help_specproc_entries.sql \
 	sql/components/help_thrown_weapons_entries.sql \
 	sql/components/help_vessel_entries.sql \
@@ -811,6 +816,11 @@ EXTRA_DIST = \
 	sql/components/verify_help_necromancer_entries.sql \
 	sql/components/verify_help_rol_feat_entries.sql \
 	sql/components/verify_help_rol_object_trap_entries.sql \
+	sql/components/verify_help_race_half_illithid_entries.sql \
+	sql/components/verify_help_race_half_ogre_entries.sql \
+	sql/components/verify_help_race_myconid_entries.sql \
+	sql/components/verify_help_race_wemic_entries.sql \
+	sql/components/verify_help_race_yuan_ti_entries.sql \
 	sql/components/verify_help_specproc_entries.sql \
 	sql/components/verify_help_thrown_weapons_entries.sql \
 	sql/components/verify_help_vessel_entries.sql \

--- a/Makefile.am
+++ b/Makefile.am
@@ -801,6 +801,7 @@ EXTRA_DIST = \
 	sql/components/help_race_myconid_entries.sql \
 	sql/components/help_race_wemic_entries.sql \
 	sql/components/help_race_yuan_ti_entries.sql \
+	sql/components/help_trelux_equipment_entries.sql \
 	sql/components/help_specproc_entries.sql \
 	sql/components/help_thrown_weapons_entries.sql \
 	sql/components/help_vessel_entries.sql \
@@ -821,6 +822,7 @@ EXTRA_DIST = \
 	sql/components/verify_help_race_myconid_entries.sql \
 	sql/components/verify_help_race_wemic_entries.sql \
 	sql/components/verify_help_race_yuan_ti_entries.sql \
+	sql/components/verify_help_trelux_equipment_entries.sql \
 	sql/components/verify_help_specproc_entries.sql \
 	sql/components/verify_help_thrown_weapons_entries.sql \
 	sql/components/verify_help_vessel_entries.sql \

--- a/docs/guides/ADDING_NEW_RACE_GUIDE.md
+++ b/docs/guides/ADDING_NEW_RACE_GUIDE.md
@@ -1,6 +1,6 @@
 # Adding a New Player Race to LuminariMUD
 
-Status: source-backed developer guide, verified 2026-08-23.
+Status: source-backed developer guide, verified 2026-08-24.
 
 This guide covers the complete path for adding a player race to LuminariMUD.
 Most sections describe a race selected during character creation. It also
@@ -113,8 +113,9 @@ implementation choices, not formulas derived from the tier label:
 
 Half-Troll is inside the dense creation range, has `is_pc` true, and is parsed
 by `parse_race_long()`. Before purchase, the terminal and web creation catalogs
-omit it. `accexp race` finds it inside the `NUM_RACES` loop, stores ID 3 in
-`unlocked_races`, and creation accepts it after reload. Its `IS_ADVANCE` value
+omit it. `accexp race` finds it in the extended registry through the shared
+creation policy, stores ID 3 in `unlocked_races`, and creation accepts it after
+reload. Its `IS_ADVANCE` value
 only supplies the label; the 1,000 account-XP cost, adjustment 2 presentation,
 and 2x `level_exp()` multiplier are three separate registrations.
 
@@ -146,11 +147,12 @@ it. That flag does not mean "selectable at creation."
 
 The current lock has several layers:
 
-- terminal and web catalogs enumerate only `0..NUM_RACES - 1`;
-- `init_char()` rejects a new-character race outside that range;
-- `has_unlocked_race()` always returns false for Lich and Vampire, even if the
-  account array or database contains the ID;
-- account purchase also enumerates only `0..NUM_RACES - 1`;
+- terminal, web, account purchase, and `init_char()` all use
+  `race_is_creation_eligible()`, which explicitly denies Lich and Vampire;
+- `has_unlocked_race()` also always returns false for Lich and Vampire, even if
+  the account array or database contains the ID;
+- direct terminal submission uses the same creation predicate as the catalogs;
+  and
 - the nominal cost is 999,999,999 while account XP is capped at 100,000,000.
 
 The large cost is defense in depth, not the hard-lock implementation. A new
@@ -189,47 +191,52 @@ numeric race references. Never renumber or reuse a released ID.
 
 As of this guide's verification date, `src/structs.h` has these boundaries:
 
-- Selectable IDs are the dense range 0 through 27, with `NUM_RACES` set to 28.
+- IDs 0 through 27 remain the original dense creation range, with `NUM_RACES`
+  set to 28 for legacy positional tables. Creation eligibility is no longer
+  inferred from that bound.
 - IDs 26 and 27 are registered as Goblin and Hobgoblin. The stale
   `RACE_DEEP_GNOME` and `RACE_ORC` defines collide with those IDs; they are not
   spare slots or valid distinct persistent identities.
-- `RACE_H_OGRE` is already assigned ID 28 but is not implemented as a
-  selectable race.
-- IDs 29 through 54 are reserved legacy IDs. Lich 45 and Vampire 46 are
+- Half-Ogre is the creation-selectable ID 28.
+- IDs 29 through 54 remain reserved legacy IDs. Lich 45 and Vampire 46 are
   explicit quest-only exceptions inside that area.
 - IDs 55 through 59 are reserved by comment for future quest-only races.
-- Extended NPC/form IDs begin at 60 and currently continue through 148.
-- `NUM_EXTENDED_RACES` is 149, the array bound rather than a playable count.
-- `char_player_data.race` is a signed `byte`, so values above 127 cannot be
-  represented safely without changing that field and auditing every reader,
-  writer, serializer, and protocol consumer.
+- Extended NPC/form IDs begin at 60. Myconid promotes its existing conceptual
+  identity at ID 114 to a creation-selectable PC race without renumbering it.
+- Wemic, Half-Illithid, and Yuan-Ti are creation-selectable IDs 149 through
+  151. `NUM_EXTENDED_RACES` is therefore 152, the registry array bound, while
+  `NUM_CREATION_RACES` is the independent count 33.
+- `char_player_data.race` is a signed `sh_int`, so the full current registry is
+  representable. Player-file and account-unlock storage remain numeric.
 
-There is therefore no generic safe "next playable race ID" in the current
-layout.
+There is still no generic safe "next playable race ID." Every new identity
+requires the same persistence and compatibility review.
 
-### Creation-selectable implementation paths
+### Creation-selectable implementation path
 
-1. **Implement Half Ogre using its existing ID 28.** This is the only existing
-   named slot immediately after the dense player range. Bringing it into the
-   creation range requires raising `NUM_RACES` to 29 and updating every fixed
-   table, loop, test, and boundary that uses `NUM_RACES`. It does not authorize
-   using ID 29 for the following race.
+The registry now supports sparse creation-selectable IDs. Terminal creation,
+web onboarding, account purchase, initialization, lookup, tracks, and random
+basic-race selection scan `NUM_EXTENDED_RACES` and apply the shared creation
+policy where appropriate. Web media uses keyed cases for sparse IDs, and race
+storage is wide enough for the current bound.
 
-2. **Add any other new creation-selectable race.** Make a separate, reviewed
-   registry decision first. The change must either establish a safe non-dense
-   playable registry or widen and migrate race storage before allocating a new
-   ID. Do not consume a legacy, quest-only, or NPC/form ID merely because it
-   appears unused in one source file.
+For another race, make a separate reviewed ID decision. Do not consume a
+legacy, quest-only, or NPC/form ID merely because it appears unused in one
+source file. Promoting an existing NPC/form ID is valid only when it is the
+same persistent conceptual identity, as with Myconid, and still requires an
+audit of world references and changed registry behavior. Keep `NUM_RACES` as
+the legacy dense bound unless every positional consumer is deliberately
+migrated.
 
 ### Transformation-only allocation
 
 IDs 55 through 59 are reserved only by a source comment for future quest-only
 races. Using one still requires an explicit registry and persistence review.
-Do not raise `NUM_RACES`, because doing so would make every intervening ID part
-of dense creation iteration. Decide whether `NUM_EXTENDED_PC_RACES` should be
-replaced with keyed PC iteration rather than enlarged across legacy holes, and
-audit every consumer of the chosen ID. The hard-lock and conversion work in
-sections 7 and 8 is required in addition to ordinary registry mechanics.
+Do not raise `NUM_RACES` across legacy holes: creation no longer depends on
+that bound, while remaining positional consumers would acquire misleading or
+oversized ranges. Prefer the keyed extended-registry policy, and audit every
+consumer of the chosen ID. The hard-lock and conversion work in sections 7 and
+8 is required in addition to ordinary registry mechanics.
 
 An ID-layout change is a persistence migration and should be reviewed as such.
 The proposal must state the old and new bounds, the chosen stable ID, how
@@ -255,22 +262,22 @@ following common consumers:
 
 | Source | Why it matters |
 |--------|----------------|
-| `src/interpreter.c` | Terminal creation menus, parsing result, and race help dispatch |
-| `src/db.c` | `init_char()` rejects a selected race outside `NUM_RACES` |
-| `src/account.c` | Account-XP race listing and purchase loops use `NUM_RACES` |
-| `src/net/onboarding.c` | Web catalog bounds and a position-indexed media-key table |
-| `src/utils.c` | `get_race_by_name()` searches only `NUM_RACES` |
+| `src/interpreter.c` | Terminal creation menus, direct validation, and race help dispatch |
+| `src/db.c` | `init_char()` applies the shared creation-eligibility policy |
+| `src/account.c` | Account-XP listing and purchase apply the shared sparse policy |
+| `src/net/onboarding.c` | Web catalog policy and keyed sparse media lookup |
+| `src/utils.c` | `get_race_by_name()` scans creation-eligible sparse entries |
 | `src/character/race.c` | Random basic-race selection and extended registry allocation |
 | `src/constants.c` | `racial_spells[NUM_RACES][3]` has positional entries |
-| `src/character/feats.c` | Legacy race-feat display uses `NUM_EXTENDED_PC_RACES` |
-| `src/movement/movement_tracks.c` | PC race-name lookup is bounded by `NUM_RACES` |
+| `src/character/feats.c` | Legacy race-feat display scans the extended registry |
+| `src/movement/movement_tracks.c` | PC race-name lookup uses the extended bound |
 | `src/olc/medit.c` | One random PC-race display path uses `NUM_RACES` |
 | `unittests/CuTest/test_web_onboarding.c` | Media bounds and every-playable-race assertions |
 
-Also inspect `get_random_basic_pc_race()` before changing `NUM_RACES`. Its
-current `dice(1, NUM_RACES + 1)` followed by decrement can sample index
-`NUM_RACES`; expansion work must add a regression test and correct the
-selection boundary rather than copying it.
+Also inspect `get_random_basic_pc_race()` when changing race eligibility. It
+uses reservoir selection across creation-eligible normal races, so a new race
+must have the intended `epic_adv` category and remain covered by its regression
+test.
 
 ## 3. Add the registry constant and bounds
 
@@ -472,12 +479,11 @@ remain useful to `race info`, but creation must reject it as described in
 section 8.
 
 The terminal creation flow is in `nanny()` in `src/interpreter.c`. The menu and
-the submitted-name handler are separate policy surfaces: the menu enumerates
-`0..NUM_RACES - 1` and checks `is_pc` plus the account lock, while the current
-`CON_QRACE` handler parses any name known to `parse_race_long()` and checks only
-the lock. It does not independently reject an ID outside `NUM_RACES` or an
-entry whose `is_pc` is false. Do not treat absence from the printed menu as an
-access control.
+the submitted-name handler are separate control-flow surfaces, but both now
+apply `race_is_selectable_for_creation()`. The direct handler first applies
+`race_is_creation_eligible()` so a forged unlock cannot authorize a
+conversion-only or NPC/form race. Preserve this shared policy; absence from a
+printed menu is still not sufficient access control by itself.
 
 `race_is_available()` is not currently a creation-eligibility predicate. It
 accepts any ID below `NUM_EXTENDED_RACES` and is used to mark entries in the
@@ -489,15 +495,14 @@ selection-mode and creation-bound policy rather than reusing that helper alone.
    This is an ordered `is_abbrev()` chain, so test that the new prefixes do not
    steal an existing race's input and that the registry `type` sent as the web
    `wireValue` parses back to the intended ID.
-2. Make sure both enumeration and submitted-name validation require the
-   approved creation range, `race_list[i].is_pc`, and account unlock state.
-   Prefer one shared predicate for terminal and web onboarding.
+2. Make sure both enumeration and submitted-name validation use the shared
+   creation-eligibility and account-unlock predicates.
 3. Add a `CON_QRACE` switch case that calls
    `perform_help(d, "race-new-race")`.
 4. Confirm that `CON_QRACE_HELP` can return to the menu and that the selected
    race reaches class selection.
-5. Confirm `init_char()` in `src/db.c` accepts the ID instead of resetting it
-   to `RACE_UNDEFINED`.
+5. Confirm `init_char()` in `src/db.c` accepts the ID through
+   `race_is_creation_eligible()` instead of resetting it to `RACE_UNDEFINED`.
 
 `parse_race()` is the old single-character mapping used by legacy race
 bitvectors. It is not the main creation parser. Do not add an arbitrary letter
@@ -524,7 +529,8 @@ only the menu is not enforcement.
   supported configuration; use zero for a free race.
 
 For a creation-selectable locked race, verify all of these paths in
-`src/account.c`:
+`src/account.c`. Its race listing and purchase scan the extended registry but
+must filter every entry through `race_is_creation_eligible()`:
 
 - `accexp race` lists it with the correct cost;
 - `accexp race <name>` finds and purchases it;
@@ -553,10 +559,10 @@ after an economy change, and an unlock row can be inserted independently of a
 purchase. Under the current terminal handler, retain a positive nominal cost
 so the lock check runs, but make the explicit hard-denial policy authoritative.
 
-The current Lich/Vampire exception is an explicit denial in
-`has_unlocked_race()`. Their IDs are also outside `NUM_RACES`, so account
-purchase and both creation catalogs cannot enumerate them. Preserve all of
-these defenses for a new hard-locked race:
+The current Lich/Vampire exception is an explicit denial in both
+`race_is_creation_eligible()` and `has_unlocked_race()`. Their IDs being outside
+the old dense `NUM_RACES` range is no longer treated as access control.
+Preserve all of these defenses for a new hard-locked race:
 
 - a centralized policy denial that ignores a forged account unlock;
 - no account-XP listing or purchase match;
@@ -657,8 +663,8 @@ This section does not apply to a transformation-only race, which must have no
 web creation media entry or catalog choice. The web catalog is server-owned in
 `src/net/onboarding.c`; a client must not duplicate race eligibility rules.
 
-1. Add a stable `race/<slug>` entry to `race_media_keys` or to the replacement
-   keyed lookup introduced by a non-dense registry change.
+1. Add a stable `race/<slug>` entry to the dense `race_media_keys` table or the
+   keyed sparse cases in `web_onboarding_race_media_key()`.
 2. Keep the key independent of colored display text and spelling aliases.
 3. Ensure `race_is_selectable()` can address the new ID.
 4. Extend `TestWebOnboardingMediaKeysAreStableAndBounded()` in
@@ -668,20 +674,20 @@ web creation media entry or catalog choice. The web catalog is server-owned in
 6. Provision the matching image or fallback behavior in the web-client asset
    repository when the UI expects race art.
 
-The current `race_is_selectable()` separately implements the same bounds,
-`is_pc`, and account-lock policy expected by terminal creation; it does not
-call a shared terminal predicate. Keep both paths synchronized or introduce a
-shared eligibility function and test it through both transports.
+The web adapter calls `race_is_selectable_for_creation()`, the same policy used
+by terminal creation. Test the policy through both transports whenever it
+changes.
 
-The current media table is indexed directly by IDs from 0 through
-`NUM_RACES - 1`. A non-dense player ID cannot be added safely by merely making
-that array larger: the creation, bounds, fallback, and every-playable-race tests
-must be redesigned around the approved registry model.
+The legacy media table remains indexed directly by IDs from 0 through
+`NUM_RACES - 1`, while `web_onboarding_race_media_key()` has keyed cases for
+sparse player IDs. Do not enlarge the dense table across legacy and NPC holes;
+add a keyed mapping and extend the fallback, catalog, pagination, and
+wire-budget tests.
 
 `web_onboarding_race_media_key()` is also used when existing account characters
-are displayed. Because it is bounded by `NUM_RACES`, a current Lich or Vampire
-receives the fallback race image. If a transformation-only race needs distinct
-account-card art, separate display-media lookup from creation eligibility; do
+are displayed. Lich and Vampire currently have no keyed case and therefore
+receive the fallback race image. If a transformation-only race needs distinct
+account-card art, add display media without weakening creation eligibility; do
 not add the race to the creation catalog merely to obtain an image.
 
 ## 10. Add player help in both maintained stores
@@ -783,8 +789,8 @@ At minimum, add these assertions for either path:
 
 For a creation-selectable race, also assert:
 
-- terminal menu and direct-name submission use the same range, `is_pc`, and
-  lock policy;
+- terminal menu and direct-name submission use the same creation-eligibility
+  and lock policy;
 - locked and unlocked eligibility, account purchase, and account persistence;
 - at least one valid class/alignment path;
 - a non-fallback web media key and presence in the web race catalog; and

--- a/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
@@ -2,6 +2,40 @@
 
 Status: source audit completed 2026-08-23.
 
+## Implementation progress
+
+Checkpoint 2026-08-24 (core implementation builds):
+
+- The five gaps now have concrete Luminari identities: Barbarian maps to the
+  advanced Wemic, Ogre maps to the advanced Half-Ogre, Illithid maps to the
+  epic Half-Illithid, Yuan-Ti remains an advanced Yuan-Ti, and the unfinished
+  Myconid becomes an epic Myconid.
+- Persistent IDs preserve every released and reserved identity. Half-Ogre uses
+  its preassigned ID 28, Myconid corrects and aliases the existing `MYCANOID`
+  ID 114, and Wemic, Half-Illithid, and Yuan-Ti use new IDs 149 through 151.
+  The character race field is now a signed short so those IDs round-trip.
+- Character creation, account-XP purchase, terminal help dispatch, web
+  onboarding, media keys, race lookup, tracks, and initialization now use a
+  shared sparse-race policy. Lich and Vampire remain conversion-only even if
+  an unlock is forged.
+- Advanced races use adjustment 2, cost 1,000 account XP, and 2x experience.
+  Epic races use adjustment 10, cost 30,000 account XP, and 7x experience.
+- Registry data, racial statistics, size, family, language, level-one feat
+  packages, stacked natural armor, and racial hit-point progression are
+  implemented for all five races.
+- `unittests/CuTest/test_race_equivalence.c` covers ID width and uniqueness,
+  sparse selection count, tiers, stats, sizes, families, anatomy, parser
+  aliases, feat packages, and XP multipliers. Web media-key coverage includes
+  all five races. The production binary builds cleanly with GNU C23 and
+  `-Wall -Wextra`.
+
+Remaining at this checkpoint:
+
+- add matching SQL and flat-file help entries for all five races;
+- run the production-linked CuTest suite and install the tested binary;
+- perform local database/help and creation smoke checks where the development
+  environment permits them.
+
 This document accompanies `ROL_SPELL_EQUIVALENCE_GAPS.md` in the Realms of
 Luminari conversion series and compares RoL's player-character races with
 LuminariMUD's playable races.

--- a/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
@@ -1,6 +1,7 @@
 # RoL Playable Races Without a Close LuminariMUD Equivalent
 
-Status: source audit completed 2026-08-23.
+Status: implementation completed 2026-08-24. Development runtime smoke remains
+environment-dependent as described below.
 
 ## Implementation progress
 
@@ -42,13 +43,34 @@ Checkpoint 2026-08-24 (maintained help complete):
   checks. No persistent database was changed because this worktree has no
   `lib/.env` or `lib/mysql_config` identifying a development environment.
 
-Remaining at this checkpoint:
+Checkpoint 2026-08-24 (implementation validation complete):
 
-- extend integration coverage for unlock selection, full web catalog
-  inclusion, racial feat application, and persistence-sensitive behavior;
-- run the production-linked CuTest suite and install the tested binary;
-- perform terminal and web creation smoke checks where the development
-  environment permits them.
+- RoL parser aliases now resolve Barbarian to Wemic and Ogre to Half-Ogre in
+  addition to the Illithid, Yuan-Ti, and Myconid aliases.
+- Racial starting and per-level hit points use one shared policy in character
+  initialization, level advancement, and derived-stat rebuilding. This also
+  closes the pre-existing rebuild gap for the Vital races whose fixed starting
+  bonus was previously transient.
+- Integration coverage now verifies locked and unlocked creation policy,
+  conversion-only denial, every level-one racial feat grant and stack, derived
+  hit-point reconstruction, all pages of the web race catalog, and a sparse ID
+  151 player-file round trip.
+- The production-linked CuTest binary passes all 893 tests. The complete root
+  `make test` path also passes its fallback, help-sync, autorun, deployment,
+  healthcheck, background-help, vessel, and process-memory checks when the
+  committed special-procedure inventory fixture is selected and the unavailable
+  world boot is explicitly skipped. `make install` installed `bin/luminari` and
+  removed the root-level build artifact.
+
+Development runtime validation constraint:
+
+- This fresh worktree has neither `lib/.env` nor `lib/mysql_config`, and its
+  production world directories are unpopulated. The game correctly refuses a
+  real world boot without required MySQL initialization. Terminal creation and
+  in-game help lookup therefore could not be smoke-tested against a development
+  server without inventing an environment identity or credentials. The shared
+  terminal/web policy, web payloads, persistence, SQL help migrations, and flat
+  help projection are covered by the tests above.
 
 This document accompanies `ROL_SPELL_EQUIVALENCE_GAPS.md` in the Realms of
 Luminari conversion series and compares RoL's player-character races with
@@ -70,7 +92,8 @@ all is a gap.
 - Reserved empty slots for future PC races: 2
 - Races with a close LuminariMUD equivalent: 11
 - Races without a close equivalent: 5
-- LuminariMUD playable races, for comparison: 30
+- LuminariMUD registered PC races in the pre-implementation audit: 30
+- LuminariMUD creation-eligible races after this implementation: 33
 
 ## Player-facing gaps
 
@@ -83,6 +106,10 @@ all is a gap.
 | 15 | Myconid | `RACE_MYCONID` | PS | none | (placeholder row, copied from Lich) |
 
 ### Why each is a gap
+
+The descriptions in this section record the pre-implementation source audit.
+The implementation checkpoints above describe their current LuminariMUD
+equivalents.
 
 **Barbarian (2).** In RoL this is a race, not a class: a distinct human-variant
 people with its own racewar hometown and a three-class restriction. In
@@ -169,13 +196,14 @@ stat rows. There is nothing to port.
 
 ## LuminariMUD-side notes
 
-- LuminariMUD has 30 playable races against RoL's 14 selectable ones, so this
-  comparison is lopsided in LuminariMUD's favor overall. Races such as
+- Before this work, LuminariMUD had 30 registered PC races against RoL's 14
+  selectable ones. It now has 33 creation-eligible races after excluding the
+  conversion-only Lich and Vampire identities. Races such as
   Dragonborn, Tiefling, Aasimar, Tabaxi, Goliath, Shade, Fae, Trelux,
   Arcana Golem, Crystal Dwarf, Vampire, Goblin, and Hobgoblin have no RoL
   counterpart at all. That direction is out of scope here.
-- `RACE_H_OGRE` (28) is defined with `// not yet implemented` and is the
-  natural landing slot if Ogre is ported.
+- `RACE_H_OGRE` (28) was the natural landing slot and is now the implemented
+  Half-Ogre identity.
 - Watch the LuminariMUD race ID range when porting. `NUM_RACES` is 28, and the
   three constants immediately after it reuse live IDs:
   `RACE_DEEP_GNOME` 26 collides with `RACE_GOBLIN`, `RACE_ORC` 27 collides with

--- a/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
@@ -1,7 +1,6 @@
 # RoL Playable Races Without a Close LuminariMUD Equivalent
 
-Status: implementation completed 2026-08-24. Development runtime smoke remains
-environment-dependent as described below.
+Status: implementation and completion audit finished 2026-08-24.
 
 ## Implementation progress
 
@@ -55,22 +54,34 @@ Checkpoint 2026-08-24 (implementation validation complete):
   conversion-only denial, every level-one racial feat grant and stack, derived
   hit-point reconstruction, all pages of the web race catalog, and a sparse ID
   151 player-file round trip.
-- The production-linked CuTest binary passes all 893 tests. The complete root
-  `make test` path also passes its fallback, help-sync, autorun, deployment,
-  healthcheck, background-help, vessel, and process-memory checks when the
-  committed special-procedure inventory fixture is selected and the unavailable
-  world boot is explicitly skipped. `make install` installed `bin/luminari` and
-  removed the root-level build artifact.
+- At this checkpoint, the production-linked CuTest binary passed all 893 tests.
+  The complete root `make test` path also passed its fallback, help-sync,
+  autorun, deployment, healthcheck, background-help, vessel, and process-memory
+  checks when the committed special-procedure inventory fixture was selected
+  and the then-unavailable world boot was explicitly skipped. `make install`
+  installed `bin/luminari` and removed the root-level build artifact. The later
+  completion audit below removes that runtime limitation.
 
-Development runtime validation constraint:
+Checkpoint 2026-08-24 (completion audit):
 
-- This fresh worktree has neither `lib/.env` nor `lib/mysql_config`, and its
-  production world directories are unpopulated. The game correctly refuses a
-  real world boot without required MySQL initialization. Terminal creation and
-  in-game help lookup therefore could not be smoke-tested against a development
-  server without inventing an environment identity or credentials. The shared
-  terminal/web policy, web payloads, persistence, SQL help migrations, and flat
-  help projection are covered by the tests above.
+- The canonical constant names are now `RACE_HALF_OGRE` and `RACE_MYCONID`;
+  the historical `RACE_H_OGRE` and misspelled `RACE_MYCANOID` names remain
+  compatibility aliases.
+- Production-flow coverage now submits every race through the terminal nanny,
+  rejects locked and forged conversion-only choices, purchases all five with
+  `accexp`, and applies every race through the premade-build stat path.
+- A live MariaDB integration test purchases the five unlocks for one account,
+  persists each purchase through the normal account save, reloads the account,
+  and verifies the exact five SQL rows and sparse IDs.
+- `docs/guides/ADDING_NEW_RACE_GUIDE.md` was re-audited against the completed
+  sparse registry, shared creation policy, widened race storage, and keyed web
+  media implementation so it no longer describes the pre-implementation
+  bounds as current behavior.
+- The repository-provided isolated runtime was prepared against a disposable
+  MariaDB instance. Both the focused binary and the complete root `make test`
+  path passed all 897 production-linked CuTests with the syntax/world boot,
+  SQL integration tests, and committed special-procedure fixture enabled.
+  No production or persistent development database was changed.
 
 This document accompanies `ROL_SPELL_EQUIVALENCE_GAPS.md` in the Realms of
 Luminari conversion series and compares RoL's player-character races with

--- a/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
@@ -83,6 +83,25 @@ Checkpoint 2026-08-24 (completion audit):
   SQL integration tests, and committed special-procedure fixture enabled.
   No production or persistent development database was changed.
 
+Checkpoint 2026-08-24 (racial anatomy balance):
+
+- Wemic now grants the innate Leonine Frame feat at level one. Its four-legged
+  lower body cannot use the legs or feet equipment slots; ankle equipment
+  remains available.
+- Race definitions now carry per-slot anatomy restrictions and player-facing
+  rejection text. The wear command and the low-level equipment boundary share
+  this policy, so automatic slot selection, saved gear, and scripted or system
+  equipment placement cannot bypass it. Rejected low-level equipment is
+  returned safely to inventory.
+- The pre-existing Trelux exceptions now use the same policy. This preserves
+  the established ring, shield, wield, and hold restrictions and closes the
+  documented but previously unenforced glove, leg, and foot restrictions.
+  Disguises do not change either race's physical equipment slots.
+- Focused production-linked tests cover the policy matrix, Wemic feat grant,
+  normal wear flow, saved-equipment restoration, and direct low-level equip
+  calls. Matching flat-file and database help describe both races' available
+  slots.
+
 This document accompanies `ROL_SPELL_EQUIVALENCE_GAPS.md` in the Realms of
 Luminari conversion series and compares RoL's player-character races with
 LuminariMUD's playable races.

--- a/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
+++ b/docs/ongoing-projects/ROL_RACE_EQUIVALENCE_GAPS.md
@@ -29,11 +29,25 @@ Checkpoint 2026-08-24 (core implementation builds):
   all five races. The production binary builds cleanly with GNU C23 and
   `-Wall -Wextra`.
 
+Checkpoint 2026-08-24 (maintained help complete):
+
+- Each race now has an idempotent database migration, a read-only verifier,
+  and a matching player topic in `lib/text/help/help.hlp`. Canonical names,
+  RoL names, and legacy Mycanoid spelling are deterministic aliases.
+- All ten SQL files are packaged and classified for fresh-schema CI. The
+  component inventory also now classifies the pre-existing help-sync schema
+  and verifier, restoring the rule that every component appears exactly once.
+- An isolated temporary MariaDB test applied all five migrations twice and
+  returned `PASS` for all 22 entry, keyword, content, ownership, and aggregate
+  checks. No persistent database was changed because this worktree has no
+  `lib/.env` or `lib/mysql_config` identifying a development environment.
+
 Remaining at this checkpoint:
 
-- add matching SQL and flat-file help entries for all five races;
+- extend integration coverage for unlock selection, full web catalog
+  inclusion, racial feat application, and persistence-sensitive behavior;
 - run the production-linked CuTest suite and install the tested binary;
-- perform local database/help and creation smoke checks where the development
+- perform terminal and web creation smoke checks where the development
   environment permits them.
 
 This document accompanies `ROL_SPELL_EQUIVALENCE_GAPS.md` in the Realms of

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -40838,4 +40838,109 @@ The 'list' shows all currently unlocked zones.
 
 See also: ZLOCK
 #31
+WEMIC RACE-WEMIC BARBARIAN RACE-BARBARIAN
+
+Wemic
+
+Wemics are Large monstrous humanoids with a humanoid torso and a leonine lower
+body. They are the Luminari equivalent of the Realms of Luminari Barbarian
+people, expressed as an actual Wemic ancestry rather than a class.
+
+Tier: Advanced (level adjustment 2)
+Unlock: 1,000 account experience
+Progression: 2x normal experience requirements
+Ability modifiers: +8 Str, +4 Con, -2 Int, +2 Wis, +2 Dex, -2 Cha
+Size: Large
+Language: Common
+
+Racial feats include low-light vision, Natural Athlete, Powerful Build,
+Claws and Bite, Survival Instinct, and Hardy. Wemics also gain one additional
+hit point per level.
+
+See also: ACCEXP, RACE, RACE-HALF-OGRE, RACE-YUAN-TI
+#0
+HALF-OGRE HALF-OGRE-RACE RACE-HALF-OGRE OGRE RACE-OGRE
+
+Half-Ogre
+
+Half-ogres are Large giant-blooded people who combine tremendous strength and
+reach with mortal adaptability. They are the Luminari equivalent of the Realms
+of Luminari Ogre player race, expressed as an actual Half-Ogre ancestry.
+
+Tier: Advanced (level adjustment 2)
+Unlock: 1,000 account experience
+Progression: 2x normal experience requirements
+Ability modifiers: +6 Str, +2 Con, -2 Int, -2 Dex, -2 Cha
+Size: Large
+Language: Giant
+
+Racial feats include ultravision, Powerful Build, strong poison resistance,
+and two stacking ranks of Armor Skin. Half-ogres gain two additional hit
+points per level.
+
+See also: ACCEXP, RACE, RACE-WEMIC, RACE-MYCONID
+#0
+HALF-ILLITHID HALF-ILLITHID-RACE RACE-HALF-ILLITHID ILLITHID RACE-ILLITHID
+
+Half-Illithid
+
+Half-illithids retain a mortal ancestry while bearing an illithid-transformed
+mind and unsettling physical traits. They are the Luminari equivalent of the
+Realms of Luminari Illithid player race, expressed as an actual Half-Illithid.
+
+Tier: Epic (level adjustment 10)
+Unlock: 30,000 account experience
+Progression: 7x normal experience requirements
+Ability modifiers: +4 Int, +4 Wis, +4 Cha
+Size: Medium
+Language: Aberration
+
+Racial feats include ultravision, Quick Mind, Stubborn Mind,
+innate Levitation, three stacking ranks of Armor Skin, Vital, and Hardy.
+Half-illithids gain four additional hit points per level.
+
+See also: ACCEXP, LEVITATE, PSIONICIST, RACE, RACE-YUAN-TI
+#0
+YUAN-TI YUANTI RACE-YUAN-TI
+
+Yuan-Ti
+
+Yuan-ti are serpentfolk whose controlled minds, scaled bodies, venom, and
+innate magic make them dangerous adventurers. Pureblooded yuan-ti can pass
+among humanoids, but their reptilian heritage is never entirely hidden.
+
+Tier: Advanced (level adjustment 2)
+Unlock: 1,000 account experience
+Progression: 2x normal experience requirements
+Ability modifiers: +2 Int, +2 Dex, +2 Cha
+Size: Medium
+Language: Draconic
+
+Racial feats include ultravision, Poison Bite, poison immunity, Stubborn Mind,
+and two stacking ranks of Armor Skin. Poison Bite applies when fighting
+bare-handed.
+
+See also: ACCEXP, POISON, RACE, RACE-HALF-ILLITHID
+#0
+MYCONID MYCANOID RACE-MYCONID
+
+Myconid
+
+Myconids are Large fungal beings whose alien plant biology resists poison,
+paralysis, and sleep. This epic ancestry completes the unfinished Myconid
+player concept from Realms of Luminari.
+
+Tier: Epic (level adjustment 10)
+Unlock: 30,000 account experience
+Progression: 7x normal experience requirements
+Ability modifiers: +8 Str, +6 Con, -2 Int, -2 Wis, -4 Dex, -4 Cha
+Size: Large
+Language: Undercommon
+
+Racial feats include ultravision, Vital, Hardy, poison immunity, sleep
+immunity, paralysis immunity, and four stacking ranks of Armor Skin. Myconids
+count as plants and gain four additional hit points per level.
+
+See also: ACCEXP, RACE, RACE-HALF-OGRE
+#0
 $~

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -35247,11 +35247,14 @@ more challenging experience-chart.  Type 'levels' in-game to view
 #0
 TRELUX-EQ
 
-Due to their pincer-like hands, Trelux cannot wield weapons, hold items,
-wear gloves or wear rings.
+Trelux anatomy does not support several traditional equipment slots.
 
-Also due to their insect-like legs, Trelux cannot wear items on their
-legs and feet.
+Their pincer-like forelimbs cannot wield weapons, hold items, use shields,
+wear gloves, or wear rings. Their insect-like legs cannot wear leg or foot
+equipment. Arm, wrist, and ankle equipment slots remain available.
+
+These restrictions apply to ordinary wear commands, saved equipment, and
+equipment placed by game systems.
 #0
 TRELUX-EXOSKELETON
 
@@ -40854,8 +40857,12 @@ Size: Large
 Language: Common
 
 Racial feats include low-light vision, Natural Athlete, Powerful Build,
-Claws and Bite, Survival Instinct, and Hardy. Wemics also gain one additional
-hit point per level.
+Claws and Bite, Survival Instinct, Hardy, and Leonine Frame. Wemics also gain
+one additional hit point per level.
+
+Leonine Frame represents a Wemic's four-legged lower body. Wemics cannot equip
+traditional leg or foot gear, including pants and boots. Their ankle equipment
+slots remain available.
 
 See also: ACCEXP, RACE, RACE-HALF-OGRE, RACE-YUAN-TI
 #0

--- a/sql/components/ci_schema_manifest.txt
+++ b/sql/components/ci_schema_manifest.txt
@@ -21,7 +21,13 @@ apply help_necromancer_entries.sql
 apply help_oedit_values_armor_ac.sql
 apply help_rol_feat_entries.sql
 apply help_rol_object_trap_entries.sql
+apply help_race_half_illithid_entries.sql
+apply help_race_half_ogre_entries.sql
+apply help_race_myconid_entries.sql
+apply help_race_wemic_entries.sql
+apply help_race_yuan_ti_entries.sql
 apply help_specproc_entries.sql
+apply help_sync_schema.sql
 apply help_system_indexes.sql
 apply help_thrown_weapons_entries.sql
 apply help_vessel_entries.sql
@@ -49,7 +55,13 @@ skip verify_help_intermud3_entries.sql
 skip verify_help_necromancer_entries.sql
 skip verify_help_rol_feat_entries.sql
 skip verify_help_rol_object_trap_entries.sql
+skip verify_help_race_half_illithid_entries.sql
+skip verify_help_race_half_ogre_entries.sql
+skip verify_help_race_myconid_entries.sql
+skip verify_help_race_wemic_entries.sql
+skip verify_help_race_yuan_ti_entries.sql
 skip verify_help_specproc_entries.sql
+skip verify_help_sync_schema.sql
 skip verify_help_thrown_weapons_entries.sql
 skip verify_help_vessel_entries.sql
 skip verify_help_worship_entries.sql

--- a/sql/components/ci_schema_manifest.txt
+++ b/sql/components/ci_schema_manifest.txt
@@ -26,6 +26,7 @@ apply help_race_half_ogre_entries.sql
 apply help_race_myconid_entries.sql
 apply help_race_wemic_entries.sql
 apply help_race_yuan_ti_entries.sql
+apply help_trelux_equipment_entries.sql
 apply help_specproc_entries.sql
 apply help_sync_schema.sql
 apply help_system_indexes.sql
@@ -60,6 +61,7 @@ skip verify_help_race_half_ogre_entries.sql
 skip verify_help_race_myconid_entries.sql
 skip verify_help_race_wemic_entries.sql
 skip verify_help_race_yuan_ti_entries.sql
+skip verify_help_trelux_equipment_entries.sql
 skip verify_help_specproc_entries.sql
 skip verify_help_sync_schema.sql
 skip verify_help_thrown_weapons_entries.sql

--- a/sql/components/help_race_half_illithid_entries.sql
+++ b/sql/components/help_race_half_illithid_entries.sql
@@ -1,0 +1,39 @@
+-- Player help for the epic Half-Illithid race.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('RACE-HALF-ILLITHID', 'Half-Illithid
+
+Half-illithids retain a mortal ancestry while bearing an illithid-transformed
+mind and unsettling physical traits. They are the Luminari equivalent of the
+Realms of Luminari Illithid player race, expressed as an actual Half-Illithid.
+
+Tier: Epic (level adjustment 10)
+Unlock: 30,000 account experience
+Progression: 7x normal experience requirements
+Ability modifiers: +4 Int, +4 Wis, +4 Cha
+Size: Medium
+Language: Aberration
+
+Racial feats include ultravision, Quick Mind, Stubborn Mind,
+innate Levitation, three stacking ranks of Armor Skin, Vital, and Hardy.
+Half-illithids gain four additional hit points per level.
+
+See also: ACCEXP, LEVITATE, PSIONICIST, RACE, RACE-YUAN-TI', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN
+  ('HALF-ILLITHID', 'HALF-ILLITHID-RACE', 'RACE-HALF-ILLITHID', 'ILLITHID',
+   'RACE-ILLITHID');
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+  ('RACE-HALF-ILLITHID', 'HALF-ILLITHID'),
+  ('RACE-HALF-ILLITHID', 'HALF-ILLITHID-RACE'),
+  ('RACE-HALF-ILLITHID', 'RACE-HALF-ILLITHID'),
+  ('RACE-HALF-ILLITHID', 'ILLITHID'),
+  ('RACE-HALF-ILLITHID', 'RACE-ILLITHID');
+
+COMMIT;

--- a/sql/components/help_race_half_ogre_entries.sql
+++ b/sql/components/help_race_half_ogre_entries.sql
@@ -1,0 +1,38 @@
+-- Player help for the advanced Half-Ogre race.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('RACE-HALF-OGRE', 'Half-Ogre
+
+Half-ogres are Large giant-blooded people who combine tremendous strength and
+reach with mortal adaptability. They are the Luminari equivalent of the Realms
+of Luminari Ogre player race, expressed as an actual Half-Ogre ancestry.
+
+Tier: Advanced (level adjustment 2)
+Unlock: 1,000 account experience
+Progression: 2x normal experience requirements
+Ability modifiers: +6 Str, +2 Con, -2 Int, -2 Dex, -2 Cha
+Size: Large
+Language: Giant
+
+Racial feats include ultravision, Powerful Build, strong poison resistance,
+and two stacking ranks of Armor Skin. Half-ogres gain two additional hit
+points per level.
+
+See also: ACCEXP, RACE, RACE-WEMIC, RACE-MYCONID', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN
+  ('HALF-OGRE', 'HALF-OGRE-RACE', 'RACE-HALF-OGRE', 'OGRE', 'RACE-OGRE');
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+  ('RACE-HALF-OGRE', 'HALF-OGRE'),
+  ('RACE-HALF-OGRE', 'HALF-OGRE-RACE'),
+  ('RACE-HALF-OGRE', 'RACE-HALF-OGRE'),
+  ('RACE-HALF-OGRE', 'OGRE'),
+  ('RACE-HALF-OGRE', 'RACE-OGRE');
+
+COMMIT;

--- a/sql/components/help_race_myconid_entries.sql
+++ b/sql/components/help_race_myconid_entries.sql
@@ -1,0 +1,35 @@
+-- Player help for the epic Myconid race.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('RACE-MYCONID', 'Myconid
+
+Myconids are Large fungal beings whose alien plant biology resists poison,
+paralysis, and sleep. This epic ancestry completes the unfinished Myconid
+player concept from Realms of Luminari.
+
+Tier: Epic (level adjustment 10)
+Unlock: 30,000 account experience
+Progression: 7x normal experience requirements
+Ability modifiers: +8 Str, +6 Con, -2 Int, -2 Wis, -4 Dex, -4 Cha
+Size: Large
+Language: Undercommon
+
+Racial feats include ultravision, Vital, Hardy, poison immunity, sleep
+immunity, paralysis immunity, and four stacking ranks of Armor Skin. Myconids
+count as plants and gain four additional hit points per level.
+
+See also: ACCEXP, RACE, RACE-HALF-OGRE', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN ('MYCONID', 'MYCANOID', 'RACE-MYCONID');
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+  ('RACE-MYCONID', 'MYCONID'),
+  ('RACE-MYCONID', 'MYCANOID'),
+  ('RACE-MYCONID', 'RACE-MYCONID');
+
+COMMIT;

--- a/sql/components/help_race_wemic_entries.sql
+++ b/sql/components/help_race_wemic_entries.sql
@@ -1,0 +1,36 @@
+-- Player help for the advanced Wemic race.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('RACE-WEMIC', 'Wemic
+
+Wemics are Large monstrous humanoids with a humanoid torso and a leonine lower
+body. They are the Luminari equivalent of the Realms of Luminari Barbarian
+people, expressed as an actual Wemic ancestry rather than a class.
+
+Tier: Advanced (level adjustment 2)
+Unlock: 1,000 account experience
+Progression: 2x normal experience requirements
+Ability modifiers: +8 Str, +4 Con, -2 Int, +2 Wis, +2 Dex, -2 Cha
+Size: Large
+Language: Common
+
+Racial feats include low-light vision, Natural Athlete, Powerful Build,
+Claws and Bite, Survival Instinct, and Hardy. Wemics also gain one additional
+hit point per level.
+
+See also: ACCEXP, RACE, RACE-HALF-OGRE, RACE-YUAN-TI', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN ('WEMIC', 'RACE-WEMIC', 'BARBARIAN', 'RACE-BARBARIAN');
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+  ('RACE-WEMIC', 'WEMIC'),
+  ('RACE-WEMIC', 'RACE-WEMIC'),
+  ('RACE-WEMIC', 'BARBARIAN'),
+  ('RACE-WEMIC', 'RACE-BARBARIAN');
+
+COMMIT;

--- a/sql/components/help_race_wemic_entries.sql
+++ b/sql/components/help_race_wemic_entries.sql
@@ -17,8 +17,12 @@ Size: Large
 Language: Common
 
 Racial feats include low-light vision, Natural Athlete, Powerful Build,
-Claws and Bite, Survival Instinct, and Hardy. Wemics also gain one additional
-hit point per level.
+Claws and Bite, Survival Instinct, Hardy, and Leonine Frame. Wemics also gain
+one additional hit point per level.
+
+Leonine Frame represents a Wemic''s four-legged lower body. Wemics cannot equip
+traditional leg or foot gear, including pants and boots. Their ankle equipment
+slots remain available.
 
 See also: ACCEXP, RACE, RACE-HALF-OGRE, RACE-YUAN-TI', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),

--- a/sql/components/help_race_yuan_ti_entries.sql
+++ b/sql/components/help_race_yuan_ti_entries.sql
@@ -1,0 +1,35 @@
+-- Player help for the advanced Yuan-Ti race.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('RACE-YUAN-TI', 'Yuan-Ti
+
+Yuan-ti are serpentfolk whose controlled minds, scaled bodies, venom, and
+innate magic make them dangerous adventurers. Pureblooded yuan-ti can pass
+among humanoids, but their reptilian heritage is never entirely hidden.
+
+Tier: Advanced (level adjustment 2)
+Unlock: 1,000 account experience
+Progression: 2x normal experience requirements
+Ability modifiers: +2 Int, +2 Dex, +2 Cha
+Size: Medium
+Language: Draconic
+
+Racial feats include ultravision, Poison Bite, poison immunity, Stubborn Mind,
+and two stacking ranks of Armor Skin. Poison Bite applies when fighting
+bare-handed.
+
+See also: ACCEXP, POISON, RACE, RACE-HALF-ILLITHID', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN ('YUAN-TI', 'YUANTI', 'RACE-YUAN-TI');
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+  ('RACE-YUAN-TI', 'YUAN-TI'),
+  ('RACE-YUAN-TI', 'YUANTI'),
+  ('RACE-YUAN-TI', 'RACE-YUAN-TI');
+
+COMMIT;

--- a/sql/components/help_trelux_equipment_entries.sql
+++ b/sql/components/help_trelux_equipment_entries.sql
@@ -1,0 +1,28 @@
+-- Player help for Trelux anatomy-based equipment restrictions.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('TRELUX-EQ', 'Trelux Equipment
+
+Trelux anatomy does not support several traditional equipment slots.
+
+Their pincer-like forelimbs cannot wield weapons, hold items, use shields,
+wear gloves, or wear rings. Their insect-like legs cannot wear leg or foot
+equipment. Arm, wrist, and ankle equipment slots remain available.
+
+These restrictions apply to ordinary wear commands, saved equipment, and
+equipment placed by game systems.
+
+See also: RACE-TRELUX, TRELUX-PINCERS', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN ('TRELUX-EQ', 'TRELUX-EQUIPMENT');
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+  ('TRELUX-EQ', 'TRELUX-EQ'),
+  ('TRELUX-EQ', 'TRELUX-EQUIPMENT');
+
+COMMIT;

--- a/sql/components/verify_help_race_half_illithid_entries.sql
+++ b/sql/components/verify_help_race_half_illithid_entries.sql
@@ -1,0 +1,35 @@
+-- Read-only verification for help_race_half_illithid_entries.sql.
+
+SELECT 'race_half_illithid_entry' AS check_name, COUNT(*) AS actual, 1 AS expected,
+       IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'RACE-HALF-ILLITHID' AND min_level = 0 AND auto_generated = FALSE
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
+
+SELECT 'race_half_illithid_keywords' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'RACE-HALF-ILLITHID'
+  AND UPPER(keyword) IN
+    ('HALF-ILLITHID', 'HALF-ILLITHID-RACE', 'RACE-HALF-ILLITHID', 'ILLITHID',
+     'RACE-ILLITHID');
+
+SELECT 'race_half_illithid_content' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT '+4 Int' AS required_text
+  UNION ALL SELECT 'Epic (level adjustment 10)'
+  UNION ALL SELECT '30,000 account experience'
+  UNION ALL SELECT '7x normal experience requirements'
+  UNION ALL SELECT 'innate Levitation'
+) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
+WHERE h.tag = 'RACE-HALF-ILLITHID';
+
+SELECT 'race_half_illithid_keyword_conflicts' AS check_name, COUNT(*) AS actual, 0 AS expected,
+       IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN
+    ('HALF-ILLITHID', 'HALF-ILLITHID-RACE', 'RACE-HALF-ILLITHID', 'ILLITHID',
+     'RACE-ILLITHID')
+  AND help_tag <> 'RACE-HALF-ILLITHID';

--- a/sql/components/verify_help_race_half_ogre_entries.sql
+++ b/sql/components/verify_help_race_half_ogre_entries.sql
@@ -1,0 +1,33 @@
+-- Read-only verification for help_race_half_ogre_entries.sql.
+
+SELECT 'race_half_ogre_entry' AS check_name, COUNT(*) AS actual, 1 AS expected,
+       IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'RACE-HALF-OGRE' AND min_level = 0 AND auto_generated = FALSE
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
+
+SELECT 'race_half_ogre_keywords' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'RACE-HALF-OGRE'
+  AND UPPER(keyword) IN
+    ('HALF-OGRE', 'HALF-OGRE-RACE', 'RACE-HALF-OGRE', 'OGRE', 'RACE-OGRE');
+
+SELECT 'race_half_ogre_content' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT '+6 Str' AS required_text
+  UNION ALL SELECT 'Advanced (level adjustment 2)'
+  UNION ALL SELECT '1,000 account experience'
+  UNION ALL SELECT '2x normal experience requirements'
+  UNION ALL SELECT 'two stacking ranks of Armor Skin'
+) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
+WHERE h.tag = 'RACE-HALF-OGRE';
+
+SELECT 'race_half_ogre_keyword_conflicts' AS check_name, COUNT(*) AS actual, 0 AS expected,
+       IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN
+    ('HALF-OGRE', 'HALF-OGRE-RACE', 'RACE-HALF-OGRE', 'OGRE', 'RACE-OGRE')
+  AND help_tag <> 'RACE-HALF-OGRE';

--- a/sql/components/verify_help_race_myconid_entries.sql
+++ b/sql/components/verify_help_race_myconid_entries.sql
@@ -1,0 +1,31 @@
+-- Read-only verification for help_race_myconid_entries.sql.
+
+SELECT 'race_myconid_entry' AS check_name, COUNT(*) AS actual, 1 AS expected,
+       IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'RACE-MYCONID' AND min_level = 0 AND auto_generated = FALSE
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
+
+SELECT 'race_myconid_keywords' AS check_name, COUNT(*) AS actual, 3 AS expected,
+       IF(COUNT(*) = 3, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'RACE-MYCONID'
+  AND UPPER(keyword) IN ('MYCONID', 'MYCANOID', 'RACE-MYCONID');
+
+SELECT 'race_myconid_content' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT '+8 Str' AS required_text
+  UNION ALL SELECT 'Epic (level adjustment 10)'
+  UNION ALL SELECT '30,000 account experience'
+  UNION ALL SELECT '7x normal experience requirements'
+  UNION ALL SELECT 'count as plants'
+) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
+WHERE h.tag = 'RACE-MYCONID';
+
+SELECT 'race_myconid_keyword_conflicts' AS check_name, COUNT(*) AS actual, 0 AS expected,
+       IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN ('MYCONID', 'MYCANOID', 'RACE-MYCONID')
+  AND help_tag <> 'RACE-MYCONID';

--- a/sql/components/verify_help_race_wemic_entries.sql
+++ b/sql/components/verify_help_race_wemic_entries.sql
@@ -12,8 +12,8 @@ FROM help_keywords
 WHERE help_tag = 'RACE-WEMIC'
   AND UPPER(keyword) IN ('WEMIC', 'RACE-WEMIC', 'BARBARIAN', 'RACE-BARBARIAN');
 
-SELECT 'race_wemic_content' AS check_name, COUNT(*) AS actual, 5 AS expected,
-       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+SELECT 'race_wemic_content' AS check_name, COUNT(*) AS actual, 8 AS expected,
+       IF(COUNT(*) = 8, 'PASS', 'FAIL') AS result
 FROM help_entries AS h
 JOIN (
   SELECT '+8 Str' AS required_text
@@ -21,6 +21,9 @@ JOIN (
   UNION ALL SELECT '1,000 account experience'
   UNION ALL SELECT '2x normal experience requirements'
   UNION ALL SELECT 'Claws and Bite'
+  UNION ALL SELECT 'Leonine Frame'
+  UNION ALL SELECT 'pants and boots'
+  UNION ALL SELECT 'ankle equipment'
 ) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
 WHERE h.tag = 'RACE-WEMIC';
 

--- a/sql/components/verify_help_race_wemic_entries.sql
+++ b/sql/components/verify_help_race_wemic_entries.sql
@@ -1,0 +1,31 @@
+-- Read-only verification for help_race_wemic_entries.sql.
+
+SELECT 'race_wemic_entry' AS check_name, COUNT(*) AS actual, 1 AS expected,
+       IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'RACE-WEMIC' AND min_level = 0 AND auto_generated = FALSE
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
+
+SELECT 'race_wemic_keywords' AS check_name, COUNT(*) AS actual, 4 AS expected,
+       IF(COUNT(*) = 4, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'RACE-WEMIC'
+  AND UPPER(keyword) IN ('WEMIC', 'RACE-WEMIC', 'BARBARIAN', 'RACE-BARBARIAN');
+
+SELECT 'race_wemic_content' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT '+8 Str' AS required_text
+  UNION ALL SELECT 'Advanced (level adjustment 2)'
+  UNION ALL SELECT '1,000 account experience'
+  UNION ALL SELECT '2x normal experience requirements'
+  UNION ALL SELECT 'Claws and Bite'
+) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
+WHERE h.tag = 'RACE-WEMIC';
+
+SELECT 'race_wemic_keyword_conflicts' AS check_name, COUNT(*) AS actual, 0 AS expected,
+       IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN ('WEMIC', 'RACE-WEMIC', 'BARBARIAN', 'RACE-BARBARIAN')
+  AND help_tag <> 'RACE-WEMIC';

--- a/sql/components/verify_help_race_yuan_ti_entries.sql
+++ b/sql/components/verify_help_race_yuan_ti_entries.sql
@@ -1,0 +1,31 @@
+-- Read-only verification for help_race_yuan_ti_entries.sql.
+
+SELECT 'race_yuan_ti_entry' AS check_name, COUNT(*) AS actual, 1 AS expected,
+       IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'RACE-YUAN-TI' AND min_level = 0 AND auto_generated = FALSE
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
+
+SELECT 'race_yuan_ti_keywords' AS check_name, COUNT(*) AS actual, 3 AS expected,
+       IF(COUNT(*) = 3, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'RACE-YUAN-TI'
+  AND UPPER(keyword) IN ('YUAN-TI', 'YUANTI', 'RACE-YUAN-TI');
+
+SELECT 'race_yuan_ti_content' AS check_name, COUNT(*) AS actual, 5 AS expected,
+       IF(COUNT(*) = 5, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT '+2 Int' AS required_text
+  UNION ALL SELECT 'Advanced (level adjustment 2)'
+  UNION ALL SELECT '1,000 account experience'
+  UNION ALL SELECT '2x normal experience requirements'
+  UNION ALL SELECT 'Poison Bite'
+) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
+WHERE h.tag = 'RACE-YUAN-TI';
+
+SELECT 'race_yuan_ti_keyword_conflicts' AS check_name, COUNT(*) AS actual, 0 AS expected,
+       IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN ('YUAN-TI', 'YUANTI', 'RACE-YUAN-TI')
+  AND help_tag <> 'RACE-YUAN-TI';

--- a/sql/components/verify_help_trelux_equipment_entries.sql
+++ b/sql/components/verify_help_trelux_equipment_entries.sql
@@ -1,0 +1,34 @@
+-- Read-only verification for help_trelux_equipment_entries.sql.
+
+SELECT 'trelux_equipment_entry' AS check_name, COUNT(*) AS actual, 1 AS expected,
+       IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'TRELUX-EQ' AND min_level = 0 AND auto_generated = FALSE
+  AND CHAR_LENGTH(TRIM(entry)) > 0;
+
+SELECT 'trelux_equipment_keywords' AS check_name, COUNT(*) AS actual, 2 AS expected,
+       IF(COUNT(*) = 2, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'TRELUX-EQ'
+  AND UPPER(keyword) IN ('TRELUX-EQ', 'TRELUX-EQUIPMENT');
+
+SELECT 'trelux_equipment_content' AS check_name, COUNT(*) AS actual, 8 AS expected,
+       IF(COUNT(*) = 8, 'PASS', 'FAIL') AS result
+FROM help_entries AS h
+JOIN (
+  SELECT 'wield weapons' AS required_text
+  UNION ALL SELECT 'hold items'
+  UNION ALL SELECT 'use shields'
+  UNION ALL SELECT 'wear gloves'
+  UNION ALL SELECT 'wear rings'
+  UNION ALL SELECT 'insect-like legs'
+  UNION ALL SELECT 'ankle equipment slots remain available'
+  UNION ALL SELECT 'saved equipment'
+) AS expected_content ON INSTR(h.entry, expected_content.required_text) > 0
+WHERE h.tag = 'TRELUX-EQ';
+
+SELECT 'trelux_equipment_keyword_conflicts' AS check_name, COUNT(*) AS actual, 0 AS expected,
+       IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN ('TRELUX-EQ', 'TRELUX-EQUIPMENT')
+  AND help_tag <> 'TRELUX-EQ';

--- a/src/account.c
+++ b/src/account.c
@@ -65,6 +65,7 @@
 #include "magic/spells.h"
 #include "screen.h"
 #include "character/class.h"
+#include "character/race.h"
 #include "act.h"
 #include "account.h"
 #include "vessels/routing.h"
@@ -347,7 +348,7 @@ ACMD(do_accexp)
     int end = 0;
 
     start = 0;
-    end = NUM_RACES;
+    end = NUM_EXTENDED_RACES;
 
     /* No argument: list lockable races that are not yet unlocked */
     if (!*arg2)
@@ -356,7 +357,7 @@ ACMD(do_accexp)
 
       for (i = start; i < end; i++)
       {
-        if (!is_locked_race(i) || has_unlocked_race(ch, i))
+        if (!race_is_creation_eligible(i) || !is_locked_race(i) || has_unlocked_race(ch, i))
           continue;
 
         int cost = locked_race_cost(i);
@@ -367,7 +368,7 @@ ACMD(do_accexp)
     /* Identify the intended race to unlock by name abbreviation */
     for (i = start; i < end; i++)
     {
-      if (race_list[i].is_pc && is_abbrev(arg2, race_list[i].type) && is_locked_race(i) &&
+      if (race_is_creation_eligible(i) && is_abbrev(arg2, race_list[i].type) && is_locked_race(i) &&
           !has_unlocked_race(ch, i))
       {
         cost = locked_race_cost(i);

--- a/src/account.h
+++ b/src/account.h
@@ -23,6 +23,7 @@ extern "C"
 void perform_do_account(struct char_data *ch, struct char_data *vict);
 int change_account_xp(struct char_data *ch, int change_val);
 void load_account_characters(struct account_data *account);
+void load_account_unlocks(struct account_data *account);
 bool link_character_to_account_checked(struct char_data *ch, struct account_data *account);
 bool save_account_checked(struct account_data *account);
 

--- a/src/character/class.c
+++ b/src/character/class.c
@@ -2900,6 +2900,10 @@ void init_start_char(struct char_data *ch)
   case RACE_VAMPIRE:
     GET_MAX_HIT(ch) += 10; /* vital */
     break;
+  case RACE_HALF_ILLITHID:
+  case RACE_MYCONID:
+    GET_MAX_HIT(ch) += 10; /* vital */
+    break;
   case RACE_HALF_TROLL:
   case RACE_ARCANA_GOLEM:
   case RACE_DROW:
@@ -3534,6 +3538,16 @@ void advance_level(struct char_data *ch, int class)
   case RACE_VAMPIRE:
     add_hp += 4;
     break;
+  case RACE_HALF_ILLITHID:
+  case RACE_MYCONID:
+    add_hp += 4;
+    break;
+  case RACE_HALF_OGRE:
+    add_hp += 2;
+    break;
+  case RACE_WEMIC:
+    add_hp++;
+    break;
   default:
     break;
   }
@@ -3823,6 +3837,11 @@ long int level_exp(struct char_data *ch, int level)
   case RACE_DUERGAR:
     exp *= 2;
     break;
+  case RACE_WEMIC:
+  case RACE_HALF_OGRE:
+  case RACE_YUAN_TI:
+    exp *= 2;
+    break;
 
     /* epic races */
   case RACE_CRYSTAL_DWARF:
@@ -3834,6 +3853,11 @@ long int level_exp(struct char_data *ch, int level)
     break;
 
   case RACE_TRELUX:
+    exp *= 7;
+    break;
+
+  case RACE_HALF_ILLITHID:
+  case RACE_MYCONID:
     exp *= 7;
     break;
 

--- a/src/character/class.c
+++ b/src/character/class.c
@@ -2879,6 +2879,7 @@ void init_start_char(struct char_data *ch)
 
   /* setting racial size here */
   GET_REAL_SIZE(ch) = race_list[GET_RACE(ch)].size;
+  GET_REAL_MAX_HIT(ch) += race_starting_hp_bonus(GET_RACE(ch));
 
   /* some racial related modifications */
   switch (GET_RACE(ch))
@@ -2888,32 +2889,6 @@ void init_start_char(struct char_data *ch)
     GET_FEAT_POINTS(ch)++;
     trains += 3;
     break;
-  case RACE_CRYSTAL_DWARF:
-    GET_MAX_HIT(ch) += 10; /* vital */
-    break;
-  case RACE_TRELUX:
-    GET_MAX_HIT(ch) += 10; /* vital */
-    break;
-  case RACE_LICH:
-    GET_MAX_HIT(ch) += 10; /* vital */
-    break;
-  case RACE_VAMPIRE:
-    GET_MAX_HIT(ch) += 10; /* vital */
-    break;
-  case RACE_HALF_ILLITHID:
-  case RACE_MYCONID:
-    GET_MAX_HIT(ch) += 10; /* vital */
-    break;
-  case RACE_HALF_TROLL:
-  case RACE_ARCANA_GOLEM:
-  case RACE_DROW:
-  case RACE_ELF:
-  case RACE_DUERGAR:
-  case RACE_DWARF:
-  case RACE_HALFLING:
-  case RACE_H_ELF:
-  case RACE_H_ORC:
-  case RACE_GNOME:
   default:
     break;
   }
@@ -3519,38 +3494,10 @@ void advance_level(struct char_data *ch, int class)
   /* 'free' class feats gained that depend on previous class or feat choices */
   process_conditional_class_level_feats(ch, class);
 
-  // Racial Bonuses
-  switch (GET_RACE(ch))
-  {
-  case RACE_HUMAN:
-  case LEGACY_RACE_HUMAN:
+  /* Racial bonuses */
+  if (GET_RACE(ch) == RACE_HUMAN || GET_RACE(ch) == LEGACY_RACE_HUMAN)
     trains++;
-    break;
-  case RACE_CRYSTAL_DWARF:
-    add_hp += 4;
-    break;
-  case RACE_TRELUX:
-    add_hp += 4;
-    break;
-  case RACE_LICH:
-    add_hp += 4;
-    break;
-  case RACE_VAMPIRE:
-    add_hp += 4;
-    break;
-  case RACE_HALF_ILLITHID:
-  case RACE_MYCONID:
-    add_hp += 4;
-    break;
-  case RACE_HALF_OGRE:
-    add_hp += 2;
-    break;
-  case RACE_WEMIC:
-    add_hp++;
-    break;
-  default:
-    break;
-  }
+  add_hp += race_hp_bonus_per_level(GET_RACE(ch));
 
   if (class == CLASS_NECROMANCER && CLASS_LEVEL(ch, CLASS_NECROMANCER) == 6)
   {

--- a/src/character/class.h
+++ b/src/character/class.h
@@ -114,6 +114,7 @@ bool display_weapon_info(struct char_data *ch, const char *weapon);
 bool display_armor_info(struct char_data *ch, const char *armor);
 int parse_class_long(const char *arg);
 void roll_real_abils(struct char_data *ch);
+void process_race_level_feats(struct char_data *ch);
 byte saving_throws(struct char_data *, int type);
 int BAB(struct char_data *ch);
 const char *titles(int chclass, int level);

--- a/src/character/feats.c
+++ b/src/character/feats.c
@@ -9364,7 +9364,7 @@ bool display_feat_info(struct char_data *ch, const char *featname)
   first = true;
   snprintf(buf, sizeof(buf), "\tn");
 
-  for (i = 0; i < NUM_EXTENDED_PC_RACES; i++)
+  for (i = 0; i < NUM_EXTENDED_RACES; i++)
   {
     j = 0;
     while (level_feats[j][LF_FEAT] != FEAT_UNDEFINED)

--- a/src/character/feats.c
+++ b/src/character/feats.c
@@ -957,7 +957,8 @@ void assign_feats(void)
   feato(FEAT_TRELUX_EQ, "trelux eq", TRUE, FALSE, FALSE, FEAT_TYPE_INNATE_ABILITY,
         "can't use some eq slots",
         "Due to their pincer-like hands, Trelux cannot wield weapons, hold items, use shields or "
-        "wear rings.");
+        "wear gloves or rings. Their insect-like legs also prevent them from wearing leg or foot "
+        "equipment.");
   feato(FEAT_TRELUX_PINCERS, "trelux pincers", TRUE, FALSE, FALSE, FEAT_TYPE_INNATE_ABILITY,
         "trelux natural pincer weapon",
         "Trelux don't have hands, they have insect-like pincers.  These pincers can "
@@ -5979,6 +5980,10 @@ void assign_feats(void)
         "instead of starting one of your own.  Your perform ability and instrument raise the "
         "quality of the lead performance, and if the lead falters you take the song over rather "
         "than letting it end.  Type 'accompany' alone to stop accompanying.");
+  feato(FEAT_LEONINE_FRAME, "leonine frame", TRUE, FALSE, FALSE, FEAT_TYPE_INNATE_ABILITY,
+        "cannot wear leg or foot equipment",
+        "Your humanoid torso rises from a powerful four-legged leonine body. This anatomy "
+        "prevents you from wearing equipment in the legs and feet slots.");
   feat_prereq_ability(FEAT_SHADOW, ABILITY_STEALTH, 21);
   feat_prereq_attribute(FEAT_CALM, AB_CHA, 19);
   feat_prereq_ability(FEAT_ESTABLISH_CAMP, ABILITY_SURVIVAL, 3);

--- a/src/character/race.c
+++ b/src/character/race.c
@@ -276,6 +276,30 @@ bool race_is_available(struct char_data *ch, int race_num)
   return TRUE;
 }
 
+/* Creation policy is deliberately independent of numeric density. */
+bool race_is_creation_eligible(int race_num)
+{
+  if (race_num < 0 || race_num >= NUM_EXTENDED_RACES)
+    return FALSE;
+
+  if (!race_list[race_num].is_pc)
+    return FALSE;
+
+  /* These races are acquired only by their existing conversion paths. */
+  if (race_num == RACE_LICH || race_num == RACE_VAMPIRE)
+    return FALSE;
+
+  return TRUE;
+}
+
+bool race_is_selectable_for_creation(struct char_data *ch, int race_num)
+{
+  if (!race_is_creation_eligible(race_num))
+    return FALSE;
+
+  return !is_locked_race(race_num) || has_unlocked_race(ch, race_num);
+}
+
 /*****************************/
 /*****************************/
 
@@ -1773,6 +1797,103 @@ void assign_races(void)
   /****************************************************************************/
 
   /****************************************************************************/
+  add_race(RACE_WEMIC, "wemic", "Wemic", "\tYWemic\tn", "Wemc", "\tYWemc\tn",
+           RACE_TYPE_MONSTROUS_HUMANOID, SIZE_LARGE, TRUE, 2, 1000, IS_ADVANCE);
+  set_race_details(
+      RACE_WEMIC,
+      "Wemics are leonine centaur-folk: proud hunters whose humanoid torsos rise from powerful "
+      "lion bodies. Their strength, speed, keen senses, and wilderness lore make them fearsome "
+      "front-line combatants and scouts. This race is the Luminari equivalent of the tribal "
+      "Barbarian people found in Realms of Luminari.",
+      "Your body broadens and a leonine lower body forms until you become a Wemic.",
+      "$n's body broadens and a leonine lower body forms until $e becomes a Wemic.");
+  set_race_genders(RACE_WEMIC, N, Y, Y);
+  set_race_abilities(RACE_WEMIC, 8, 4, -2, 2, 2, -2);
+  set_race_alignments(RACE_WEMIC, Y, Y, Y, Y, Y, Y, Y, Y, Y);
+  set_race_attack_types(RACE_WEMIC, N, N, N, N, Y, N, N, N, Y, N, N, N, N, N, N, N, N, N, N, N, N,
+                        Y, N, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_INFRAVISION, 1, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_NATURAL_ATHLETE, 1, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_POWERFUL_BUILD, 1, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_CLAWS_AND_BITE, 1, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_SURVIVAL_INSTINCT, 1, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_HARDY, 1, N);
+  race_list[RACE_WEMIC].racial_language = SKILL_LANG_COMMON;
+
+  /****************************************************************************/
+  add_race(RACE_HALF_OGRE, "half ogre", "Half-Ogre", "\trHalf-Ogre\tn", "HOgr", "\trHOgr\tn",
+           RACE_TYPE_GIANT, SIZE_LARGE, TRUE, 2, 1000, IS_ADVANCE);
+  set_race_details(
+      RACE_HALF_OGRE,
+      "Half-ogres combine a giant's raw power and reach with the adaptability of their smaller "
+      "kin. They are imposing, durable, and often underestimated as tacticians. This race is the "
+      "Luminari equivalent of the Ogre player race found in Realms of Luminari.",
+      "Your frame swells with giant blood until you become a Half-Ogre.",
+      "$n's frame swells with giant blood until $e becomes a Half-Ogre.");
+  set_race_genders(RACE_HALF_OGRE, N, Y, Y);
+  set_race_abilities(RACE_HALF_OGRE, 6, 2, -2, 0, -2, -2);
+  set_race_alignments(RACE_HALF_OGRE, Y, Y, Y, Y, Y, Y, Y, Y, Y);
+  set_race_attack_types(RACE_HALF_OGRE, Y, N, N, N, N, N, N, Y, N, N, N, N, N, Y, N, N, N, N, N, N,
+                        Y, N, N, N);
+  feat_race_assignment(RACE_HALF_OGRE, FEAT_ULTRAVISION, 1, N);
+  feat_race_assignment(RACE_HALF_OGRE, FEAT_POWERFUL_BUILD, 1, N);
+  feat_race_assignment(RACE_HALF_OGRE, FEAT_STRONG_AGAINST_POISON, 1, N);
+  feat_race_assignment(RACE_HALF_OGRE, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_HALF_OGRE, FEAT_ARMOR_SKIN, 1, Y);
+  race_list[RACE_HALF_OGRE].racial_language = SKILL_LANG_GIANT;
+
+  /****************************************************************************/
+  add_race(RACE_HALF_ILLITHID, "half illithid", "Half-Illithid", "\tMHalf-Illithid\tn", "HIll",
+           "\tMHIll\tn", RACE_TYPE_ABERRATION, SIZE_MEDIUM, TRUE, 10, 30000, IS_EPIC_R);
+  set_race_details(
+      RACE_HALF_ILLITHID,
+      "Half-illithids bear the transformed mind and unsettling features of the illithid while "
+      "retaining a mortal ancestry. Their formidable intellect, will, psionic instinct, and "
+      "levitation make them an epic race. This race is the Luminari equivalent of the Illithid "
+      "player race found in Realms of Luminari.",
+      "Your thoughts expand as illithid traits reshape your face and mind.",
+      "$n shudders as illithid traits reshape $s face and mind.");
+  set_race_genders(RACE_HALF_ILLITHID, N, Y, Y);
+  set_race_abilities(RACE_HALF_ILLITHID, 0, 0, 4, 4, 0, 4);
+  set_race_alignments(RACE_HALF_ILLITHID, Y, Y, Y, Y, Y, Y, Y, Y, Y);
+  set_race_attack_types(RACE_HALF_ILLITHID, Y, N, N, N, N, N, N, N, N, N, Y, N, N, Y, N, N, N, N, N,
+                        N, N, N, N, N);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_ULTRAVISION, 1, N);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_QUICK_MIND, 1, N);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_STUBBORN_MIND, 1, N);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_SLA_LEVITATE, 1, N);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_VITAL, 1, N);
+  feat_race_assignment(RACE_HALF_ILLITHID, FEAT_HARDY, 1, N);
+  race_list[RACE_HALF_ILLITHID].racial_language = SKILL_LANG_ABERRATION;
+
+  /****************************************************************************/
+  add_race(RACE_YUAN_TI, "yuan-ti", "Yuan-Ti", "\tgYuan-Ti\tn", "Yuan", "\tgYuan\tn",
+           RACE_TYPE_MONSTROUS_HUMANOID, SIZE_MEDIUM, TRUE, 2, 1000, IS_ADVANCE);
+  set_race_details(
+      RACE_YUAN_TI,
+      "Yuan-ti are serpentfolk whose controlled minds, scaled bodies, venom, and innate magic "
+      "make them dangerous adversaries. Pureblooded yuan-ti can pass among humanoids, but their "
+      "reptilian heritage is never entirely hidden. This race directly preserves the Yuan-Ti "
+      "archetype found in Realms of Luminari.",
+      "Scales ripple across your skin as your form becomes Yuan-Ti.",
+      "Scales ripple across $n's skin as $s form becomes Yuan-Ti.");
+  set_race_genders(RACE_YUAN_TI, N, Y, Y);
+  set_race_abilities(RACE_YUAN_TI, 0, 0, 2, 0, 2, 2);
+  set_race_alignments(RACE_YUAN_TI, N, N, N, Y, Y, Y, Y, Y, Y);
+  set_race_attack_types(RACE_YUAN_TI, N, N, N, N, Y, N, N, N, N, N, Y, N, N, N, N, N, N, N, N, N, N,
+                        N, N, N);
+  feat_race_assignment(RACE_YUAN_TI, FEAT_ULTRAVISION, 1, N);
+  feat_race_assignment(RACE_YUAN_TI, FEAT_POISON_BITE, 1, N);
+  feat_race_assignment(RACE_YUAN_TI, FEAT_POISON_IMMUNITY, 1, N);
+  feat_race_assignment(RACE_YUAN_TI, FEAT_STUBBORN_MIND, 1, N);
+  feat_race_assignment(RACE_YUAN_TI, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_YUAN_TI, FEAT_ARMOR_SKIN, 1, Y);
+  race_list[RACE_YUAN_TI].racial_language = SKILL_LANG_DRACONIC;
+
+  /****************************************************************************/
   /*            simple-name, no-color-name, color-name, abbrev, color-abbrev*/
   add_race(RACE_LICH, "lich", "Lich", "\tLLich\tn", "Lich", "\tLLich\tn",
            /* race-family,     size-class,  Is PC?, Lvl-Adj, Unlock, Epic? */
@@ -2407,14 +2528,36 @@ void assign_races(void)
 
   /****************************************************************************/
   /*                  simple-name, no-color-name, color-name, abbrev (4), color-abbrev (4) */
-  add_race(RACE_MYCANOID, "mycanoid", "Mycanoid", "Mycanoid", "Mycd", "Mycd",
+  add_race(RACE_MYCONID, "myconid", "Myconid", "\tgMyconid\tn", "Myco", "\tgMyco\tn",
            /* race-family, size-class, Is PC?, Lvl-Adj, Unlock, Epic? */
-           RACE_TYPE_PLANT, SIZE_MEDIUM, FALSE, 0, 0, IS_NORMAL);
-  set_race_attack_types(RACE_MYCANOID,
+           RACE_TYPE_PLANT, SIZE_LARGE, TRUE, 10, 30000, IS_EPIC_R);
+  set_race_details(
+      RACE_MYCONID,
+      "Myconids are communal fungal beings whose alien biology resists poison, paralysis, and "
+      "sleep. Powerful myconid adventurers combine immense physical resilience with a patient, "
+      "collective outlook. This epic race completes the unfinished Myconid player concept from "
+      "Realms of Luminari.",
+      "Fungal tissue spreads across your growing frame until you become a Myconid.",
+      "Fungal tissue spreads across $n's growing frame until $e becomes a Myconid.");
+  set_race_genders(RACE_MYCONID, Y, Y, Y);
+  set_race_abilities(RACE_MYCONID, 8, 6, -2, -2, -4, -4);
+  set_race_alignments(RACE_MYCONID, Y, Y, Y, Y, Y, Y, Y, Y, Y);
+  set_race_attack_types(RACE_MYCONID,
                         /* hit sting whip slash bite bludgeon crush pound claw maul thrash pierce */
                         N, N, N, N, N, Y, Y, Y, N, N, N, N,
                         /* blast punch stab slice thrust hack rake peck smash trample charge gore */
                         N, N, N, N, N, N, N, N, Y, N, N, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_ULTRAVISION, 1, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_VITAL, 1, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_HARDY, 1, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_POISON_IMMUNITY, 1, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_SLEEP_ENCHANTMENT_IMMUNITY, 1, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_PARALYSIS_IMMUNITY, 1, N);
+  feat_race_assignment(RACE_MYCONID, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_MYCONID, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_MYCONID, FEAT_ARMOR_SKIN, 1, Y);
+  feat_race_assignment(RACE_MYCONID, FEAT_ARMOR_SKIN, 1, Y);
+  race_list[RACE_MYCONID].racial_language = SKILL_LANG_UNDERCOMMON;
   /****************************************************************************/
 
   /****************************************************************************/
@@ -2960,12 +3103,15 @@ int parse_race(char arg)
 /* accept short descrip, return race */
 int parse_race_long(const char *arg_in)
 {
-  size_t arg_sz = strlen(arg_in) + 1;
-  char arg_buf[arg_sz];
-  strlcpy(arg_buf, arg_in, arg_sz);
+  char arg_buf[MAX_INPUT_LENGTH];
   char *arg = arg_buf;
 
   int l = 0; /* string length */
+
+  if (arg_in == NULL)
+    return RACE_UNDEFINED;
+
+  strlcpy(arg_buf, arg_in, sizeof(arg_buf));
 
   for (l = 0; *(arg + l); l++) /* convert to lower case */
     *(arg + l) = LOWER(*(arg + l));
@@ -3062,6 +3208,12 @@ int parse_race_long(const char *arg_in)
     return RACE_HALF_TROLL;
   if (is_abbrev(arg, "half troll"))
     return RACE_HALF_TROLL;
+  if (is_abbrev(arg, "half-ogre"))
+    return RACE_HALF_OGRE;
+  if (is_abbrev(arg, "halfogre"))
+    return RACE_HALF_OGRE;
+  if (is_abbrev(arg, "half ogre"))
+    return RACE_HALF_OGRE;
   if (is_abbrev(arg, "arcanagolem"))
     return RACE_ARCANA_GOLEM;
   if (is_abbrev(arg, "arcana-golem"))
@@ -3130,6 +3282,26 @@ int parse_race_long(const char *arg_in)
     return RACE_SHADE;
   if (is_abbrev(arg, "goliath"))
     return RACE_GOLIATH;
+  if (is_abbrev(arg, "wemic"))
+    return RACE_WEMIC;
+  if (is_abbrev(arg, "half-illithid"))
+    return RACE_HALF_ILLITHID;
+  if (is_abbrev(arg, "halfillithid"))
+    return RACE_HALF_ILLITHID;
+  if (is_abbrev(arg, "half illithid"))
+    return RACE_HALF_ILLITHID;
+  if (is_abbrev(arg, "illithid"))
+    return RACE_HALF_ILLITHID;
+  if (is_abbrev(arg, "yuan-ti"))
+    return RACE_YUAN_TI;
+  if (is_abbrev(arg, "yuanti"))
+    return RACE_YUAN_TI;
+  if (is_abbrev(arg, "yuan ti"))
+    return RACE_YUAN_TI;
+  if (is_abbrev(arg, "myconid"))
+    return RACE_MYCONID;
+  if (is_abbrev(arg, "mycanoid"))
+    return RACE_MYCONID;
   if (is_abbrev(arg, "lich"))
     return RACE_LICH;
   if (is_abbrev(arg, "vampire"))
@@ -3207,16 +3379,21 @@ sbyte has_racial_abils_unchosen(struct char_data *ch)
 
 int get_random_basic_pc_race(void)
 {
-  int num = dice(1, NUM_RACES + 1);
-  num--;
+  int candidate = RACE_HUMAN;
+  int count = 0;
+  int race = 0;
 
-  while (race_list[num].epic_adv != IS_NORMAL)
+  for (race = 0; race < NUM_EXTENDED_RACES; race++)
   {
-    num = dice(1, NUM_RACES + 1);
-    num--;
+    if (!race_is_creation_eligible(race) || race_list[race].epic_adv != IS_NORMAL)
+      continue;
+
+    count++;
+    if (dice(1, count) == 1)
+      candidate = race;
   }
 
-  return num;
+  return candidate;
 }
 
 /* can a class be this race because of potential alignment issues? (character creation) */
@@ -3273,6 +3450,7 @@ bool is_furry(int race)
   switch (race)
   {
   case RACE_TABAXI:
+  case RACE_WEMIC:
   case LEGACY_RACE_MINOTAUR:
     return true;
   }
@@ -3295,6 +3473,7 @@ bool has_scales(int race)
   switch (race)
   {
   case RACE_DRAGONBORN:
+  case RACE_YUAN_TI:
   case LEGACY_RACE_AURAK_DRACONIAN:
   case LEGACY_RACE_BAAZ_DRACONIAN:
   case LEGACY_RACE_BOZAK_DRACONIAN:
@@ -3310,6 +3489,9 @@ bool race_has_no_hair(int race)
   switch (race)
   {
   case RACE_DRAGONBORN:
+  case RACE_HALF_ILLITHID:
+  case RACE_YUAN_TI:
+  case RACE_MYCONID:
   case LEGACY_RACE_AURAK_DRACONIAN:
   case LEGACY_RACE_BAAZ_DRACONIAN:
   case LEGACY_RACE_BOZAK_DRACONIAN:

--- a/src/character/race.c
+++ b/src/character/race.c
@@ -84,6 +84,42 @@ int get_race_stat(int race, int stat)
   return (race_list[race].ability_mods[stat]);
 }
 
+int race_starting_hp_bonus(int race_num)
+{
+  switch (race_num)
+  {
+  case RACE_CRYSTAL_DWARF:
+  case RACE_TRELUX:
+  case RACE_LICH:
+  case RACE_VAMPIRE:
+  case RACE_HALF_ILLITHID:
+  case RACE_MYCONID:
+    return 10;
+  default:
+    return 0;
+  }
+}
+
+int race_hp_bonus_per_level(int race_num)
+{
+  switch (race_num)
+  {
+  case RACE_CRYSTAL_DWARF:
+  case RACE_TRELUX:
+  case RACE_LICH:
+  case RACE_VAMPIRE:
+  case RACE_HALF_ILLITHID:
+  case RACE_MYCONID:
+    return 4;
+  case RACE_HALF_OGRE:
+    return 2;
+  case RACE_WEMIC:
+    return 1;
+  default:
+    return 0;
+  }
+}
+
 /* appropriate alignments for given race */
 void set_race_alignments(int race, int lg, int ng, int cg, int ln, int tn, int cn, int le, int ne,
                          int ce)
@@ -3214,6 +3250,8 @@ int parse_race_long(const char *arg_in)
     return RACE_HALF_OGRE;
   if (is_abbrev(arg, "half ogre"))
     return RACE_HALF_OGRE;
+  if (is_abbrev(arg, "ogre"))
+    return RACE_HALF_OGRE;
   if (is_abbrev(arg, "arcanagolem"))
     return RACE_ARCANA_GOLEM;
   if (is_abbrev(arg, "arcana-golem"))
@@ -3283,6 +3321,8 @@ int parse_race_long(const char *arg_in)
   if (is_abbrev(arg, "goliath"))
     return RACE_GOLIATH;
   if (is_abbrev(arg, "wemic"))
+    return RACE_WEMIC;
+  if (is_abbrev(arg, "barbarian"))
     return RACE_WEMIC;
   if (is_abbrev(arg, "half-illithid"))
     return RACE_HALF_ILLITHID;

--- a/src/character/race.c
+++ b/src/character/race.c
@@ -120,6 +120,41 @@ int race_hp_bonus_per_level(int race_num)
   }
 }
 
+/* Register an equipment slot that a race's anatomy does not possess. */
+static void set_race_wear_restriction(int race_num, int wear_slot, const char *message)
+{
+  if (race_num < 0 || race_num >= NUM_EXTENDED_RACES || wear_slot < 0 || wear_slot >= NUM_WEARS ||
+      message == NULL)
+  {
+    log("SYSERR: Invalid race wear restriction: race %d, slot %d.", race_num, wear_slot);
+    return;
+  }
+
+  race_list[race_num].wear_slot_restrictions[wear_slot] = message;
+}
+
+const char *character_wear_slot_restriction(const struct char_data *ch, int wear_slot)
+{
+  int race_num;
+
+  if (ch == NULL || IS_NPC(ch) || wear_slot < 0 || wear_slot >= NUM_WEARS)
+    return NULL;
+
+  race_num = GET_REAL_RACE(ch);
+  if (race_num < 0 || race_num >= NUM_EXTENDED_RACES)
+    return NULL;
+
+  return race_list[race_num].wear_slot_restrictions[wear_slot];
+}
+
+bool character_can_use_wear_slot(const struct char_data *ch, int wear_slot)
+{
+  if (ch == NULL || wear_slot < 0 || wear_slot >= NUM_WEARS)
+    return false;
+
+  return character_wear_slot_restriction(ch, wear_slot) == NULL;
+}
+
 /* appropriate alignments for given race */
 void set_race_alignments(int race, int lg, int ng, int cg, int ln, int tn, int cn, int le, int ne,
                          int ce)
@@ -171,7 +206,7 @@ void set_race_attack_types(int race, int hit, int sting, int whip, int slash, in
 /* function to initialize the whole race list to empty values */
 void initialize_races(void)
 {
-  int i = 0;
+  int i = 0, wear_slot = 0;
 
   for (i = 0; i < NUM_EXTENDED_RACES; i++)
   {
@@ -201,6 +236,8 @@ void initialize_races(void)
     set_race_alignments(i, N, N, N, N, N, N, N, N, N);
     set_race_attack_types(i, Y, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N, N,
                           N);
+    for (wear_slot = 0; wear_slot < NUM_WEARS; wear_slot++)
+      race_list[i].wear_slot_restrictions[wear_slot] = NULL;
 
     /* any linked lists to initailze? */
   }
@@ -1616,6 +1653,30 @@ void assign_races(void)
                         N, N, N, N, Y, N, N, N, Y, N, N, Y,
                         /* blast punch stab slice thrust hack rake peck smash trample charge gore */
                         N, N, Y, N, N, N, N, N, N, N, N, N);
+  set_race_wear_restriction(RACE_TRELUX, WEAR_FINGER_R,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_FINGER_L,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_HANDS,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_SHIELD,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_WIELD_1,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_WIELD_OFFHAND,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_WIELD_2H,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_HOLD_1,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_HOLD_2,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_HOLD_2H,
+                            "Your pincer-like forelimbs cannot use equipment made for hands.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_LEGS,
+                            "Your insect-like legs cannot wear leg or foot equipment.");
+  set_race_wear_restriction(RACE_TRELUX, WEAR_FEET,
+                            "Your insect-like legs cannot wear leg or foot equipment.");
   /* feat assignment */
   /*                   race-num    feat                  lvl stack */
   feat_race_assignment(RACE_TRELUX, FEAT_ULTRAVISION, 1, N);
@@ -1848,12 +1909,17 @@ void assign_races(void)
   set_race_alignments(RACE_WEMIC, Y, Y, Y, Y, Y, Y, Y, Y, Y);
   set_race_attack_types(RACE_WEMIC, N, N, N, N, Y, N, N, N, Y, N, N, N, N, N, N, N, N, N, N, N, N,
                         Y, N, N);
+  set_race_wear_restriction(RACE_WEMIC, WEAR_LEGS,
+                            "Your leonine frame cannot wear leg or foot equipment.");
+  set_race_wear_restriction(RACE_WEMIC, WEAR_FEET,
+                            "Your leonine frame cannot wear leg or foot equipment.");
   feat_race_assignment(RACE_WEMIC, FEAT_INFRAVISION, 1, N);
   feat_race_assignment(RACE_WEMIC, FEAT_NATURAL_ATHLETE, 1, N);
   feat_race_assignment(RACE_WEMIC, FEAT_POWERFUL_BUILD, 1, N);
   feat_race_assignment(RACE_WEMIC, FEAT_CLAWS_AND_BITE, 1, N);
   feat_race_assignment(RACE_WEMIC, FEAT_SURVIVAL_INSTINCT, 1, N);
   feat_race_assignment(RACE_WEMIC, FEAT_HARDY, 1, N);
+  feat_race_assignment(RACE_WEMIC, FEAT_LEONINE_FRAME, 1, N);
   race_list[RACE_WEMIC].racial_language = SKILL_LANG_COMMON;
 
   /****************************************************************************/

--- a/src/character/race.h
+++ b/src/character/race.h
@@ -52,6 +52,8 @@ bool race_is_creation_eligible(int race_num);
 bool race_is_selectable_for_creation(struct char_data *ch, int race_num);
 bool display_race_info(struct char_data *ch, const char *racename);
 int get_race_stat(int race, int stat);
+int race_starting_hp_bonus(int race_num);
+int race_hp_bonus_per_level(int race_num);
 int get_random_basic_pc_race(void);
 sbyte has_racial_abils_unchosen(struct char_data *ch);
 /* can a class be this race because of potential alignment issues? (character creation) */

--- a/src/character/race.h
+++ b/src/character/race.h
@@ -64,6 +64,8 @@ bool has_scales(int race);
 bool has_horns(int race);
 bool is_furry(int race);
 bool race_has_no_hair(int race);
+const char *character_wear_slot_restriction(const struct char_data *ch, int wear_slot);
+bool character_can_use_wear_slot(const struct char_data *ch, int wear_slot);
 int compare_races(const void *x, const void *y);
 void sort_races(void);
 

--- a/src/character/race.h
+++ b/src/character/race.h
@@ -48,6 +48,8 @@ bitvector_t find_race_bitvector(const char *arg);
 int invalid_race(struct char_data *ch, struct obj_data *obj);
 int parse_race_long(const char *arg);
 void assign_races(void);
+bool race_is_creation_eligible(int race_num);
+bool race_is_selectable_for_creation(struct char_data *ch, int race_num);
 bool display_race_info(struct char_data *ch, const char *racename);
 int get_race_stat(int race, int stat);
 int get_random_basic_pc_race(void);

--- a/src/db.c
+++ b/src/db.c
@@ -7590,7 +7590,7 @@ void init_char(struct char_data *ch)
 
   GET_REAL_SIZE(ch) = SIZE_MEDIUM;
 
-  if (GET_RACE(ch) < -1 || GET_RACE(ch) >= NUM_RACES)
+  if (GET_RACE(ch) != RACE_UNDEFINED && !race_is_creation_eligible(GET_RACE(ch)))
     GET_REAL_RACE(ch) = RACE_UNDEFINED;
 
   if ((i = get_ptable_by_name(GET_NAME(ch))) != -1)

--- a/src/handler.c
+++ b/src/handler.c
@@ -23,6 +23,7 @@
 #include "act.h"
 #include "character/abilities.h"
 #include "character/class.h"
+#include "character/race.h"
 #include "combat/fight.h"
 #include "combat/projectiles.h"
 #include "quest/quest.h"
@@ -2494,6 +2495,11 @@ void equip_char(struct char_data *ch, struct obj_data *obj, int pos)
   if (IN_ROOM(obj) != NOWHERE)
   {
     log("SYSERR: EQUIP: Obj is in_room when equip.");
+    return;
+  }
+  if (!character_can_use_wear_slot(ch, pos))
+  {
+    obj_to_char(obj, ch);
     return;
   }
   /*  Changed this - proficiencies are handles in the places where they apply penalties.

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -7875,9 +7875,9 @@ void nanny(struct descriptor_data *d, char *arg)
       return;
     }
     write_to_output(d, "Races of Luminari\r\n\r\n");
-    for (i = 0; i < NUM_RACES; i++)
+    for (i = 0; i < NUM_EXTENDED_RACES; i++)
     {
-      if ((!is_locked_race(i) || has_unlocked_race(d->character, i)) && race_list[i].is_pc)
+      if (race_is_selectable_for_creation(d->character, i))
         write_to_output(d, "%s\r\n", race_list[i].type);
     }
     write_to_output(d, "\r\nRace Selection (type 'human' if you do not know "
@@ -7895,7 +7895,12 @@ void nanny(struct descriptor_data *d, char *arg)
       write_to_output(d, "\r\nThat's not a race.\r\nRace: ");
       return;
     }
-    else if (is_locked_race(load_result) && !has_unlocked_race(d->character, load_result))
+    else if (!race_is_creation_eligible(load_result))
+    {
+      write_to_output(d, "\r\nThat race cannot be selected during character creation.\r\nRace: ");
+      return;
+    }
+    else if (!race_is_selectable_for_creation(d->character, load_result))
     {
       write_to_output(d, "\r\nYou have not unlocked that race yet, type 'account' "
                          "in-game to view your unlocked races.\r\nRace: ");
@@ -7990,6 +7995,21 @@ void nanny(struct descriptor_data *d, char *arg)
     case RACE_HOBGOBLIN:
       perform_help(d, "race-hobgoblin");
       break;
+    case RACE_WEMIC:
+      perform_help(d, "race-wemic");
+      break;
+    case RACE_HALF_OGRE:
+      perform_help(d, "race-half-ogre");
+      break;
+    case RACE_HALF_ILLITHID:
+      perform_help(d, "race-half-illithid");
+      break;
+    case RACE_YUAN_TI:
+      perform_help(d, "race-yuan-ti");
+      break;
+    case RACE_MYCONID:
+      perform_help(d, "race-myconid");
+      break;
     default:
       write_to_output(d, "\r\nCommand not understood.\r\n");
       return;
@@ -8013,9 +8033,9 @@ void nanny(struct descriptor_data *d, char *arg)
     else
     {
       write_to_output(d, "Races of Luminari\r\n\r\n");
-      for (i = 0; i < NUM_RACES; i++)
+      for (i = 0; i < NUM_EXTENDED_RACES; i++)
       {
-        if ((!is_locked_race(i) || has_unlocked_race(d->character, i)) && race_list[i].is_pc)
+        if (race_is_selectable_for_creation(d->character, i))
           write_to_output(d, "%s\r\n", race_list[i].type);
       }
       // {

--- a/src/movement/movement_tracks.c
+++ b/src/movement/movement_tracks.c
@@ -216,7 +216,7 @@ void create_tracks(struct char_data *ch, int dir, int flag)
   else
   {
     race_idx = GET_RACE(ch);
-    if (race_idx >= 0 && race_idx < NUM_RACES && race_list[race_idx].name)
+    if (race_idx >= 0 && race_idx < NUM_EXTENDED_RACES && race_list[race_idx].name)
       race = race_list[race_idx].name;
   }
 

--- a/src/net/onboarding.c
+++ b/src/net/onboarding.c
@@ -1875,10 +1875,24 @@ bool web_onboarding_has_active_outbound_transfer_for_test(struct descriptor_data
 
 const char *web_onboarding_race_media_key(int race)
 {
-  if (race < 0 || race >= NUM_RACES || race_media_keys[race] == NULL)
-    return "race/fallback";
+  if (race >= 0 && race < NUM_RACES && race_media_keys[race] != NULL)
+    return race_media_keys[race];
 
-  return race_media_keys[race];
+  switch (race)
+  {
+  case RACE_HALF_OGRE:
+    return "race/half-ogre";
+  case RACE_MYCONID:
+    return "race/myconid";
+  case RACE_WEMIC:
+    return "race/wemic";
+  case RACE_HALF_ILLITHID:
+    return "race/half-illithid";
+  case RACE_YUAN_TI:
+    return "race/yuan-ti";
+  default:
+    return "race/fallback";
+  }
 }
 
 const char *web_onboarding_class_media_key(int chclass)
@@ -1971,11 +1985,9 @@ static void catalog_page_bounds(struct descriptor_data *d, int state, int total,
 
 static bool race_is_selectable(struct descriptor_data *d, int race)
 {
-  if (d == NULL || d->character == NULL || race < 0 || race >= NUM_RACES)
+  if (d == NULL || d->character == NULL)
     return FALSE;
-  if (!race_list[race].is_pc)
-    return FALSE;
-  return !is_locked_race(race) || has_unlocked_race(d->character, race);
+  return race_is_selectable_for_creation(d->character, race);
 }
 
 /* Races the server would actually accept right now, using the same lock and
@@ -2002,7 +2014,7 @@ static void build_race_choices(struct json_writer *w, struct descriptor_data *d)
     (void)page_count;
   }
 
-  for (race = 0; race < NUM_RACES; race++)
+  for (race = 0; race < NUM_EXTENDED_RACES; race++)
   {
     if (!race_is_selectable(d, race))
       continue;
@@ -2396,7 +2408,7 @@ static void build_selection(struct json_writer *w, struct descriptor_data *d)
     json_field_string(w, "sex", GET_SEX(ch) == SEX_MALE ? "Male" : "Female", 16);
   }
 
-  if (selection_has_race(state) && GET_REAL_RACE(ch) >= 0 && GET_REAL_RACE(ch) < NUM_RACES)
+  if (selection_has_race(state) && GET_REAL_RACE(ch) >= 0 && GET_REAL_RACE(ch) < NUM_EXTENDED_RACES)
   {
     if (!first)
       json_raw(w, ",");
@@ -2797,7 +2809,7 @@ static int selectable_race_count(struct descriptor_data *d)
   int race = 0;
   int count = 0;
 
-  for (race = 0; race < NUM_RACES; race++)
+  for (race = 0; race < NUM_EXTENDED_RACES; race++)
     if (race_is_selectable(d, race))
       count++;
   return count;
@@ -3972,7 +3984,8 @@ static void build_selected_detail(struct json_writer *w, struct descriptor_data 
   if (ch == NULL)
     return;
 
-  if (screen->state == CON_QRACE_HELP && GET_REAL_RACE(ch) >= 0 && GET_REAL_RACE(ch) < NUM_RACES)
+  if (screen->state == CON_QRACE_HELP && GET_REAL_RACE(ch) >= 0 &&
+      GET_REAL_RACE(ch) < NUM_EXTENDED_RACES)
   {
     json_field_string(w, "mediaKey", web_onboarding_race_media_key(GET_REAL_RACE(ch)), 64);
     json_raw(w, ",");

--- a/src/obj/act.item.c
+++ b/src/obj/act.item.c
@@ -46,6 +46,7 @@
 #include "craft/crafts.h"
 #include "quest/hunts.h"
 #include "character/class.h"
+#include "character/race.h"
 #include "magic/spell_prep.h"
 #include "olc/genobj.h"
 #include "character/backgrounds.h"
@@ -4185,6 +4186,7 @@ int is_wielding_type(struct char_data *ch)
 void perform_wear(struct char_data *ch, struct obj_data *obj, int where)
 {
   char buf[MAX_INPUT_LENGTH] = {'\0'};
+  const char *wear_restriction = NULL;
 
   /* TAKE is used for objects that don't require special bits, ex. HOLD */
   int wear_bitvectors[] = {ITEM_WEAR_TAKE,
@@ -4283,6 +4285,13 @@ void perform_wear(struct char_data *ch, struct obj_data *obj, int where)
     return;
   }
 
+  wear_restriction = character_wear_slot_restriction(ch, where);
+  if (wear_restriction != NULL)
+  {
+    send_to_char(ch, "%s\r\n", wear_restriction);
+    return;
+  }
+
   /* see hands_needed() for notes */
   int handsNeeded = hands_needed(ch, obj);
   if (handsNeeded == -1)
@@ -4353,12 +4362,6 @@ void perform_wear(struct char_data *ch, struct obj_data *obj, int where)
     }
   }
 
-  if (GET_RACE(ch) == RACE_TRELUX && (where == WEAR_FINGER_R || where == WEAR_FINGER_L))
-  {
-    send_to_char(ch, "Your anatomy does not allow you to wear that...\r\n");
-    return;
-  }
-
   if ((where == WEAR_AMMO_POUCH && GET_EQ(ch, WEAR_SHEATH)) ||
       (where == WEAR_SHEATH && GET_EQ(ch, WEAR_AMMO_POUCH)))
   {
@@ -4403,12 +4406,6 @@ void perform_wear(struct char_data *ch, struct obj_data *obj, int where)
       where == WEAR_HOLD_2 || where == WEAR_SHIELD || where == WEAR_WIELD_2H ||
       where == WEAR_HOLD_2H)
   {
-    if (GET_RACE(ch) == RACE_TRELUX)
-    {
-      send_to_char(ch, "You have no hands!\r\n");
-      return;
-    }
-
     if (handsNeeded == 2 && where == WEAR_WIELD_1)
       where = WEAR_WIELD_2H;
     if (handsNeeded == 2 && where == WEAR_HOLD_1)

--- a/src/structs.h
+++ b/src/structs.h
@@ -779,8 +779,8 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define RACE_DEEP_GNOME 26
 #define RACE_SVIRFNEBLIN RACE_DEEP_GNOME
 #define RACE_ORC 27
-#define RACE_H_OGRE 28 // not yet implemented
-#define RACE_HALF_OGRE RACE_H_OGRE
+#define RACE_HALF_OGRE 28
+#define RACE_H_OGRE RACE_HALF_OGRE
 /* Retired race IDs remain reserved for persisted character and world data. */
 #define LEGACY_RACE_START 29
 #define LEGACY_RACE_HUMAN 29
@@ -870,8 +870,8 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define RACE_OWLBEAR 111
 #define RACE_SHAMBLING_MOUND 112
 #define RACE_TREANT 113
-#define RACE_MYCANOID 114
-#define RACE_MYCONID RACE_MYCANOID
+#define RACE_MYCONID 114
+#define RACE_MYCANOID RACE_MYCONID
 #define RACE_SKELETON 115
 #define RACE_ZOMBIE 116
 #define RACE_WOLF 117

--- a/src/structs.h
+++ b/src/structs.h
@@ -773,7 +773,7 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define RACE_GOBLIN 26
 #define RACE_HOBGOBLIN 27
 
-/* last playable race above +1 */
+/* End of the original dense creation range. New playable races may be sparse. */
 #define NUM_RACES 28
 
 #define RACE_DEEP_GNOME 26
@@ -871,6 +871,7 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define RACE_SHAMBLING_MOUND 112
 #define RACE_TREANT 113
 #define RACE_MYCANOID 114
+#define RACE_MYCONID RACE_MYCANOID
 #define RACE_SKELETON 115
 #define RACE_ZOMBIE 116
 #define RACE_WOLF 117
@@ -905,9 +906,16 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define RACE_DIRE_ROC 146
 #define RACE_PURPLE_WORM 147
 #define RACE_CRIMSON_WORM 148
+#define RACE_WEMIC 149
+#define RACE_HALF_ILLITHID 150
+#define RACE_ILLITHID RACE_HALF_ILLITHID
+#define RACE_YUAN_TI 151
+#define RACE_YUANTI RACE_YUAN_TI
 /**/
-/* Total Number of available (in-game) PC Races*/
-#define NUM_EXTENDED_RACES 149
+/* Number of creation-selectable races, independent of their numeric IDs. */
+#define NUM_CREATION_RACES 33
+/* Array bound for every concrete PC, NPC, and form race. */
+#define NUM_EXTENDED_RACES 152
 /*****/
 
 // npc sub-race types, currently our NPC's get 3 of these
@@ -6162,7 +6170,7 @@ struct char_player_data
   struct time_data time;           /**< PC AGE in days */
   ubyte weight;                    /**< PC / NPC weight */
   ubyte height;                    /**< PC / NPC height */
-  byte race;                       // Race
+  sh_int race;                     // Persistent concrete race ID
   byte pc_subrace;                 // SubRace
   char *walkin;                    // NPC (for now) walkin message
   char *walkout;                   // NPC (for now) walkout message

--- a/src/structs.h
+++ b/src/structs.h
@@ -2993,11 +2993,12 @@ typedef int32_t IDXTYPE; /**< Fixed-width type for virtual and real indexes. */
 #define FEAT_ESTABLISH_CAMP 1264
 #define FEAT_GARROTE 1265
 #define FEAT_ACCOMPANY 1266
+#define FEAT_LEONINE_FRAME 1267
 
 /** reserved above feat# + 1**/
-#define FEAT_LAST_FEAT 1267
+#define FEAT_LAST_FEAT 1268
 /** FEAT_LAST_FEAT + 1 ***/
-#define NUM_FEATS 1268
+#define NUM_FEATS 1269
 /** absolute cap **/
 #define MAX_FEATS 1500
 /*****/
@@ -8049,6 +8050,9 @@ struct race_data
   sbyte alignments[NUM_ALIGNMENTS];    /* acceptable alignments for this race */
   byte attack_types[NUM_ATTACK_TYPES]; /* race have this attack type? (when not wielding) */
 
+  /* NULL means this anatomy supports the slot; otherwise this is the rejection message. */
+  const char *wear_slot_restrictions[NUM_WEARS];
+
   /* linked lists */
   struct race_feat_assign *featassign_list; /* list of feat assigns */
   struct affect_assign *affassign_list;     /* list of affect assigns */
@@ -8057,7 +8061,6 @@ struct race_data
 
   /* these are only ideas for now */
 
-  /*int body_parts[NUM_WEARS];*/   /* for expansion - to add customized wear slots */
   /*byte favored_class[NUM_SEX];*/ /* favored class system, not yet implemented */
   /*ush_int language;*/            /* default language - not used yet */
 };

--- a/src/utils.c
+++ b/src/utils.c
@@ -4923,8 +4923,8 @@ int get_race_by_name(char *racename)
 {
   int i;
 
-  for (i = 0; i < NUM_RACES; i++)
-    if (is_abbrev(racename, race_list[i].type))
+  for (i = 0; i < NUM_EXTENDED_RACES; i++)
+    if (race_is_creation_eligible(i) && is_abbrev(racename, race_list[i].type))
       return (i);
 
   return (-1);
@@ -8414,6 +8414,31 @@ void calculate_max_hp(struct char_data *ch, bool display)
     max_hp += GET_LEVEL(ch) * 4;
     if (display)
       send_to_char(ch, "%-40s = +%d\r\n", "Vampire Racial Hit Point Bonus", GET_LEVEL(ch) * 4);
+  }
+  if (GET_REAL_RACE(ch) == RACE_HALF_ILLITHID)
+  {
+    max_hp += GET_LEVEL(ch) * 4;
+    if (display)
+      send_to_char(ch, "%-40s = +%d\r\n", "Half-Illithid Racial Hit Point Bonus",
+                   GET_LEVEL(ch) * 4);
+  }
+  if (GET_REAL_RACE(ch) == RACE_MYCONID)
+  {
+    max_hp += GET_LEVEL(ch) * 4;
+    if (display)
+      send_to_char(ch, "%-40s = +%d\r\n", "Myconid Racial Hit Point Bonus", GET_LEVEL(ch) * 4);
+  }
+  if (GET_REAL_RACE(ch) == RACE_HALF_OGRE)
+  {
+    max_hp += GET_LEVEL(ch) * 2;
+    if (display)
+      send_to_char(ch, "%-40s = +%d\r\n", "Half-Ogre Racial Hit Point Bonus", GET_LEVEL(ch) * 2);
+  }
+  if (GET_REAL_RACE(ch) == RACE_WEMIC)
+  {
+    max_hp += GET_LEVEL(ch);
+    if (display)
+      send_to_char(ch, "%-40s = +%d\r\n", "Wemic Racial Hit Point Bonus", GET_LEVEL(ch));
   }
 
   // perks

--- a/src/utils.c
+++ b/src/utils.c
@@ -8204,6 +8204,8 @@ void calculate_max_hp(struct char_data *ch, bool display)
 
   int i = 0, j = 0;
   int max_hp = 20; // start point
+  int racial_hp_bonus = 0;
+  int racial_starting_hp_bonus = 0;
   int max_value[NUM_BONUS_TYPES];
   int max_val_spell[NUM_BONUS_TYPES];
   int max_val_worn_slot[NUM_BONUS_TYPES];
@@ -8389,57 +8391,15 @@ void calculate_max_hp(struct char_data *ch, bool display)
                    30 * HAS_FEAT(ch, FEAT_EPIC_TOUGHNESS));
   }
 
-  // race
-  if (GET_REAL_RACE(ch) == RACE_CRYSTAL_DWARF)
-  {
-    max_hp += GET_LEVEL(ch) * 4;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Crystal Dwarf Racial Hit Point Bonus",
-                   GET_LEVEL(ch) * 4);
-  }
-  if (GET_REAL_RACE(ch) == RACE_TRELUX)
-  {
-    max_hp += GET_LEVEL(ch) * 4;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Trelux Racial Hit Point Bonus", GET_LEVEL(ch) * 4);
-  }
-  if (GET_REAL_RACE(ch) == RACE_LICH)
-  {
-    max_hp += GET_LEVEL(ch) * 4;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Lich Racial Hit Point Bonus", GET_LEVEL(ch) * 4);
-  }
-  if (GET_REAL_RACE(ch) == RACE_VAMPIRE)
-  {
-    max_hp += GET_LEVEL(ch) * 4;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Vampire Racial Hit Point Bonus", GET_LEVEL(ch) * 4);
-  }
-  if (GET_REAL_RACE(ch) == RACE_HALF_ILLITHID)
-  {
-    max_hp += GET_LEVEL(ch) * 4;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Half-Illithid Racial Hit Point Bonus",
-                   GET_LEVEL(ch) * 4);
-  }
-  if (GET_REAL_RACE(ch) == RACE_MYCONID)
-  {
-    max_hp += GET_LEVEL(ch) * 4;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Myconid Racial Hit Point Bonus", GET_LEVEL(ch) * 4);
-  }
-  if (GET_REAL_RACE(ch) == RACE_HALF_OGRE)
-  {
-    max_hp += GET_LEVEL(ch) * 2;
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Half-Ogre Racial Hit Point Bonus", GET_LEVEL(ch) * 2);
-  }
-  if (GET_REAL_RACE(ch) == RACE_WEMIC)
-  {
-    max_hp += GET_LEVEL(ch);
-    if (display)
-      send_to_char(ch, "%-40s = +%d\r\n", "Wemic Racial Hit Point Bonus", GET_LEVEL(ch));
-  }
+  /* Race */
+  racial_starting_hp_bonus = race_starting_hp_bonus(GET_REAL_RACE(ch));
+  racial_hp_bonus = GET_LEVEL(ch) * race_hp_bonus_per_level(GET_REAL_RACE(ch));
+  max_hp += racial_starting_hp_bonus + racial_hp_bonus;
+  if (display && racial_starting_hp_bonus > 0)
+    send_to_char(ch, "%-40s = +%d\r\n", "Racial Starting Hit Point Bonus",
+                 racial_starting_hp_bonus);
+  if (display && racial_hp_bonus > 0)
+    send_to_char(ch, "%-40s = +%d\r\n", "Racial Hit Point Bonus", racial_hp_bonus);
 
   // perks
   int perk_hp_bonus = get_perk_hp_bonus(ch);

--- a/src/utils.h
+++ b/src/utils.h
@@ -81,7 +81,7 @@
  *   2 if the character would normally be able to use the command, but temporarily can't.
  */
 #define ACMDCHECK(name)                                                                            \
-  int name(struct char_data *ch __attribute__((unused)),                                          \
+  int name(struct char_data *ch __attribute__((unused)),                                           \
            const char *argument __attribute__((unused)), bool show_error __attribute__((unused)))
 #define ACMD_ERRORMSG(error)                                                                       \
   if (show_error == true)                                                                          \
@@ -972,9 +972,9 @@ void char_from_furniture(struct char_data *ch);
 #define IS_EPIC(ch) (IS_EPIC_LEVEL(ch))
 
 #define TOTAL_STAT_POINTS(ch)                                                                      \
-  ((GET_REAL_RACE(ch) == RACE_HUMAN || GET_REAL_RACE(ch) == LEGACY_RACE_HUMAN)         ? 34            \
-   : (GET_REAL_RACE(ch) == RACE_HALF_ELF || GET_REAL_RACE(ch) == LEGACY_RACE_HALF_ELF) ? 32            \
-                                                                                   : 30)
+  ((GET_REAL_RACE(ch) == RACE_HUMAN || GET_REAL_RACE(ch) == LEGACY_RACE_HUMAN)         ? 34        \
+   : (GET_REAL_RACE(ch) == RACE_HALF_ELF || GET_REAL_RACE(ch) == LEGACY_RACE_HALF_ELF) ? 32        \
+                                                                                       : 30)
 #define MAX_POINTS_IN_A_STAT 10
 #define BASE_STAT 8
 
@@ -1005,8 +1005,7 @@ void char_from_furniture(struct char_data *ch);
        ? GET_LEVEL(ch)                                                                             \
        : (CLASS_LEVEL(ch, CLASS_SUMMONER) + CLASS_LEVEL(ch, CLASS_NECROMANCER)))
 #define GET_PSIONIC_LEVEL(ch)                                                                      \
-  (((IS_NPC(ch) &&                                                                                 \
-     (GET_CLASS(ch) == CLASS_PSIONICIST || MOB_FLAGGED(ch, MOB_ROL_HAS_PS))) ||                    \
+  (((IS_NPC(ch) && (GET_CLASS(ch) == CLASS_PSIONICIST || MOB_FLAGGED(ch, MOB_ROL_HAS_PS))) ||      \
     GET_LEVEL(ch) >= LVL_IMMORT)                                                                   \
        ? GET_LEVEL(ch)                                                                             \
        : CLASS_LEVEL(ch, CLASS_PSIONICIST))
@@ -2226,15 +2225,14 @@ int ACTUAL_BAB(struct char_data *ch);
   (CLASS_LEVEL(ch, CLASS_CLERIC) || (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_ROL_HAS_CL)))
 #define IS_INQUISITOR(ch) (CLASS_LEVEL(ch, CLASS_INQUISITOR))
 #define IS_DRUID(ch) (CLASS_LEVEL(ch, CLASS_DRUID))
-#define IS_ROGUE(ch)                                                                                \
+#define IS_ROGUE(ch)                                                                               \
   (CLASS_LEVEL(ch, CLASS_ROGUE) || (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_ROL_HAS_TH)))
 #define IS_ROGUE_TYPE(ch)                                                                          \
-  (IS_ROGUE(ch) + CLASS_LEVEL(ch, CLASS_DUELIST) +                                                 \
-   CLASS_LEVEL(ch, CLASS_SHADOW_DANCER) + CLASS_LEVEL(ch, CLASS_ASSASSIN) +                        \
-   CLASS_LEVEL(ch, CLASS_ARCANE_SHADOW) + CLASS_LEVEL(ch, CLASS_RANGER) +                          \
-   CLASS_LEVEL(ch, CLASS_BARD))
+  (IS_ROGUE(ch) + CLASS_LEVEL(ch, CLASS_DUELIST) + CLASS_LEVEL(ch, CLASS_SHADOW_DANCER) +          \
+   CLASS_LEVEL(ch, CLASS_ASSASSIN) + CLASS_LEVEL(ch, CLASS_ARCANE_SHADOW) +                        \
+   CLASS_LEVEL(ch, CLASS_RANGER) + CLASS_LEVEL(ch, CLASS_BARD))
 #define IS_PSI_TYPE(ch) (CLASS_LEVEL(ch, CLASS_PSIONICIST)) /* for expansion! */
-#define IS_WARRIOR(ch)                                                                              \
+#define IS_WARRIOR(ch)                                                                             \
   (CLASS_LEVEL(ch, CLASS_WARRIOR) || (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_ROL_HAS_WA)))
 #define IS_WEAPONMASTER(ch) (CLASS_LEVEL(ch, CLASS_WEAPON_MASTER))
 #define IS_STALWARTDEFENDER(ch) (CLASS_LEVEL(ch, CLASS_STALWART_DEFENDER))
@@ -2296,7 +2294,8 @@ int ACTUAL_BAB(struct char_data *ch);
   (CHECK_PLAYER_SPECIAL(ch, (ch->player_specials->saved.necromancer_bonus_levels)))
 
 /* 1 if ch is race, 0 if not */
-#define IS_HUMAN(ch) (!IS_NPC(ch) && (GET_RACE(ch) == RACE_HUMAN || GET_RACE(ch) == LEGACY_RACE_HUMAN))
+#define IS_HUMAN(ch)                                                                               \
+  (!IS_NPC(ch) && (GET_RACE(ch) == RACE_HUMAN || GET_RACE(ch) == LEGACY_RACE_HUMAN))
 #define IS_ELF(ch)                                                                                 \
   (!IS_NPC(ch) &&                                                                                  \
    (GET_RACE(ch) == RACE_ELF || GET_RACE(ch) == RACE_WILD_ELF || GET_RACE(ch) == RACE_HIGH_ELF))
@@ -2327,6 +2326,11 @@ int ACTUAL_BAB(struct char_data *ch);
     (GET_SUBRACE(ch, 0) == SUBRACE_GOBLINOID || GET_SUBRACE(ch, 1) == SUBRACE_GOBLINOID ||         \
      GET_SUBRACE(ch, 2) == SUBRACE_GOBLINOID)) ||                                                  \
    (!IS_NPC(ch) && (GET_RACE(ch) == RACE_GOBLIN || GET_RACE(ch) == RACE_HOBGOBLIN)))
+#define IS_WEMIC(ch) (!IS_NPC(ch) && GET_REAL_RACE(ch) == RACE_WEMIC)
+#define IS_HALF_OGRE(ch) (!IS_NPC(ch) && GET_REAL_RACE(ch) == RACE_HALF_OGRE)
+#define IS_HALF_ILLITHID(ch) (!IS_NPC(ch) && GET_REAL_RACE(ch) == RACE_HALF_ILLITHID)
+#define IS_YUAN_TI(ch) (!IS_NPC(ch) && GET_REAL_RACE(ch) == RACE_YUAN_TI)
+#define IS_MYCONID(ch) (!IS_NPC(ch) && GET_REAL_RACE(ch) == RACE_MYCONID)
 
 // backwards compatibility for old circlemud code snippets
 #define SEND_TO_Q(buf, desc) (write_to_output(desc, "%s", buf))
@@ -2340,8 +2344,8 @@ int ACTUAL_BAB(struct char_data *ch);
 
 #define HIGH_ELF_CANTRIP(ch) (ch->player_specials->saved.high_elf_cantrip)
 #define CAN_CHOOSE_HIGH_ELF_CANTRIP(ch)                                                            \
-  (HIGH_ELF_CANTRIP(ch) ||                                                                         \
-   (GET_RACE(d->character) != RACE_HIGH_ELF && GET_RACE(d->character) != LEGACY_RACE_SILVANESTI_ELF))
+  (HIGH_ELF_CANTRIP(ch) || (GET_RACE(d->character) != RACE_HIGH_ELF &&                             \
+                            GET_RACE(d->character) != LEGACY_RACE_SILVANESTI_ELF))
 #define GET_RACIAL_MAGIC(ch, slot) (ch->player_specials->saved.racial_magic[slot])
 #define GET_RACIAL_COOLDOWN(ch, slot) (ch->player_specials->saved.racial_cooldown[slot])
 #define GET_DRAGONBORN_ANCESTRY(ch) (ch->player_specials->saved.dragonborn_draconic_ancestry)
@@ -2376,7 +2380,17 @@ int ACTUAL_BAB(struct char_data *ch);
    (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_ELEMENTAL))
 #define IS_PLANT(ch)                                                                               \
   ((IS_NPC(ch) && GET_RACE(ch) == RACE_TYPE_PLANT) ||                                              \
-   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_PLANT))
+   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_PLANT) || IS_MYCONID(ch))
+#define IS_GIANT(ch)                                                                               \
+  ((IS_NPC(ch) && GET_RACE(ch) == RACE_TYPE_GIANT) ||                                              \
+   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_GIANT) || IS_HALF_OGRE(ch))
+#define IS_ABERRATION(ch)                                                                          \
+  ((IS_NPC(ch) && GET_RACE(ch) == RACE_TYPE_ABERRATION) ||                                         \
+   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_ABERRATION) || IS_HALF_ILLITHID(ch))
+#define IS_MONSTROUS_HUMANOID(ch)                                                                  \
+  ((IS_NPC(ch) && GET_RACE(ch) == RACE_TYPE_MONSTROUS_HUMANOID) ||                                 \
+   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_MONSTROUS_HUMANOID) || IS_WEMIC(ch) ||              \
+   IS_YUAN_TI(ch))
 #define IS_OOZE(ch)                                                                                \
   ((IS_NPC(ch) && GET_RACE(ch) == RACE_TYPE_OOZE) ||                                               \
    (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_OOZE))
@@ -2391,11 +2405,13 @@ int ACTUAL_BAB(struct char_data *ch);
    affected_by_spell(ch, SPELL_GREATER_PLANAR_HEALING))
 #define IS_HUMANOID(ch)                                                                            \
   ((IS_NPC(ch) && GET_RACE(ch) == RACE_TYPE_HUMANOID) ||                                           \
-   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_HUMANOID) || (!IS_NPC(ch) && !IS_MORPHED(ch)))
+   (!IS_NPC(ch) && IS_MORPHED(ch) == RACE_TYPE_HUMANOID) ||                                        \
+   (!IS_NPC(ch) && !IS_MORPHED(ch) && !IS_LICH(ch) && !IS_VAMPIRE(ch) && !IS_WEMIC(ch) &&          \
+    !IS_HALF_OGRE(ch) && !IS_HALF_ILLITHID(ch) && !IS_YUAN_TI(ch) && !IS_MYCONID(ch)))
 #define IS_DRACONIAN(ch)                                                                           \
   (IS_NPC(ch) &&                                                                                   \
-   (GET_RACE(ch) == LEGACY_RACE_BAAZ_DRACONIAN || GET_RACE(ch) == LEGACY_RACE_BOZAK_DRACONIAN ||           \
-    GET_RACE(ch) == LEGACY_RACE_KAPAK_DRACONIAN || GET_RACE(ch) == LEGACY_RACE_SIVAK_DRACONIAN ||          \
+   (GET_RACE(ch) == LEGACY_RACE_BAAZ_DRACONIAN || GET_RACE(ch) == LEGACY_RACE_BOZAK_DRACONIAN ||   \
+    GET_RACE(ch) == LEGACY_RACE_KAPAK_DRACONIAN || GET_RACE(ch) == LEGACY_RACE_SIVAK_DRACONIAN ||  \
     GET_RACE(ch) == LEGACY_RACE_AURAK_DRACONIAN))
 #define IS_LIVING(ch) (!IS_UNDEAD(ch) && !IS_CONSTRUCT(ch))
 #define IS_VAMPIRE(ch)                                                                             \

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -4,10 +4,14 @@
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"
+#include "../../src/account.h"
+#include "../../src/act.h"
+#include "../../src/character/race.h"
 #include "../../src/comm.h"
 #include "../../src/db.h"
 #include "../../src/handler.h"
 #include "../../src/mysql.h"
+#include "../../src/net/protocol.h"
 #include "../../src/db_init.h"
 #include "../../src/mudlim.h"
 #include "../../src/magic/spells.h"
@@ -396,6 +400,137 @@ void Test_database_production_prepared_statement_round_trip(CuTest *tc)
   CuAssertTrue(tc, fetched);
   CuAssertTrue(tc, payload_matches);
   CuAssertIntEquals(tc, 42, stored_count);
+}
+
+void Test_race_equivalence_account_unlock_database_round_trip(CuTest *tc)
+{
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  const char *race_names[] = {"Wemic", "Half-Ogre", "Half-Illithid", "Yuan-Ti", "Myconid"};
+  const char *queries[] = {
+      "CREATE TEMPORARY TABLE account_data ("
+      "id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL, "
+      "password VARCHAR(64) NOT NULL, experience INT NOT NULL, email VARCHAR(255) NULL, "
+      "quit_survey_completed BOOLEAN NOT NULL) ENGINE=InnoDB",
+      "CREATE TEMPORARY TABLE unlocked_races ("
+      "account_id INT NOT NULL, race_id INT NOT NULL, "
+      "UNIQUE KEY unique_account_race (account_id, race_id)) ENGINE=InnoDB",
+      "CREATE TEMPORARY TABLE unlocked_classes ("
+      "account_id INT NOT NULL, class_id INT NOT NULL, "
+      "UNIQUE KEY unique_account_class (account_id, class_id)) ENGINE=InnoDB",
+      NULL};
+  const char *enabled;
+  MYSQL *connection;
+  MYSQL *saved_conn;
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data saved_account;
+  struct account_data loaded_account;
+  bool saved_available;
+  bool schema_created = true;
+  bool saved = false;
+  bool found = false;
+  bool protocol_created = false;
+  char command[MAX_INPUT_LENGTH];
+  char count_query[256];
+  int stored_count = -1;
+  int query_index = 0;
+  int race_index = 0;
+  int slot = 0;
+
+  enabled = getenv("LUMINARI_TEST_MYSQL_ENABLE");
+  if (enabled == NULL || strcmp(enabled, "1") != 0)
+  {
+    CuAssertTrue(tc, 1);
+    return;
+  }
+
+  connection = open_test_database();
+  if (connection == NULL)
+  {
+    CuFail(tc, "could not connect to the explicitly configured test database");
+    return;
+  }
+
+  saved_conn = conn;
+  saved_available = mysql_available;
+  conn = connection;
+  mysql_available = true;
+  memset(&ch, 0, sizeof(ch));
+  memset(&specials, 0, sizeof(specials));
+  memset(&descriptor, 0, sizeof(descriptor));
+  memset(&saved_account, 0, sizeof(saved_account));
+  memset(&loaded_account, 0, sizeof(loaded_account));
+  ch.player_specials = &specials;
+  ch.desc = &descriptor;
+  descriptor.character = &ch;
+  descriptor.account = &saved_account;
+  descriptor.output = descriptor.small_outbuf;
+  descriptor.bufspace = SMALL_BUFSIZE - 1;
+  descriptor.pProtocol = ProtocolCreate();
+  protocol_created = descriptor.pProtocol != NULL;
+  if (race_list[RACE_WEMIC].type == NULL)
+    assign_races();
+
+  for (query_index = 0; queries[query_index] != NULL; query_index++)
+    if (mysql_query(connection, queries[query_index]))
+    {
+      schema_created = false;
+      break;
+    }
+
+  if (schema_created && protocol_created)
+  {
+    saved_account.name = (char *)"RaceEquivalenceAccount";
+    strlcpy(saved_account.password, "test-password", sizeof(saved_account.password));
+    saved_account.experience = 63000;
+    for (race_index = 0; race_index < (int)(sizeof(races) / sizeof(races[0])); race_index++)
+    {
+      snprintf(command, sizeof(command), "race %s", race_names[race_index]);
+      do_accexp(&ch, command, 0, 0);
+    }
+    saved = saved_account.id > 0 && saved_account.experience == 0;
+  }
+
+  if (saved)
+  {
+    loaded_account.id = saved_account.id;
+    load_account_unlocks(&loaded_account);
+    snprintf(count_query, sizeof(count_query),
+             "SELECT COUNT(*) FROM unlocked_races WHERE account_id = %d", saved_account.id);
+    stored_count = query_single_int(connection, count_query, -1);
+  }
+
+  if (descriptor.pProtocol != NULL)
+  {
+    ProtocolDestroy(descriptor.pProtocol);
+    descriptor.pProtocol = NULL;
+  }
+  if (descriptor.large_outbuf != NULL)
+  {
+    free(descriptor.large_outbuf->text);
+    free(descriptor.large_outbuf);
+  }
+  mysql_close(connection);
+  conn = saved_conn;
+  mysql_available = saved_available;
+
+  CuAssertTrue(tc, schema_created);
+  CuAssertTrue(tc, protocol_created);
+  CuAssertTrue(tc, saved);
+  CuAssertTrue(tc, saved_account.id > 0);
+  CuAssertIntEquals(tc, (int)(sizeof(races) / sizeof(races[0])), stored_count);
+  for (race_index = 0; race_index < (int)(sizeof(races) / sizeof(races[0])); race_index++)
+  {
+    found = false;
+    for (slot = 0; slot < MAX_UNLOCKED_RACES; slot++)
+      if (loaded_account.races[slot] == races[race_index])
+      {
+        found = true;
+        break;
+      }
+    CuAssertTrue(tc, found);
+  }
 }
 
 void Test_pet_persistence_legacy_schema_migration_is_idempotent(CuTest *tc)

--- a/unittests/CuTest/test_gameplay_e2e.c
+++ b/unittests/CuTest/test_gameplay_e2e.c
@@ -1026,6 +1026,7 @@ void Test_gameplay_e2e_player_file_round_trip(CuTest *tc)
   int load_result;
   int loaded_level;
   int loaded_gold;
+  int loaded_race;
   int loaded_boarding;
   int legacy_loaded_boarding;
   int restore_result;
@@ -1066,6 +1067,7 @@ void Test_gameplay_e2e_player_file_round_trip(CuTest *tc)
   GET_PFILEPOS(source) = 0;
   GET_IDNUM(source) = 4242;
   GET_LEVEL(source) = 7;
+  GET_REAL_RACE(source) = RACE_YUAN_TI;
   GET_GOLD(source) = 12345;
   SET_ABILITY(source, ABILITY_BOARDING, 9);
   GET_FACTION_STANDING(source, 1) = 111;
@@ -1097,6 +1099,7 @@ void Test_gameplay_e2e_player_file_round_trip(CuTest *tc)
   load_result = -1;
   loaded_level = -1;
   loaded_gold = -1;
+  loaded_race = RACE_UNDEFINED;
   loaded_boarding = -1;
   legacy_loaded_boarding = -1;
   loaded_faction_one = 0;
@@ -1125,6 +1128,7 @@ void Test_gameplay_e2e_player_file_round_trip(CuTest *tc)
       {
         loaded_level = GET_LEVEL(loaded);
         loaded_gold = GET_GOLD(loaded);
+        loaded_race = GET_REAL_RACE(loaded);
         loaded_boarding = GET_ABILITY(loaded, ABILITY_BOARDING);
         loaded_faction_one = GET_FACTION_STANDING(loaded, 1);
         loaded_faction_two = GET_FACTION_STANDING(loaded, 2);
@@ -1163,6 +1167,7 @@ void Test_gameplay_e2e_player_file_round_trip(CuTest *tc)
   CuAssertTrue(tc, loaded_name_matches);
   CuAssertIntEquals(tc, 7, loaded_level);
   CuAssertIntEquals(tc, 12345, loaded_gold);
+  CuAssertIntEquals(tc, RACE_YUAN_TI, loaded_race);
   CuAssertIntEquals(tc, 9, loaded_boarding);
   CuAssertTrue(tc, legacy_file_ready);
   CuAssertIntEquals(tc, 0, legacy_loaded_boarding);

--- a/unittests/CuTest/test_race_equivalence.c
+++ b/unittests/CuTest/test_race_equivalence.c
@@ -1,0 +1,171 @@
+#include "CuTest.h"
+
+#include <string.h>
+
+#include "../../src/conf.h"
+#include "../../src/sysdep.h"
+#include "../../src/structs.h"
+#include "../../src/utils.h"
+#include "../../src/character/class.h"
+#include "../../src/character/race.h"
+#include "../../src/magic/spells.h"
+
+static void ensure_race_equivalence_registry(void)
+{
+  static bool initialized = FALSE;
+
+  if (!initialized)
+  {
+    assign_races();
+    initialized = TRUE;
+  }
+}
+
+static int count_racial_feat(int race, int feat)
+{
+  struct race_feat_assign *assignment = NULL;
+  int count = 0;
+
+  for (assignment = race_list[race].featassign_list; assignment != NULL;
+       assignment = assignment->next)
+    if (assignment->feat_num == feat)
+      count++;
+
+  return count;
+}
+
+void TestRaceEquivalenceIdsAreUniqueAndRepresentable(CuTest *tc)
+{
+  struct char_data ch;
+
+  memset(&ch, 0, sizeof(ch));
+  GET_REAL_RACE(&ch) = RACE_YUAN_TI;
+
+  CuAssertTrue(tc, sizeof(ch.player.race) >= 2);
+  CuAssertIntEquals(tc, 28, RACE_HALF_OGRE);
+  CuAssertIntEquals(tc, 114, RACE_MYCONID);
+  CuAssertIntEquals(tc, 149, RACE_WEMIC);
+  CuAssertIntEquals(tc, 150, RACE_HALF_ILLITHID);
+  CuAssertIntEquals(tc, 151, RACE_YUAN_TI);
+  CuAssertIntEquals(tc, RACE_YUAN_TI, GET_REAL_RACE(&ch));
+  CuAssertTrue(tc, RACE_WEMIC != RACE_HALF_ILLITHID);
+  CuAssertTrue(tc, RACE_HALF_ILLITHID != RACE_YUAN_TI);
+  CuAssertTrue(tc, RACE_YUAN_TI < NUM_EXTENDED_RACES);
+}
+
+void TestRaceEquivalenceRegistryMatchesApprovedTiers(CuTest *tc)
+{
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  int count = 0;
+  int race = 0;
+  size_t i = 0;
+
+  ensure_race_equivalence_registry();
+
+  for (race = 0; race < NUM_EXTENDED_RACES; race++)
+    if (race_is_creation_eligible(race))
+      count++;
+  CuAssertIntEquals(tc, NUM_CREATION_RACES, count);
+
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+  {
+    CuAssertTrue(tc, race_list[races[i]].is_pc);
+    CuAssertTrue(tc, race_is_creation_eligible(races[i]));
+    CuAssertPtrNotNull(tc, race_list[races[i]].descrip);
+    CuAssertTrue(tc, race_list[races[i]].racial_language >= SKILL_LANG_COMMON);
+  }
+
+  CuAssertTrue(tc, !race_is_creation_eligible(RACE_LICH));
+  CuAssertTrue(tc, !race_is_creation_eligible(RACE_VAMPIRE));
+  CuAssertIntEquals(tc, 1, race_list[RACE_WEMIC].epic_adv);
+  CuAssertIntEquals(tc, 1, race_list[RACE_HALF_OGRE].epic_adv);
+  CuAssertIntEquals(tc, 1, race_list[RACE_YUAN_TI].epic_adv);
+  CuAssertIntEquals(tc, 2, race_list[RACE_HALF_ILLITHID].epic_adv);
+  CuAssertIntEquals(tc, 2, race_list[RACE_MYCONID].epic_adv);
+  CuAssertIntEquals(tc, 1000, race_list[RACE_WEMIC].unlock_cost);
+  CuAssertIntEquals(tc, 30000, race_list[RACE_HALF_ILLITHID].unlock_cost);
+}
+
+void TestRaceEquivalenceStatsSizesAndFamilies(CuTest *tc)
+{
+  struct char_data ch;
+
+  ensure_race_equivalence_registry();
+  memset(&ch, 0, sizeof(ch));
+
+  CuAssertIntEquals(tc, 8, get_race_stat(RACE_WEMIC, R_STR_MOD));
+  CuAssertIntEquals(tc, 4, get_race_stat(RACE_WEMIC, R_CON_MOD));
+  CuAssertIntEquals(tc, 6, get_race_stat(RACE_HALF_OGRE, R_STR_MOD));
+  CuAssertIntEquals(tc, -2, get_race_stat(RACE_HALF_OGRE, R_DEX_MOD));
+  CuAssertIntEquals(tc, 4, get_race_stat(RACE_HALF_ILLITHID, R_INTEL_MOD));
+  CuAssertIntEquals(tc, 2, get_race_stat(RACE_YUAN_TI, R_CHA_MOD));
+  CuAssertIntEquals(tc, 8, get_race_stat(RACE_MYCONID, R_STR_MOD));
+  CuAssertIntEquals(tc, -4, get_race_stat(RACE_MYCONID, R_DEX_MOD));
+  CuAssertIntEquals(tc, SIZE_LARGE, race_list[RACE_WEMIC].size);
+  CuAssertIntEquals(tc, SIZE_LARGE, race_list[RACE_HALF_OGRE].size);
+  CuAssertIntEquals(tc, SIZE_MEDIUM, race_list[RACE_HALF_ILLITHID].size);
+  CuAssertIntEquals(tc, SIZE_LARGE, race_list[RACE_MYCONID].size);
+
+  GET_REAL_RACE(&ch) = RACE_WEMIC;
+  CuAssertTrue(tc, IS_MONSTROUS_HUMANOID(&ch));
+  CuAssertTrue(tc, is_furry(RACE_WEMIC));
+  GET_REAL_RACE(&ch) = RACE_HALF_OGRE;
+  CuAssertTrue(tc, IS_GIANT(&ch));
+  GET_REAL_RACE(&ch) = RACE_HALF_ILLITHID;
+  CuAssertTrue(tc, IS_ABERRATION(&ch));
+  GET_REAL_RACE(&ch) = RACE_YUAN_TI;
+  CuAssertTrue(tc, IS_MONSTROUS_HUMANOID(&ch));
+  CuAssertTrue(tc, has_scales(RACE_YUAN_TI));
+  GET_REAL_RACE(&ch) = RACE_MYCONID;
+  CuAssertTrue(tc, IS_PLANT(&ch));
+  CuAssertTrue(tc, race_has_no_hair(RACE_MYCONID));
+  CuAssertTrue(tc, !IS_HUMANOID(&ch));
+}
+
+void TestRaceEquivalenceParsersAndRacialFeats(CuTest *tc)
+{
+  ensure_race_equivalence_registry();
+
+  CuAssertIntEquals(tc, RACE_WEMIC, parse_race_long("Wemic"));
+  CuAssertIntEquals(tc, RACE_HALF_OGRE, parse_race_long("Half-Ogre"));
+  CuAssertIntEquals(tc, RACE_HALF_ILLITHID, parse_race_long("Half-Illithid"));
+  CuAssertIntEquals(tc, RACE_HALF_ILLITHID, parse_race_long("Illithid"));
+  CuAssertIntEquals(tc, RACE_YUAN_TI, parse_race_long("Yuan-Ti"));
+  CuAssertIntEquals(tc, RACE_MYCONID, parse_race_long("Myconid"));
+  CuAssertIntEquals(tc, RACE_MYCONID, parse_race_long("Mycanoid"));
+
+  CuAssertIntEquals(tc, 1, count_racial_feat(RACE_WEMIC, FEAT_CLAWS_AND_BITE));
+  CuAssertIntEquals(tc, 2, count_racial_feat(RACE_HALF_OGRE, FEAT_ARMOR_SKIN));
+  CuAssertIntEquals(tc, 1, count_racial_feat(RACE_HALF_ILLITHID, FEAT_SLA_LEVITATE));
+  CuAssertIntEquals(tc, 3, count_racial_feat(RACE_HALF_ILLITHID, FEAT_ARMOR_SKIN));
+  CuAssertIntEquals(tc, 1, count_racial_feat(RACE_YUAN_TI, FEAT_POISON_BITE));
+  CuAssertIntEquals(tc, 1, count_racial_feat(RACE_YUAN_TI, FEAT_POISON_IMMUNITY));
+  CuAssertIntEquals(tc, 4, count_racial_feat(RACE_MYCONID, FEAT_ARMOR_SKIN));
+  CuAssertIntEquals(tc, 1, count_racial_feat(RACE_MYCONID, FEAT_PARALYSIS_IMMUNITY));
+}
+
+void TestRaceEquivalenceExperienceMultipliers(CuTest *tc)
+{
+  struct char_data ch;
+  long normal = 0;
+  int old_multiplier = CONFIG_EXPERIENCE_MULTIPLIER;
+
+  memset(&ch, 0, sizeof(ch));
+  GET_CLASS(&ch) = CLASS_WARRIOR;
+  CONFIG_EXPERIENCE_MULTIPLIER = 100;
+
+  GET_REAL_RACE(&ch) = RACE_HUMAN;
+  normal = level_exp(&ch, 10);
+  GET_REAL_RACE(&ch) = RACE_WEMIC;
+  CuAssertTrue(tc, level_exp(&ch, 10) == normal * 2);
+  GET_REAL_RACE(&ch) = RACE_HALF_OGRE;
+  CuAssertTrue(tc, level_exp(&ch, 10) == normal * 2);
+  GET_REAL_RACE(&ch) = RACE_YUAN_TI;
+  CuAssertTrue(tc, level_exp(&ch, 10) == normal * 2);
+  GET_REAL_RACE(&ch) = RACE_HALF_ILLITHID;
+  CuAssertTrue(tc, level_exp(&ch, 10) == normal * 7);
+  GET_REAL_RACE(&ch) = RACE_MYCONID;
+  CuAssertTrue(tc, level_exp(&ch, 10) == normal * 7);
+
+  CONFIG_EXPERIENCE_MULTIPLIER = old_multiplier;
+}

--- a/unittests/CuTest/test_race_equivalence.c
+++ b/unittests/CuTest/test_race_equivalence.c
@@ -6,10 +6,14 @@
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"
+#include "../../src/act.h"
+#include "../../src/interpreter.h"
 #include "../../src/magic/spells.h"
 #include "../../src/character/class.h"
 #include "../../src/character/feats.h"
+#include "../../src/character/premadebuilds.h"
 #include "../../src/character/race.h"
+#include "../../src/net/protocol.h"
 
 static void ensure_race_equivalence_registry(void)
 {
@@ -48,6 +52,21 @@ static int count_racial_feat(int race, int feat)
       count++;
 
   return count;
+}
+
+static void cleanup_race_equivalence_descriptor(struct descriptor_data *descriptor)
+{
+  if (descriptor->pProtocol != NULL)
+  {
+    ProtocolDestroy(descriptor->pProtocol);
+    descriptor->pProtocol = NULL;
+  }
+  if (descriptor->large_outbuf != NULL)
+  {
+    free(descriptor->large_outbuf->text);
+    free(descriptor->large_outbuf);
+    descriptor->large_outbuf = NULL;
+  }
 }
 
 void TestRaceEquivalenceIdsAreUniqueAndRepresentable(CuTest *tc)
@@ -200,6 +219,139 @@ void TestRaceEquivalenceCreationUnlockPolicy(CuTest *tc)
   CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, RACE_VAMPIRE));
   CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, -1));
   CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, NUM_EXTENDED_RACES));
+}
+
+void TestRaceEquivalenceTerminalCreationPolicy(CuTest *tc)
+{
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+  char input[MAX_INPUT_LENGTH];
+  size_t i = 0;
+
+  ensure_race_equivalence_registry();
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+  descriptor.pProtocol = ProtocolCreate();
+  CuAssertPtrNotNull(tc, descriptor.pProtocol);
+  if (descriptor.pProtocol == NULL)
+    return;
+
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+    account.races[i] = races[i];
+  STATE(&descriptor) = CON_QSEX;
+  snprintf(input, sizeof(input), "m");
+  nanny(&descriptor, input);
+  CuAssertIntEquals(tc, CON_QRACE, STATE(&descriptor));
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+    CuAssertPtrNotNull(tc, strstr(descriptor.output, race_list[races[i]].type));
+  CuAssertTrue(tc, strstr(descriptor.output, "\r\nLich\r\n") == NULL);
+  CuAssertTrue(tc, strstr(descriptor.output, "\r\nVampire\r\n") == NULL);
+  cleanup_race_equivalence_descriptor(&descriptor);
+
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+  {
+    init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+    descriptor.pProtocol = ProtocolCreate();
+    CuAssertPtrNotNull(tc, descriptor.pProtocol);
+    if (descriptor.pProtocol == NULL)
+      return;
+    account.races[0] = races[i];
+    GET_REAL_RACE(&ch) = RACE_UNDEFINED;
+    STATE(&descriptor) = CON_QRACE;
+    snprintf(input, sizeof(input), "%s", race_list[races[i]].type);
+    nanny(&descriptor, input);
+    CuAssertIntEquals(tc, races[i], GET_REAL_RACE(&ch));
+    CuAssertIntEquals(tc, CON_QRACE_HELP, STATE(&descriptor));
+    cleanup_race_equivalence_descriptor(&descriptor);
+  }
+
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+  descriptor.pProtocol = ProtocolCreate();
+  CuAssertPtrNotNull(tc, descriptor.pProtocol);
+  if (descriptor.pProtocol == NULL)
+    return;
+  GET_REAL_RACE(&ch) = RACE_UNDEFINED;
+  STATE(&descriptor) = CON_QRACE;
+  snprintf(input, sizeof(input), "wemic");
+  nanny(&descriptor, input);
+  CuAssertIntEquals(tc, RACE_UNDEFINED, GET_REAL_RACE(&ch));
+  CuAssertIntEquals(tc, CON_QRACE, STATE(&descriptor));
+  CuAssertPtrNotNull(tc, strstr(descriptor.output, "not unlocked"));
+
+  account.races[0] = RACE_LICH;
+  descriptor.output[0] = '\0';
+  descriptor.bufptr = 0;
+  descriptor.bufspace = SMALL_BUFSIZE - 1;
+  snprintf(input, sizeof(input), "lich");
+  nanny(&descriptor, input);
+  CuAssertIntEquals(tc, RACE_UNDEFINED, GET_REAL_RACE(&ch));
+  CuAssertIntEquals(tc, CON_QRACE, STATE(&descriptor));
+  CuAssertPtrNotNull(tc, strstr(descriptor.output, "cannot be selected"));
+  cleanup_race_equivalence_descriptor(&descriptor);
+}
+
+void TestRaceEquivalenceAccountExperiencePurchase(CuTest *tc)
+{
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  const int costs[] = {1000, 1000, 30000, 1000, 30000};
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+  char input[MAX_INPUT_LENGTH];
+  size_t i = 0;
+
+  ensure_race_equivalence_registry();
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+  {
+    init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+    descriptor.pProtocol = ProtocolCreate();
+    CuAssertPtrNotNull(tc, descriptor.pProtocol);
+    if (descriptor.pProtocol == NULL)
+      return;
+    account.experience = costs[i];
+    snprintf(input, sizeof(input), "race %s", race_list[races[i]].type);
+    do_accexp(&ch, input, 0, 0);
+    CuAssertIntEquals(tc, races[i], account.races[0]);
+    CuAssertIntEquals(tc, 0, account.experience);
+    CuAssertTrue(tc, has_unlocked_race(&ch, races[i]));
+    CuAssertPtrNotNull(tc, strstr(descriptor.output, "You have unlocked"));
+    cleanup_race_equivalence_descriptor(&descriptor);
+  }
+}
+
+void TestRaceEquivalencePremadeBuildStats(CuTest *tc)
+{
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  const int warrior_base_stats[] = {16, 16, 14, 10, 14, 8};
+  struct char_data ch;
+  struct player_special_data specials;
+  size_t i = 0;
+
+  ensure_race_equivalence_registry();
+  memset(&ch, 0, sizeof(ch));
+  memset(&specials, 0, sizeof(specials));
+  ch.player_specials = &specials;
+
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+  {
+    GET_REAL_RACE(&ch) = races[i];
+    set_premade_stats(&ch, CLASS_WARRIOR, 1);
+    CuAssertIntEquals(tc, warrior_base_stats[0] + get_race_stat(races[i], R_STR_MOD),
+                      GET_REAL_STR(&ch));
+    CuAssertIntEquals(tc, warrior_base_stats[1] + get_race_stat(races[i], R_CON_MOD),
+                      GET_REAL_CON(&ch));
+    CuAssertIntEquals(tc, warrior_base_stats[2] + get_race_stat(races[i], R_INTEL_MOD),
+                      GET_REAL_INT(&ch));
+    CuAssertIntEquals(tc, warrior_base_stats[3] + get_race_stat(races[i], R_WIS_MOD),
+                      GET_REAL_WIS(&ch));
+    CuAssertIntEquals(tc, warrior_base_stats[4] + get_race_stat(races[i], R_DEX_MOD),
+                      GET_REAL_DEX(&ch));
+    CuAssertIntEquals(tc, warrior_base_stats[5] + get_race_stat(races[i], R_CHA_MOD),
+                      GET_REAL_CHA(&ch));
+  }
 }
 
 void TestRaceEquivalenceLevelOneFeatGrants(CuTest *tc)

--- a/unittests/CuTest/test_race_equivalence.c
+++ b/unittests/CuTest/test_race_equivalence.c
@@ -7,6 +7,8 @@
 #include "../../src/structs.h"
 #include "../../src/utils.h"
 #include "../../src/act.h"
+#include "../../src/db.h"
+#include "../../src/handler.h"
 #include "../../src/interpreter.h"
 #include "../../src/magic/spells.h"
 #include "../../src/character/class.h"
@@ -67,6 +69,18 @@ static void cleanup_race_equivalence_descriptor(struct descriptor_data *descript
     free(descriptor->large_outbuf);
     descriptor->large_outbuf = NULL;
   }
+}
+
+static void init_race_equipment_object(struct obj_data *obj, const char *name, int wear_flag)
+{
+  clear_object(obj);
+  obj->name = (char *)name;
+  obj->short_description = (char *)name;
+  obj->description = (char *)name;
+  GET_OBJ_TYPE(obj) = ITEM_ARMOR;
+  GET_OBJ_SIZE(obj) = SIZE_LARGE;
+  SET_BIT_AR(GET_OBJ_WEAR(obj), ITEM_WEAR_TAKE);
+  SET_BIT_AR(GET_OBJ_WEAR(obj), wear_flag);
 }
 
 void TestRaceEquivalenceIdsAreUniqueAndRepresentable(CuTest *tc)
@@ -183,6 +197,7 @@ void TestRaceEquivalenceParsersAndRacialFeats(CuTest *tc)
   CuAssertIntEquals(tc, RACE_MYCONID, parse_race_long("Mycanoid"));
 
   CuAssertIntEquals(tc, 1, count_racial_feat(RACE_WEMIC, FEAT_CLAWS_AND_BITE));
+  CuAssertIntEquals(tc, 1, count_racial_feat(RACE_WEMIC, FEAT_LEONINE_FRAME));
   CuAssertIntEquals(tc, 2, count_racial_feat(RACE_HALF_OGRE, FEAT_ARMOR_SKIN));
   CuAssertIntEquals(tc, 1, count_racial_feat(RACE_HALF_ILLITHID, FEAT_SLA_LEVITATE));
   CuAssertIntEquals(tc, 3, count_racial_feat(RACE_HALF_ILLITHID, FEAT_ARMOR_SKIN));
@@ -369,6 +384,7 @@ void TestRaceEquivalenceLevelOneFeatGrants(CuTest *tc)
   GET_REAL_RACE(&ch) = RACE_WEMIC;
   process_race_level_feats(&ch);
   CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_CLAWS_AND_BITE));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_LEONINE_FRAME));
 
   memset(ch.char_specials.saved.feats, 0, sizeof(ch.char_specials.saved.feats));
   GET_REAL_RACE(&ch) = RACE_HALF_OGRE;
@@ -399,6 +415,88 @@ void TestRaceEquivalenceLevelOneFeatGrants(CuTest *tc)
   GET_LEVEL(&ch) = 2;
   process_race_level_feats(&ch);
   CuAssertIntEquals(tc, 4, HAS_REAL_FEAT(&ch, FEAT_ARMOR_SKIN));
+}
+
+void TestRaceAnatomyWearSlotPolicy(CuTest *tc)
+{
+  const int trelux_restricted_slots[] = {
+      WEAR_FINGER_R, WEAR_FINGER_L, WEAR_HANDS,  WEAR_SHIELD,  WEAR_WIELD_1, WEAR_WIELD_OFFHAND,
+      WEAR_WIELD_2H, WEAR_HOLD_1,   WEAR_HOLD_2, WEAR_HOLD_2H, WEAR_LEGS,    WEAR_FEET,
+  };
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+  size_t i;
+
+  ensure_race_equivalence_registry();
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+
+  GET_REAL_RACE(&ch) = RACE_HUMAN;
+  for (i = 0; i < NUM_WEARS; i++)
+    CuAssertTrue(tc, character_can_use_wear_slot(&ch, (int)i));
+
+  GET_REAL_RACE(&ch) = RACE_WEMIC;
+  CuAssertTrue(tc, !character_can_use_wear_slot(&ch, WEAR_LEGS));
+  CuAssertTrue(tc, !character_can_use_wear_slot(&ch, WEAR_FEET));
+  CuAssertTrue(tc, character_can_use_wear_slot(&ch, WEAR_ANKLE_R));
+  CuAssertTrue(tc, character_can_use_wear_slot(&ch, WEAR_HANDS));
+  CuAssertPtrNotNull(tc, strstr(character_wear_slot_restriction(&ch, WEAR_LEGS), "leonine"));
+
+  GET_REAL_RACE(&ch) = RACE_TRELUX;
+  GET_DISGUISE_RACE(&ch) = RACE_HUMAN;
+  for (i = 0; i < sizeof(trelux_restricted_slots) / sizeof(trelux_restricted_slots[0]); i++)
+    CuAssertTrue(tc, !character_can_use_wear_slot(&ch, trelux_restricted_slots[i]));
+  CuAssertTrue(tc, character_can_use_wear_slot(&ch, WEAR_ARMS));
+  CuAssertTrue(tc, character_can_use_wear_slot(&ch, WEAR_WRIST_R));
+  CuAssertTrue(tc, character_can_use_wear_slot(&ch, WEAR_ANKLE_R));
+  CuAssertTrue(tc, !character_can_use_wear_slot(NULL, WEAR_BODY));
+  CuAssertTrue(tc, !character_can_use_wear_slot(&ch, -1));
+  CuAssertTrue(tc, !character_can_use_wear_slot(&ch, NUM_WEARS));
+}
+
+void TestRaceAnatomyRestrictionsCoverEquipmentEntryPaths(CuTest *tc)
+{
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+  struct obj_data pants;
+  struct obj_data boots;
+  struct obj_data gloves;
+
+  ensure_race_equivalence_registry();
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+  descriptor.pProtocol = ProtocolCreate();
+  CuAssertPtrNotNull(tc, descriptor.pProtocol);
+  if (descriptor.pProtocol == NULL)
+    return;
+  GET_REAL_RACE(&ch) = RACE_WEMIC;
+  GET_REAL_SIZE(&ch) = SIZE_LARGE;
+  ch.points.size = SIZE_LARGE;
+
+  init_race_equipment_object(&pants, "a pair of test pants", ITEM_WEAR_LEGS);
+  obj_to_char(&pants, &ch);
+  CuAssertIntEquals(tc, WEAR_LEGS, find_eq_pos(&ch, &pants, NULL));
+  perform_wear(&ch, &pants, WEAR_LEGS);
+  CuAssertPtrEquals(tc, NULL, GET_EQ(&ch, WEAR_LEGS));
+  CuAssertPtrEquals(tc, &ch, pants.carried_by);
+  CuAssertPtrNotNull(tc, strstr(descriptor.output, "leonine frame"));
+  obj_from_char(&pants);
+
+  init_race_equipment_object(&boots, "a pair of test boots", ITEM_WEAR_FEET);
+  test_auto_equip_loaded_object(&ch, &boots, WEAR_FEET + 1);
+  CuAssertPtrEquals(tc, NULL, GET_EQ(&ch, WEAR_FEET));
+  CuAssertPtrEquals(tc, &ch, boots.carried_by);
+  obj_from_char(&boots);
+
+  GET_REAL_RACE(&ch) = RACE_TRELUX;
+  init_race_equipment_object(&gloves, "a pair of test gloves", ITEM_WEAR_HANDS);
+  equip_char(&ch, &gloves, WEAR_HANDS);
+  CuAssertPtrEquals(tc, NULL, GET_EQ(&ch, WEAR_HANDS));
+  CuAssertPtrEquals(tc, &ch, gloves.carried_by);
+  obj_from_char(&gloves);
+  cleanup_race_equivalence_descriptor(&descriptor);
 }
 
 void TestRaceEquivalenceHitPointPolicyAndDerivedRebuild(CuTest *tc)

--- a/unittests/CuTest/test_race_equivalence.c
+++ b/unittests/CuTest/test_race_equivalence.c
@@ -6,19 +6,35 @@
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"
-#include "../../src/character/class.h"
-#include "../../src/character/race.h"
 #include "../../src/magic/spells.h"
+#include "../../src/character/class.h"
+#include "../../src/character/feats.h"
+#include "../../src/character/race.h"
 
 static void ensure_race_equivalence_registry(void)
 {
-  static bool initialized = FALSE;
-
-  if (!initialized)
-  {
+  if (race_list[RACE_WEMIC].type == NULL)
     assign_races();
-    initialized = TRUE;
-  }
+  if (feat_list[FEAT_ARMOR_SKIN].name == NULL)
+    assign_feats();
+}
+
+static void init_race_equivalence_character(struct char_data *ch,
+                                            struct player_special_data *specials,
+                                            struct descriptor_data *descriptor,
+                                            struct account_data *account)
+{
+  memset(ch, 0, sizeof(*ch));
+  memset(specials, 0, sizeof(*specials));
+  memset(descriptor, 0, sizeof(*descriptor));
+  memset(account, 0, sizeof(*account));
+  ch->player_specials = specials;
+  ch->desc = descriptor;
+  descriptor->character = ch;
+  descriptor->account = account;
+  descriptor->output = descriptor->small_outbuf;
+  descriptor->bufspace = SMALL_BUFSIZE - 1;
+  IN_ROOM(ch) = NOWHERE;
 }
 
 static int count_racial_feat(int race, int feat)
@@ -56,6 +72,9 @@ void TestRaceEquivalenceIdsAreUniqueAndRepresentable(CuTest *tc)
 void TestRaceEquivalenceRegistryMatchesApprovedTiers(CuTest *tc)
 {
   const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  const int adjustments[] = {2, 2, 10, 2, 10};
+  const int costs[] = {1000, 1000, 30000, 1000, 30000};
+  const int tiers[] = {1, 1, 2, 1, 2};
   int count = 0;
   int race = 0;
   size_t i = 0;
@@ -73,53 +92,61 @@ void TestRaceEquivalenceRegistryMatchesApprovedTiers(CuTest *tc)
     CuAssertTrue(tc, race_is_creation_eligible(races[i]));
     CuAssertPtrNotNull(tc, race_list[races[i]].descrip);
     CuAssertTrue(tc, race_list[races[i]].racial_language >= SKILL_LANG_COMMON);
+    CuAssertIntEquals(tc, adjustments[i], race_list[races[i]].level_adjustment);
+    CuAssertIntEquals(tc, costs[i], race_list[races[i]].unlock_cost);
+    CuAssertIntEquals(tc, tiers[i], race_list[races[i]].epic_adv);
+    CuAssertTrue(tc, valid_class_race_alignment(CLASS_WARRIOR, races[i]));
   }
 
   CuAssertTrue(tc, !race_is_creation_eligible(RACE_LICH));
   CuAssertTrue(tc, !race_is_creation_eligible(RACE_VAMPIRE));
-  CuAssertIntEquals(tc, 1, race_list[RACE_WEMIC].epic_adv);
-  CuAssertIntEquals(tc, 1, race_list[RACE_HALF_OGRE].epic_adv);
-  CuAssertIntEquals(tc, 1, race_list[RACE_YUAN_TI].epic_adv);
-  CuAssertIntEquals(tc, 2, race_list[RACE_HALF_ILLITHID].epic_adv);
-  CuAssertIntEquals(tc, 2, race_list[RACE_MYCONID].epic_adv);
-  CuAssertIntEquals(tc, 1000, race_list[RACE_WEMIC].unlock_cost);
-  CuAssertIntEquals(tc, 30000, race_list[RACE_HALF_ILLITHID].unlock_cost);
 }
 
 void TestRaceEquivalenceStatsSizesAndFamilies(CuTest *tc)
 {
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  const int expected_stats[][6] = {
+      {8, 4, -2, 2, 2, -2}, {6, 2, -2, 0, -2, -2},  {0, 0, 4, 4, 0, 4},
+      {0, 0, 2, 0, 2, 2},   {8, 6, -2, -2, -4, -4},
+  };
+  const int expected_sizes[] = {SIZE_LARGE, SIZE_LARGE, SIZE_MEDIUM, SIZE_MEDIUM, SIZE_LARGE};
+  const int expected_languages[] = {SKILL_LANG_COMMON, SKILL_LANG_GIANT, SKILL_LANG_ABERRATION,
+                                    SKILL_LANG_DRACONIC, SKILL_LANG_UNDERCOMMON};
   struct char_data ch;
+  struct char_data *character = &ch;
+  struct player_special_data specials;
+  size_t i = 0;
+  int stat = 0;
 
   ensure_race_equivalence_registry();
   memset(&ch, 0, sizeof(ch));
+  memset(&specials, 0, sizeof(specials));
+  ch.player_specials = &specials;
 
-  CuAssertIntEquals(tc, 8, get_race_stat(RACE_WEMIC, R_STR_MOD));
-  CuAssertIntEquals(tc, 4, get_race_stat(RACE_WEMIC, R_CON_MOD));
-  CuAssertIntEquals(tc, 6, get_race_stat(RACE_HALF_OGRE, R_STR_MOD));
-  CuAssertIntEquals(tc, -2, get_race_stat(RACE_HALF_OGRE, R_DEX_MOD));
-  CuAssertIntEquals(tc, 4, get_race_stat(RACE_HALF_ILLITHID, R_INTEL_MOD));
-  CuAssertIntEquals(tc, 2, get_race_stat(RACE_YUAN_TI, R_CHA_MOD));
-  CuAssertIntEquals(tc, 8, get_race_stat(RACE_MYCONID, R_STR_MOD));
-  CuAssertIntEquals(tc, -4, get_race_stat(RACE_MYCONID, R_DEX_MOD));
-  CuAssertIntEquals(tc, SIZE_LARGE, race_list[RACE_WEMIC].size);
-  CuAssertIntEquals(tc, SIZE_LARGE, race_list[RACE_HALF_OGRE].size);
-  CuAssertIntEquals(tc, SIZE_MEDIUM, race_list[RACE_HALF_ILLITHID].size);
-  CuAssertIntEquals(tc, SIZE_LARGE, race_list[RACE_MYCONID].size);
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+  {
+    for (stat = 0; stat < 6; stat++)
+      CuAssertIntEquals(tc, expected_stats[i][stat], get_race_stat(races[i], stat));
+    CuAssertIntEquals(tc, expected_sizes[i], race_list[races[i]].size);
+    CuAssertIntEquals(tc, expected_languages[i], race_list[races[i]].racial_language);
+  }
 
-  GET_REAL_RACE(&ch) = RACE_WEMIC;
-  CuAssertTrue(tc, IS_MONSTROUS_HUMANOID(&ch));
+  GET_REAL_RACE(character) = RACE_WEMIC;
+  CuAssertTrue(tc, IS_MONSTROUS_HUMANOID(character));
   CuAssertTrue(tc, is_furry(RACE_WEMIC));
-  GET_REAL_RACE(&ch) = RACE_HALF_OGRE;
-  CuAssertTrue(tc, IS_GIANT(&ch));
-  GET_REAL_RACE(&ch) = RACE_HALF_ILLITHID;
-  CuAssertTrue(tc, IS_ABERRATION(&ch));
-  GET_REAL_RACE(&ch) = RACE_YUAN_TI;
-  CuAssertTrue(tc, IS_MONSTROUS_HUMANOID(&ch));
+  GET_REAL_RACE(character) = RACE_HALF_OGRE;
+  CuAssertTrue(tc, IS_GIANT(character));
+  GET_REAL_RACE(character) = RACE_HALF_ILLITHID;
+  CuAssertTrue(tc, IS_ABERRATION(character));
+  CuAssertTrue(tc, race_has_no_hair(RACE_HALF_ILLITHID));
+  GET_REAL_RACE(character) = RACE_YUAN_TI;
+  CuAssertTrue(tc, IS_MONSTROUS_HUMANOID(character));
   CuAssertTrue(tc, has_scales(RACE_YUAN_TI));
-  GET_REAL_RACE(&ch) = RACE_MYCONID;
-  CuAssertTrue(tc, IS_PLANT(&ch));
+  CuAssertTrue(tc, race_has_no_hair(RACE_YUAN_TI));
+  GET_REAL_RACE(character) = RACE_MYCONID;
+  CuAssertTrue(tc, IS_PLANT(character));
   CuAssertTrue(tc, race_has_no_hair(RACE_MYCONID));
-  CuAssertTrue(tc, !IS_HUMANOID(&ch));
+  CuAssertTrue(tc, !IS_HUMANOID(character));
 }
 
 void TestRaceEquivalenceParsersAndRacialFeats(CuTest *tc)
@@ -127,7 +154,9 @@ void TestRaceEquivalenceParsersAndRacialFeats(CuTest *tc)
   ensure_race_equivalence_registry();
 
   CuAssertIntEquals(tc, RACE_WEMIC, parse_race_long("Wemic"));
+  CuAssertIntEquals(tc, RACE_WEMIC, parse_race_long("Barbarian"));
   CuAssertIntEquals(tc, RACE_HALF_OGRE, parse_race_long("Half-Ogre"));
+  CuAssertIntEquals(tc, RACE_HALF_OGRE, parse_race_long("Ogre"));
   CuAssertIntEquals(tc, RACE_HALF_ILLITHID, parse_race_long("Half-Illithid"));
   CuAssertIntEquals(tc, RACE_HALF_ILLITHID, parse_race_long("Illithid"));
   CuAssertIntEquals(tc, RACE_YUAN_TI, parse_race_long("Yuan-Ti"));
@@ -142,6 +171,126 @@ void TestRaceEquivalenceParsersAndRacialFeats(CuTest *tc)
   CuAssertIntEquals(tc, 1, count_racial_feat(RACE_YUAN_TI, FEAT_POISON_IMMUNITY));
   CuAssertIntEquals(tc, 4, count_racial_feat(RACE_MYCONID, FEAT_ARMOR_SKIN));
   CuAssertIntEquals(tc, 1, count_racial_feat(RACE_MYCONID, FEAT_PARALYSIS_IMMUNITY));
+}
+
+void TestRaceEquivalenceCreationUnlockPolicy(CuTest *tc)
+{
+  const int races[] = {RACE_WEMIC, RACE_HALF_OGRE, RACE_HALF_ILLITHID, RACE_YUAN_TI, RACE_MYCONID};
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+  size_t i = 0;
+
+  ensure_race_equivalence_registry();
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+
+  CuAssertTrue(tc, race_is_selectable_for_creation(&ch, RACE_HUMAN));
+  for (i = 0; i < sizeof(races) / sizeof(races[0]); i++)
+  {
+    CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, races[i]));
+    account.races[0] = races[i];
+    CuAssertTrue(tc, race_is_selectable_for_creation(&ch, races[i]));
+    account.races[0] = 0;
+  }
+
+  account.races[0] = RACE_LICH;
+  account.races[1] = RACE_VAMPIRE;
+  CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, RACE_LICH));
+  CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, RACE_VAMPIRE));
+  CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, -1));
+  CuAssertTrue(tc, !race_is_selectable_for_creation(&ch, NUM_EXTENDED_RACES));
+}
+
+void TestRaceEquivalenceLevelOneFeatGrants(CuTest *tc)
+{
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+
+  ensure_race_equivalence_registry();
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+  ch.desc = NULL;
+  GET_LEVEL(&ch) = 1;
+
+  GET_REAL_RACE(&ch) = RACE_WEMIC;
+  process_race_level_feats(&ch);
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_CLAWS_AND_BITE));
+
+  memset(ch.char_specials.saved.feats, 0, sizeof(ch.char_specials.saved.feats));
+  GET_REAL_RACE(&ch) = RACE_HALF_OGRE;
+  process_race_level_feats(&ch);
+  CuAssertIntEquals(tc, 2, HAS_REAL_FEAT(&ch, FEAT_ARMOR_SKIN));
+
+  memset(ch.char_specials.saved.feats, 0, sizeof(ch.char_specials.saved.feats));
+  GET_REAL_RACE(&ch) = RACE_HALF_ILLITHID;
+  process_race_level_feats(&ch);
+  CuAssertIntEquals(tc, 3, HAS_REAL_FEAT(&ch, FEAT_ARMOR_SKIN));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_SLA_LEVITATE));
+
+  memset(ch.char_specials.saved.feats, 0, sizeof(ch.char_specials.saved.feats));
+  GET_REAL_RACE(&ch) = RACE_YUAN_TI;
+  process_race_level_feats(&ch);
+  CuAssertIntEquals(tc, 2, HAS_REAL_FEAT(&ch, FEAT_ARMOR_SKIN));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_POISON_BITE));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_POISON_IMMUNITY));
+
+  memset(ch.char_specials.saved.feats, 0, sizeof(ch.char_specials.saved.feats));
+  GET_REAL_RACE(&ch) = RACE_MYCONID;
+  process_race_level_feats(&ch);
+  CuAssertIntEquals(tc, 4, HAS_REAL_FEAT(&ch, FEAT_ARMOR_SKIN));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_POISON_IMMUNITY));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_SLEEP_ENCHANTMENT_IMMUNITY));
+  CuAssertIntEquals(tc, 1, HAS_REAL_FEAT(&ch, FEAT_PARALYSIS_IMMUNITY));
+
+  GET_LEVEL(&ch) = 2;
+  process_race_level_feats(&ch);
+  CuAssertIntEquals(tc, 4, HAS_REAL_FEAT(&ch, FEAT_ARMOR_SKIN));
+}
+
+void TestRaceEquivalenceHitPointPolicyAndDerivedRebuild(CuTest *tc)
+{
+  struct char_data ch;
+  struct player_special_data specials;
+  struct descriptor_data descriptor;
+  struct account_data account;
+  int human_hp = 0;
+
+  ensure_race_equivalence_registry();
+  init_race_equivalence_character(&ch, &specials, &descriptor, &account);
+  GET_LEVEL(&ch) = 10;
+  GET_REAL_CON(&ch) = 10;
+  ch.aff_abils.con = 10;
+
+  GET_REAL_RACE(&ch) = RACE_HUMAN;
+  calculate_max_hp(&ch, FALSE);
+  human_hp = GET_MAX_HIT(&ch);
+
+  GET_REAL_RACE(&ch) = RACE_WEMIC;
+  calculate_max_hp(&ch, FALSE);
+  CuAssertIntEquals(tc, human_hp + 10, GET_MAX_HIT(&ch));
+  GET_REAL_RACE(&ch) = RACE_HALF_OGRE;
+  calculate_max_hp(&ch, FALSE);
+  CuAssertIntEquals(tc, human_hp + 20, GET_MAX_HIT(&ch));
+  GET_REAL_RACE(&ch) = RACE_HALF_ILLITHID;
+  calculate_max_hp(&ch, FALSE);
+  CuAssertIntEquals(tc, human_hp + 50, GET_MAX_HIT(&ch));
+  GET_REAL_RACE(&ch) = RACE_YUAN_TI;
+  calculate_max_hp(&ch, FALSE);
+  CuAssertIntEquals(tc, human_hp, GET_MAX_HIT(&ch));
+  GET_REAL_RACE(&ch) = RACE_MYCONID;
+  calculate_max_hp(&ch, FALSE);
+  CuAssertIntEquals(tc, human_hp + 50, GET_MAX_HIT(&ch));
+
+  CuAssertIntEquals(tc, 10, race_starting_hp_bonus(RACE_HALF_ILLITHID));
+  CuAssertIntEquals(tc, 10, race_starting_hp_bonus(RACE_MYCONID));
+  CuAssertIntEquals(tc, 0, race_starting_hp_bonus(RACE_WEMIC));
+  CuAssertIntEquals(tc, 4, race_hp_bonus_per_level(RACE_HALF_ILLITHID));
+  CuAssertIntEquals(tc, 4, race_hp_bonus_per_level(RACE_MYCONID));
+  CuAssertIntEquals(tc, 2, race_hp_bonus_per_level(RACE_HALF_OGRE));
+  CuAssertIntEquals(tc, 1, race_hp_bonus_per_level(RACE_WEMIC));
+  CuAssertIntEquals(tc, 0, race_hp_bonus_per_level(RACE_YUAN_TI));
 }
 
 void TestRaceEquivalenceExperienceMultipliers(CuTest *tc)

--- a/unittests/CuTest/test_web_onboarding.c
+++ b/unittests/CuTest/test_web_onboarding.c
@@ -107,6 +107,24 @@ static int has_control_bytes(const char *text)
   return 0;
 }
 
+static int payload_has_action(const char *payload, const char *action)
+{
+  const char *actions = NULL;
+  const char *actions_end = NULL;
+  const char *match = NULL;
+  char quoted_action[80];
+
+  actions = strstr(payload, "\"actions\":[");
+  if (actions == NULL)
+    return 0;
+  actions_end = strchr(actions, ']');
+  if (actions_end == NULL)
+    return 0;
+  snprintf(quoted_action, sizeof(quoted_action), "\"%s\"", action);
+  match = strstr(actions, quoted_action);
+  return match != NULL && match < actions_end;
+}
+
 struct expected_background_identity
 {
   int background;
@@ -1365,14 +1383,24 @@ static void cleanup_editor_descriptor(struct descriptor_data *d)
 
 void TestPopulatedRaceCatalogStaysWithinTheOnboardingWireBudget(CuTest *tc)
 {
+  const char *expected_media_keys[] = {"race/wemic", "race/half-ogre", "race/half-illithid",
+                                       "race/yuan-ti", "race/myconid"};
   struct descriptor_data d;
   struct char_data ch;
   struct player_special_data specials;
   struct account_data account;
   char payload[WEB_ONBOARDING_MAX_PAYLOAD + 1];
+  bool found_media_keys[5] = {FALSE};
+  int visited_pages = 0;
+  size_t index = 0;
 
   memset(&account, 0, sizeof(account));
   assign_races();
+  account.races[0] = RACE_WEMIC;
+  account.races[1] = RACE_HALF_OGRE;
+  account.races[2] = RACE_HALF_ILLITHID;
+  account.races[3] = RACE_YUAN_TI;
+  account.races[4] = RACE_MYCONID;
   CuAssertTrue(tc, init_editor_descriptor(&d, &ch, &specials, CON_QRACE));
   if (d.pProtocol == NULL)
     return;
@@ -1382,16 +1410,31 @@ void TestPopulatedRaceCatalogStaysWithinTheOnboardingWireBudget(CuTest *tc)
   CuAssertTrue(tc, strlen(payload) < WEB_ONBOARDING_MAX_PAYLOAD);
   CuAssertPtrNotNull(tc, strstr(payload, "\"screen\":\"race\""));
   CuAssertPtrNotNull(tc, strstr(payload, "\"page\":{\"index\":0"));
-  CuAssertPtrNotNull(tc, strstr(payload, "\"next-page\""));
+  CuAssertTrue(tc, payload_has_action(payload, "next-page"));
   CuAssertPtrNotNull(tc, strstr(payload, "\"description\":"));
   CuAssertPtrNotNull(tc, strstr(payload, "\"inspectable\":true"));
   CuAssertTrue(tc, strstr(payload, "\"cancel\"") == NULL);
 
-  CuAssertTrue(tc, web_onboarding_handle_catalog_control(&d, "__onboarding-next__"));
-  CuAssertTrue(tc, web_onboarding_build_payload(&d, payload, sizeof(payload)));
-  CuAssertTrue(tc, strlen(payload) < WEB_ONBOARDING_MAX_PAYLOAD);
-  CuAssertPtrNotNull(tc, strstr(payload, "\"page\":{\"index\":1"));
-  CuAssertPtrNotNull(tc, strstr(payload, "\"previous-page\""));
+  for (;;)
+  {
+    visited_pages++;
+    for (index = 0; index < sizeof(expected_media_keys) / sizeof(expected_media_keys[0]); index++)
+      if (strstr(payload, expected_media_keys[index]) != NULL)
+        found_media_keys[index] = TRUE;
+
+    if (!payload_has_action(payload, "next-page"))
+      break;
+    CuAssertTrue(tc, web_onboarding_handle_catalog_control(&d, "__onboarding-next__"));
+    CuAssertTrue(tc, web_onboarding_build_payload(&d, payload, sizeof(payload)));
+    CuAssertTrue(tc, strlen(payload) < WEB_ONBOARDING_MAX_PAYLOAD);
+    CuAssertTrue(tc, json_is_balanced(payload));
+    CuAssertTrue(tc, payload_has_action(payload, "previous-page"));
+    CuAssertTrue(tc, visited_pages < NUM_EXTENDED_RACES);
+  }
+
+  CuAssertTrue(tc, visited_pages > 1);
+  for (index = 0; index < sizeof(expected_media_keys) / sizeof(expected_media_keys[0]); index++)
+    CuAssertTrue(tc, found_media_keys[index]);
 
   /*
    * Protocol v1 has no pagination contract. Preserve its complete selectable

--- a/unittests/CuTest/test_web_onboarding.c
+++ b/unittests/CuTest/test_web_onboarding.c
@@ -484,12 +484,17 @@ void TestWebOnboardingMediaKeysAreStableAndBounded(CuTest *tc)
    * token spelling. */
   CuAssertStrEquals(tc, "race/tiefling", web_onboarding_race_media_key(RACE_TIEFLING));
   CuAssertStrEquals(tc, "race/human", web_onboarding_race_media_key(RACE_HUMAN));
+  CuAssertStrEquals(tc, "race/wemic", web_onboarding_race_media_key(RACE_WEMIC));
+  CuAssertStrEquals(tc, "race/half-ogre", web_onboarding_race_media_key(RACE_HALF_OGRE));
+  CuAssertStrEquals(tc, "race/half-illithid", web_onboarding_race_media_key(RACE_HALF_ILLITHID));
+  CuAssertStrEquals(tc, "race/yuan-ti", web_onboarding_race_media_key(RACE_YUAN_TI));
+  CuAssertStrEquals(tc, "race/myconid", web_onboarding_race_media_key(RACE_MYCONID));
   CuAssertStrEquals(tc, "class/wizard", web_onboarding_class_media_key(CLASS_WIZARD));
 
   /* Out-of-range and prestige entries resolve to the generic fallbacks rather
    * than reading past the table. */
   CuAssertStrEquals(tc, "race/fallback", web_onboarding_race_media_key(-1));
-  CuAssertStrEquals(tc, "race/fallback", web_onboarding_race_media_key(NUM_RACES));
+  CuAssertStrEquals(tc, "race/fallback", web_onboarding_race_media_key(NUM_EXTENDED_RACES));
   CuAssertStrEquals(tc, "class/fallback", web_onboarding_class_media_key(-1));
   CuAssertStrEquals(tc, "class/fallback", web_onboarding_class_media_key(NUM_CLASSES));
   CuAssertStrEquals(tc, "class/fallback", web_onboarding_class_media_key(CLASS_WEAPON_MASTER));


### PR DESCRIPTION
## Summary

- implement the five missing Realms of Luminari race equivalents: Wemic, Half-Ogre, Half-Illithid, Yuan-Ti, and Myconid
- unify sparse race registration, creation eligibility, account-XP unlocks, persistence, terminal creation, and web onboarding
- add complete racial statistics, feat packages, hit-point progression, aliases, help content, and database migrations
- add per-race equipment-slot anatomy policy, including Wemic Leonine Frame restrictions and hardened Trelux restrictions
- cover normal wear, saved equipment, scripts, and low-level equipment placement through one enforcement boundary

## Why

The conversion audit found five RoL player-race archetypes without complete playable Luminari equivalents. Existing race selection also assumed a mostly contiguous ID space, while several required identities use sparse persistent IDs. Wemic and Trelux anatomy additionally needed equipment restrictions that could not be bypassed through non-command equip paths.

## Player and developer impact

Players can unlock and create the five mapped races through the supported terminal and web flows. Their racial progression, aliases, help, and persistence now agree. Wemics cannot wear leg or foot equipment but retain ankle slots; Trelux restrictions now consistently cover rings, gloves, shields, wield/hold slots, legs, and feet.

Race definitions now own per-slot anatomy restrictions and player-facing rejection text. The command path and low-level equip boundary share this policy, making it reusable for future non-humanoid body plans.

## Validation

- full production-linked CuTest suite: 899/899 passed with isolated MariaDB and world fixtures
- complete `make test` auxiliary checks passed
- `make install` succeeded and removed the root-level binary
- all Wemic and Trelux help migrations passed idempotence, content, keyword, and conflict verification
- SQL component manifest completeness passed
- pre-commit formatting, line-ending, and compile hooks passed