### PR TITLE
Port upstream parser safety fixes

### DIFF
--- a/src/ban.c
+++ b/src/ban.c
@@ -32,15 +32,74 @@ static char *invalid_list[MAX_INVALID_NAMES];
 /* local utility functions */
 static void write_ban_list(void);
 static void _write_one_node(FILE *fp, struct ban_list_element *node);
+static int parse_ban_record(const char *line, struct ban_list_element *record);
+static int read_ban_record(FILE *fl, struct ban_list_element *record);
 
 static const char *ban_types[] = {"no", "new", "select", "all", "ERROR"};
+
+static int parse_ban_record(const char *line, struct ban_list_element *record)
+{
+  char ban_type[100], site_name[BANNED_SITE_LENGTH + 1], name[MAX_NAME_LENGTH + 1], extra;
+  int date, type;
+
+  if (line == NULL || record == NULL ||
+      sscanf(line, " %99s %50s %d %20s %c", ban_type, site_name, &date, name, &extra) != 4)
+    return FALSE;
+
+  for (type = BAN_NOT; type <= BAN_ALL; type++)
+    if (!strcmp(ban_type, ban_types[type]))
+      break;
+  if (type > BAN_ALL)
+    return FALSE;
+
+  strlcpy(record->site, site_name, sizeof(record->site));
+  strlcpy(record->name, name, sizeof(record->name));
+  record->date = date;
+  record->type = type;
+  record->next = NULL;
+  return TRUE;
+}
+
+static int read_ban_record(FILE *fl, struct ban_list_element *record)
+{
+  char line[READ_SIZE];
+  int c;
+
+  if (fl == NULL || record == NULL)
+    return FALSE;
+
+  while (fgets(line, sizeof(line), fl))
+  {
+    if (!strchr(line, '\n') && !feof(fl))
+    {
+      while ((c = fgetc(fl)) != '\n' && c != EOF)
+        ;
+      continue;
+    }
+
+    if (parse_ban_record(line, record))
+      return TRUE;
+  }
+
+  return FALSE;
+}
+
+#ifdef LUMINARI_CUTEST
+int ban_parse_record_for_test(const char *line, struct ban_list_element *record)
+{
+  return parse_ban_record(line, record);
+}
+
+int ban_read_record_for_test(FILE *fl, struct ban_list_element *record)
+{
+  return read_ban_record(fl, record);
+}
+#endif
 
 void load_banned(void)
 {
   FILE *fl;
-  int i, date;
-  char site_name[BANNED_SITE_LENGTH + 1], ban_type[100];
-  char name[MAX_NAME_LENGTH + 1];
+  struct ban_list_element record;
   struct ban_list_element *next_node;
 
   ban_list = 0;
@@ -55,19 +114,10 @@ void load_banned(void)
       log("   Ban file '%s' doesn't exist.", BAN_FILE);
     return;
   }
-  while (fscanf(fl, " %s %s %d %s ", ban_type, site_name, &date, name) == 4)
+  while (read_ban_record(fl, &record))
   {
     CREATE(next_node, struct ban_list_element, 1);
-    strncpy(next_node->site, site_name,
-            BANNED_SITE_LENGTH); /* strncpy: OK (n_n->site:BANNED_SITE_LENGTH+1) */
-    next_node->site[BANNED_SITE_LENGTH] = '\0';
-    strncpy(next_node->name, name, MAX_NAME_LENGTH); /* strncpy: OK (n_n->name:MAX_NAME_LENGTH+1) */
-    next_node->name[MAX_NAME_LENGTH] = '\0';
-    next_node->date = date;
-
-    for (i = BAN_NOT; i <= BAN_ALL; i++)
-      if (!strcmp(ban_type, ban_types[i]))
-        next_node->type = i;
+    *next_node = record;
 
     next_node->next = ban_list;
     ban_list = next_node;

--- a/src/ban.h
+++ b/src/ban.h
@@ -41,6 +41,10 @@ int isbanned(char *hostname);
 int valid_name(char *newname);
 void read_invalid_list(void);
 void free_invalid_list(void);
+#ifdef LUMINARI_CUTEST
+int ban_parse_record_for_test(const char *line, struct ban_list_element *record);
+int ban_read_record_for_test(FILE *fl, struct ban_list_element *record);
+#endif
 /* Command functions without subcommands */
 ACMD_DECL(do_ban);
 ACMD_DECL(do_unban);

--- a/unittests/CuTest/test_upstream_regressions.c
+++ b/unittests/CuTest/test_upstream_regressions.c
@@ -5,6 +5,7 @@
 #include "../../src/structs.h"
 #include "../../src/utils.h"
 #include "../../src/act.h"
+#include "../../src/ban.h"
 #include "../../src/comm.h"
 #include "../../src/db.h"
 #include "../../src/handler.h"
@@ -73,6 +74,75 @@ static void reset_test_descriptor_output(struct descriptor_data *descriptor)
   descriptor->output[0] = '\0';
   descriptor->bufptr = 0;
   descriptor->bufspace = SMALL_BUFSIZE - 1;
+}
+
+void Test_ban_records_are_bounded_and_reject_malformed_fields(CuTest *tc)
+{
+  struct ban_list_element record;
+  char overlong_site[BANNED_SITE_LENGTH + 2];
+  char line[READ_SIZE];
+  int parsed_valid;
+  int rejected_extra;
+  int rejected_type;
+  int rejected_overlong_site;
+
+  memset(&record, 0, sizeof(record));
+  parsed_valid = ban_parse_record_for_test("all example.org 1234 Admin\n", &record);
+  rejected_extra = !ban_parse_record_for_test("all example.org 1234 Admin trailing\n", &record);
+  rejected_type = !ban_parse_record_for_test("bogus example.org 1234 Admin\n", &record);
+
+  memset(overlong_site, 'x', sizeof(overlong_site) - 1);
+  overlong_site[sizeof(overlong_site) - 1] = '\0';
+  snprintf(line, sizeof(line), "all %s 1234 Admin\n", overlong_site);
+  rejected_overlong_site = !ban_parse_record_for_test(line, &record);
+
+  CuAssertTrue(tc, parsed_valid);
+  CuAssertStrEquals(tc, "example.org", record.site);
+  CuAssertStrEquals(tc, "Admin", record.name);
+  CuAssertIntEquals(tc, BAN_ALL, record.type);
+  CuAssertTrue(tc, record.date == (time_t)1234);
+  CuAssertTrue(tc, rejected_extra);
+  CuAssertTrue(tc, rejected_type);
+  CuAssertTrue(tc, rejected_overlong_site);
+}
+
+void Test_ban_file_reader_skips_malformed_and_overlong_records(CuTest *tc)
+{
+  FILE *fixture;
+  struct ban_list_element record;
+  int index;
+  int read_first;
+  int read_second;
+  int reached_end;
+
+  fixture = tmpfile();
+  if (fixture == NULL)
+  {
+    CuFail(tc, "could not create the ban-file parser fixture");
+    return;
+  }
+
+  fputs("all first.example 100 First\n", fixture);
+  fputs("malformed record\n", fixture);
+  for (index = 0; index < READ_SIZE + 20; index++)
+    fputc('x', fixture);
+  fputc('\n', fixture);
+  fputs("new second.example 200 Second\n", fixture);
+  rewind(fixture);
+
+  read_first = ban_read_record_for_test(fixture, &record);
+  CuAssertTrue(tc, read_first);
+  CuAssertStrEquals(tc, "first.example", record.site);
+  CuAssertIntEquals(tc, BAN_ALL, record.type);
+
+  read_second = ban_read_record_for_test(fixture, &record);
+  CuAssertTrue(tc, read_second);
+  CuAssertStrEquals(tc, "second.example", record.site);
+  CuAssertIntEquals(tc, BAN_NEW, record.type);
+
+  reached_end = !ban_read_record_for_test(fixture, &record);
+  fclose(fixture);
+  CuAssertTrue(tc, reached_end);
 }
 
 void Test_room_trigger_attachments_are_idempotent_and_reset_restorable(CuTest *tc)

--- a/util/plrtoascii.c
+++ b/util/plrtoascii.c
@@ -218,8 +218,8 @@ void convert(char *filename)
 
     printf("writing: %s\n", outname);
 
-    fprintf(index_file, "%ld %s %d 0 %ld\n", player.char_specials_saved.idnum, bits, player.level,
-            (long)player.last_logon);
+    fprintf(index_file, "%ld %s %d 0 %ld\n", player.char_specials_saved.idnum, player.name,
+            player.level, (long)player.last_logon);
 
     if (!(outfile = fopen_restricted(outname, "w")))
     {

--- a/util/rebuildAsciiIndex.c
+++ b/util/rebuildAsciiIndex.c
@@ -25,7 +25,7 @@
 /* Function prototypes */
 int atoi(const char *str);
 long atol(const char *str);
-void walkdir(FILE *index_file, char *dir);
+int walkdir(FILE *index_file, char *dir);
 int get_line(FILE *fl, char *buf);
 char *parsename(char *filename);
 char *findLine(FILE *plr_file, char *tag);
@@ -49,6 +49,7 @@ long parselast(FILE *plr_file);
 int main(int argc, char **argv)
 {
   FILE *index_file;
+  int errors;
 
   if (argc == 1)
   {
@@ -69,12 +70,12 @@ int main(int argc, char **argv)
   }
 
   printf("Scanning player files and rebuilding index...\n");
-  walkdir(index_file, ".");
+  errors = walkdir(index_file, ".");
 
   fprintf(index_file, "~\n");
   fclose(index_file);
   printf("Index rebuild complete.\n");
-  return 0;
+  return errors ? 1 : 0;
 }
 
 /**
@@ -136,7 +137,7 @@ char *findLine(FILE *plr_file, char *tag)
 long parseid(FILE *plr_file)
 {
   char *id_str = findLine(plr_file, "Id  :");
-  return id_str ? atol(id_str) : 0;
+  return id_str ? atol(id_str) : -1;
 }
 
 /**
@@ -148,7 +149,7 @@ long parseid(FILE *plr_file)
 int parselevel(FILE *plr_file)
 {
   char *level_str = findLine(plr_file, "Levl:");
-  return level_str ? atoi(level_str) : 0;
+  return level_str ? atoi(level_str) : -1;
 }
 
 /**
@@ -180,7 +181,7 @@ int parseadminlevel(FILE *plr_file, int level)
 long parselast(FILE *plr_file)
 {
   char *last_str = findLine(plr_file, "Last:");
-  return last_str ? atol(last_str) : 0;
+  return last_str ? atol(last_str) : -1;
 }
 
 /**
@@ -192,7 +193,7 @@ long parselast(FILE *plr_file)
  * @param index_file Output file for the index
  * @param dir Directory to scan
  */
-void walkdir(FILE *index_file, char *dir)
+int walkdir(FILE *index_file, char *dir)
 {
   char filename_qfd[1000];
   struct dirent *dp;
@@ -201,12 +202,12 @@ void walkdir(FILE *index_file, char *dir)
   char *name;
   FILE *plr_file;
   long id, last;
-  int level, adminlevel, entry_fd, open_flags;
+  int level, adminlevel, entry_fd, open_flags, errors = 0;
 
   if ((dfd = opendir(dir)) == NULL)
   {
     fprintf(stderr, "Can't open %s\n", dir);
-    return;
+    return 1;
   }
 
   while ((dp = readdir(dfd)) != NULL)
@@ -217,6 +218,7 @@ void walkdir(FILE *index_file, char *dir)
         (int)sizeof(filename_qfd))
     {
       fprintf(stdout, "Path is too long: %s/%s\n", dir, dp->d_name);
+      errors++;
       continue;
     }
 
@@ -230,13 +232,14 @@ void walkdir(FILE *index_file, char *dir)
       fprintf(stdout, "Unable to open file: %s\n", filename_qfd);
       if (entry_fd >= 0)
         close(entry_fd);
+      errors++;
       continue;
     }
 
     if (S_ISDIR(stbuf.st_mode))
     {
       close(entry_fd);
-      walkdir(index_file, filename_qfd);
+      errors += walkdir(index_file, filename_qfd);
     }
     else
     {
@@ -249,15 +252,40 @@ void walkdir(FILE *index_file, char *dir)
         {
           fprintf(stderr, "Warning: Could not open player file %s\n", filename_qfd);
           close(entry_fd);
+          errors++;
           continue;
         }
 
         id = parseid(plr_file);
+        if (id < 0)
+        {
+          fprintf(stderr, "Skipping %s: missing Id field\n", filename_qfd);
+          fclose(plr_file);
+          errors++;
+          continue;
+        }
+
         level = parselevel(plr_file);
+        if (level < 0)
+        {
+          fprintf(stderr, "Skipping %s: missing Levl field\n", filename_qfd);
+          fclose(plr_file);
+          errors++;
+          continue;
+        }
+
+        last = parselast(plr_file);
+        if (last < 0)
+        {
+          fprintf(stderr, "Skipping %s: missing Last field\n", filename_qfd);
+          fclose(plr_file);
+          errors++;
+          continue;
+        }
+
         adminlevel = parseadminlevel(plr_file, level);
         if (level > 30)
           level = 30;
-        last = parselast(plr_file);
 
         fprintf(index_file, "%ld %s %d %d 0 %ld\n", id, name, level, adminlevel, last);
 
@@ -268,6 +296,7 @@ void walkdir(FILE *index_file, char *dir)
     }
   }
   closedir(dfd);
+  return errors;
 }
 
 /**

--- a/util/rebuildMailIndex.c
+++ b/util/rebuildMailIndex.c
@@ -320,6 +320,14 @@ void walkdir(FILE *index_file, char *dir)
           continue;
         }
 
+        if (findLine(mail_file, "MlID:") == NULL || findLine(mail_file, "Send:") == NULL ||
+            findLine(mail_file, "Reci:") == NULL || findLine(mail_file, "Sent:") == NULL)
+        {
+          fprintf(stderr, "Skipping malformed mail file: %s\n", filename_qfd);
+          fclose(mail_file);
+          continue;
+        }
+
         id = parse_mailid(mail_file);
         sender = parse_sender(mail_file);
         recipient = parse_recipient(mail_file);

--- a/util/split.c
+++ b/util/split.c
@@ -45,7 +45,7 @@ int main(void)
   const unsigned char *filename_char;
   char *newline_pos;
   FILE *index = NULL, *outfile = NULL;
-  int file_count = 0;
+  int file_count = 0, next_char;
 
   printf("Split utility - reading from stdin...\n");
   printf("Use lines starting with '=' to specify output filenames.\n");
@@ -66,6 +66,18 @@ int main(void)
       if (newline_pos)
       {
         *newline_pos = '\0';
+      }
+      else
+      {
+        next_char = fgetc(stdin);
+        if (next_char != '\n' && next_char != EOF)
+        {
+          fprintf(stderr, "Input marker line too long.\n");
+          fclose(index);
+          if (outfile)
+            fclose(outfile);
+          exit(1);
+        }
       }
 
       filename_char = (const unsigned char *)(line + 1);


### PR DESCRIPTION
## Summary

- port applicable parser and utility fixes from tbaMUD pull requests #197-#204
- harden ban-file parsing against malformed, oversized, and invalid records
- make player and mail index rebuilds skip malformed inputs safely
- correct player index names and split marker handling
- add production-linked regression coverage for ban-file records

## Why

Several maintenance utilities and the ban loader accepted malformed or oversized input unsafely, silently emitted invalid index entries, or returned success despite processing errors. The player conversion utility also wrote the wrong name source to its index.

## Validation

- `make clean`
- `make -j$(nproc)`
- `make test` — 904 CuTest tests passed; supporting regression suites passed; 8 opt-in MariaDB tests skipped as expected
- `make install`
- targeted malformed-input fixtures for split, player/mail index rebuilds, player conversion, and argument handling
- `git diff --check`
- commit and push hooks, including compile verification