### PR TITLE
Configure CodeRabbit for stacked event reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - "review/event-core/.*"


### PR DESCRIPTION
Configure automatic CodeRabbit reviews for the intermediate review/event-core/* base branches used by the event-driven core PR stack. The default branch remains reviewed automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic code review configuration for designated review branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->