### PR TITLE
[event core 07/14] Add encounter scheduling and combat rounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,6 +513,8 @@ set(SRC_C_FILES
     src/dotenv.c
     src/elf_build_id.c
     src/combat/encounters.c
+    src/combat/combat_encounters.c
+    src/combat/combat_encounters.h
     src/character/evolutions.c
     src/character/feats.c
     src/combat/fight.c
@@ -1215,6 +1217,7 @@ set(CUTEST_TEST_SOURCES
     unittests/CuTest/test_transport_production.c
     unittests/CuTest/test_traps_production.c
     unittests/CuTest/test_combat_production.c
+    unittests/CuTest/test_combat_encounters.c
     unittests/CuTest/test_thrown_weapons.c
     unittests/CuTest/test_lists_production.c
     unittests/CuTest/test_mob_autoroll.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -835,6 +835,7 @@ EXTRA_DIST = \
 	sql/components/help_race_myconid_entries.sql \
 	sql/components/help_race_wemic_entries.sql \
 	sql/components/help_race_yuan_ti_entries.sql \
+	sql/components/help_semantic_combat_entries.sql \
 	sql/components/help_trelux_equipment_entries.sql \
 	sql/components/help_specproc_entries.sql \
 	sql/components/help_thrown_weapons_entries.sql \
@@ -856,6 +857,7 @@ EXTRA_DIST = \
 	sql/components/verify_help_race_myconid_entries.sql \
 	sql/components/verify_help_race_wemic_entries.sql \
 	sql/components/verify_help_race_yuan_ti_entries.sql \
+	sql/components/verify_help_semantic_combat_entries.sql \
 	sql/components/verify_help_trelux_equipment_entries.sql \
 	sql/components/verify_help_specproc_entries.sql \
 	sql/components/verify_help_thrown_weapons_entries.sql \

--- a/Makefile.am
+++ b/Makefile.am
@@ -100,6 +100,8 @@ luminari_SOURCES = \
 	src/elf_build_id.c \
 	src/elf_build_id.h \
 	src/combat/encounters.c \
+	src/combat/combat_encounters.c \
+	src/combat/combat_encounters.h \
 	src/character/evolutions.c \
 	src/character/feats.c \
 	src/character/talents.c \
@@ -380,6 +382,7 @@ cutest_SOURCES = \
 	unittests/CuTest/test_transport_production.c \
 	unittests/CuTest/test_traps_production.c \
 	unittests/CuTest/test_combat_production.c \
+	unittests/CuTest/test_combat_encounters.c \
 	unittests/CuTest/test_thrown_weapons.c \
 	unittests/CuTest/test_lists_production.c \
 	unittests/CuTest/test_mob_autoroll.c \
@@ -441,6 +444,7 @@ cutest_test_files = \
 	unittests/CuTest/test_transport_production.c \
 	unittests/CuTest/test_traps_production.c \
 	unittests/CuTest/test_combat_production.c \
+	unittests/CuTest/test_combat_encounters.c \
 	unittests/CuTest/test_thrown_weapons.c \
 	unittests/CuTest/test_lists_production.c \
 	unittests/CuTest/test_mob_autoroll.c \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased] - August 30, 2026
 
+### Semantic encounter rounds
+
+#### Changed
+
+- Replaced compatibility combat phases by default with one shared six-second
+  encounter round, resolved by initiative, Dexterity, and stable runtime ID.
+- Moved standard, move, swift, reaction, and four once-per-round gates into
+  participant state, including conservative cooldown transfer at combat
+  boundaries and staggered-action coupling.
+- Reset reactions and round flags once before encounter initiative begins, so
+  defenses spent against an earlier combatant cannot refresh at the defender's
+  own turn. Routed Come and Get Me's free counterattack through that same
+  reaction budget.
+- Defined the bounded action queue as a 10-command FIFO with one prevalidated
+  intent dispatched per turn before automatic attacks; semantic combat queues
+  are no longer polled by the connection loop.
+- Coalesced late joins and merged fights onto one encounter clock while
+  retaining not-before eligibility, so a merge cannot grant an early turn.
+- Corrected timing-wheel facade admission to schedule from the live game pulse,
+  preventing a newly created encounter event from firing early after an idle
+  scheduler interval.
+
+#### Operations
+
+- Added `LUMINARI_COMBAT_ROUNDS=compatibility` as the encounter-owned gameplay
+  rollback while `semantic` remains the default.
+- Extended `eventdebug` with semantic round, turn, intent, action, and reaction
+  counters, retaining compact 80-column output.
+
+#### Tests
+
+- Added initiative and tie-break ordering, shared-clock join/merge, action and
+  reaction budgets, staggered coupling, FIFO intent, cooldown transfer,
+  round-flag, callback-join, and full-attack regression coverage.
+- Added idle-clock scheduler and semantic-combat regressions that require the
+  first two participant turns exactly six seconds after encounter admission.
+- Added adversarial initiative-order coverage for reaction and round-flag state
+  triggered before the affected participant's turn.
+
 ### Encounter-owned combat scheduling
 
 #### Changed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## [Unreleased] - August 30, 2026
 
+### Encounter-owned combat scheduling
+
+#### Changed
+
+- Replaced per-character combat clocks with one generation-aware scheduled
+  event per live encounter while retaining the existing combat phase and
+  action-queue implementation.
+- Added safe encounter creation, participant admission, deferred callback
+  mutation, encounter merging with preserved deadlines, immediate departure,
+  terminal teardown, and generation reuse.
+- Published committed character death through the typed domain-event runtime;
+  movement, death, extraction, and direct cleanup now enforce encounter
+  lifecycle without polling combatants.
+
+#### Operations
+
+- Added `LUMINARI_COMBAT_EVENTS=legacy` as the exclusive boot-time rollback to
+  per-character `eCOMBAT_ROUND` events.
+- Added compact encounter mode, population, shared-event, lifecycle, phase,
+  comparison, admission, and stale-owner counters to `eventdebug`.
+
+#### Tests
+
+- Added join-timing, callback mutation, merge fairness, bridge departure,
+  terminal replacement, generation reuse, all-departure, rollback, sanitizer,
+  Valgrind, boot-matrix, database, and live-MUD coverage.
+
 ### Immortal event diagnostics
 
 #### Added

--- a/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md
+++ b/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md
@@ -1,0 +1,107 @@
+# Event-Driven Core Refactor Phase 8 Encounter Validation
+
+**Status:** Pass
+**Date:** 2026-08-31
+**Branch:** `event-driven-core-refactor`
+**Scope:** Encounter-owned compatibility combat scheduling
+
+## Specification Audit
+
+| Requirement | Disposition |
+|---|---|
+| Runtime authority | A fixed 32,768-slot `combat_encounter_data` registry owns process-local IDs and generations. It is distinct from wilderness encounter content and is torn down before world entities. |
+| One event per fight | Every active fight has one `combat_encounter_round` event with typed encounter ownership. Individual participants retain phase, deadline, and deterministic due order without owning combat events. |
+| Join and merge | Hostility creates, extends, or merges encounters. In-dispatch additions and merges are deferred; absorbed participant deadlines are preserved and already-due members still act once in the same callback. |
+| Fair eligibility | Ordinary joins preserve their existing initial initiative delay. A join created during encounter dispatch cannot act before six seconds have passed. Terminal encounters cannot be revived. |
+| Leave and end | Participants are marked inactive immediately and compacted safely after dispatch. The API classifies stop, movement, flee, teleport, death, extraction, disconnect, and administrative departure. The shared event ends exactly once when no active hostility remains. |
+| Lifecycle safety | Movement, committed death, and extraction facts resolve generation-aware character handles. Direct extraction cleanup is idempotent, DG mobile transformation preserves runtime links, and stale encounter or participant resolution is counted. |
+| Gameplay compatibility | Both modes invoke the same extracted production combat-phase routine. Existing three-phase behavior, two-second phase cadence, six-second round, action queue, reactions, attacks, and effects remain authoritative. |
+| Diagnostics | `eventdebug` reports mode, active encounters and participants, shared event count, create/end/merge totals, callbacks, phase and terminal outcomes, structural/outcome mismatches, admission failures, and stale callbacks. Queue filtering shows encounter owner ID and generation without payloads. |
+| Rollback | `LUMINARI_COMBAT_EVENTS=legacy` exclusively restores per-character `eCOMBAT_ROUND` events for the entire boot. No active fight is converted between models. |
+
+## Gameplay Boundary
+
+This tranche changes who owns the combat clock, not the combat rules. A fight
+between two or twenty combatants now wakes one encounter event at the nearest
+participant deadline. That callback runs only due participants through the
+same combat code that the old per-character events used.
+
+Mobs continue to fight other mobs in empty zones, and linkdead participants
+retain the existing continued-combat policy. Movement reactions still occur
+before successful departure. Phase 9, not Phase 8, owns any proposed change to
+initiative, action/reaction budgets, intent buffering, or the visible meaning
+of a six-second round.
+
+## Focused Coverage
+
+Eight encounter tests prove:
+
+- one shared event with exact participant cadence, phase order, and teardown;
+- joins before, during, and after dispatch, with the guard applied only during
+  dispatch;
+- deferred encounter merge, preserved due times, same-callback due work, and
+  bridge departure;
+- callback removal of every participant without iterator invalidation;
+- slot reuse with a new generation and no stale revival;
+- terminal encounter replacement rather than revival;
+- every declared departure reason plus exactly-once shared cancellation; and
+- exclusive legacy selection with no encounter state or event.
+
+The production runtime test also proves that the runtime registers eight
+handlers in total, including all three encounter lifecycle handlers, without
+test-order state leakage. It also proves that committed character death
+publishes the foundational typed fact.
+
+## Validation Evidence
+
+The accepted tree passed:
+
+- warning-clean production Autotools and CMake builds;
+- the isolated authoritative `make test-all` gate, including 1,004
+  production-linked C tests, 504 world-tool tests, 29 protocol tests,
+  process-memory and character-rename checks, and release installation;
+- all 1,004 C tests against a disposable `luminari_test` MariaDB runtime;
+- four representative direct syntax boots: encounter/scheduler/libevent,
+  character/scheduler/libevent, encounter/legacy/libevent, and
+  encounter/scheduler/select;
+- an AddressSanitizer and UndefinedBehaviorSanitizer production-linked CMake
+  build with all 1,004 tests and no finding;
+- strict child-tracing Valgrind with all 1,004 tests, zero errors, and no
+  definite, indirect, or possible leaks; and
+- a logged live scheduler/libevent MUD session on port 4101 as Ornir at level
+  34. Two durable NPC fixtures entered combat, `eventdebug` showed one
+  encounter, two participants, one shared event, encounter owner ID/generation,
+  and successful callbacks; `peace` reduced the encounter, participant, and
+  event counts to zero.
+
+The first unisolated repository gate reproduced the two known mutable-world
+fixture collisions. The authoritative rerun used the tracked spec inventory
+and disposable syntax world and passed; this was a harness isolation correction,
+not a product failure. Live credentials were redacted and restored byte for
+byte, the player file and temporary target prototype were restored, the server
+shut down normally, and port 4101 was closed.
+
+Adversarial testing found and fixed a passive-membership/turn-eligibility
+conflation, terminal encounter revival, dispatch-terminal event accounting,
+generic payload cleanup, leaked test selection, missing death publication, and
+missing stale-resolution telemetry before acceptance. Logs remain under
+`.ci-runtime/phase8-*` and `.ci-runtime/eventdebug-live-*` and are untracked.
+
+## Validation Policy
+
+The encounter implementation is now the development focus. It receives full
+gameplay, database, sanitizer, Valgrind, performance, and live-MUD coverage.
+The character-event implementation remains only as a temporary rollback path,
+so it receives compile, syntax-boot, and focused exclusivity smoke coverage
+until the final dual-mode removal gate.
+
+## Rollback And Next Tranche
+
+Restart with `LUMINARI_COMBAT_EVENTS=legacy` to restore per-character combat
+events. Live mode switching and conversion of active fights are unsupported.
+
+Phase 9 is next: separately approve and implement semantic encounter rounds,
+initiative ordering, explicit action and reaction budgets, intent buffering,
+six-second D20 round behavior, and appropriate encounter-owned round flags.
+Its gameplay and help changes require design and balance review rather than
+being inferred from this compatibility migration.

--- a/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md
+++ b/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md
@@ -1,0 +1,157 @@
+# Event-Driven Core Refactor Phase 9 Validation
+
+**Status:** Accepted
+**Accepted:** 2026-08-31
+**Scope:** Semantic encounter rounds, action economy, intent dispatch, combat help,
+and live timing acceptance
+
+## Accepted Contract
+
+Phase 9 makes semantic combat the default gameplay path while retaining the
+Phase 8 encounter-owned compatibility cadence as a boot-time rollback only.
+
+- One generation-aware event owns each live encounter.
+- One shared round lasts six seconds and resolves every eligible participant.
+- Turn order is descending initiative, descending Dexterity, then ascending
+  stable runtime ID.
+- Participants joining during a callback wait until the next shared round.
+  Ordinary joins and encounter merges preserve their not-before eligibility.
+- Each participant owns explicit standard, move, swift, and reaction budgets.
+  Reactions and once-per-round flags reset once before initiative begins.
+  Spending a standard action alone permits only the first automatic attack;
+  standard plus move permits the established full attack rotation.
+- Staggered combatants couple standard and move availability.
+- Perfect Tempo, Deflective Screen, Smash Defense, and Relentless Assault use
+  participant round flags rather than independent cooldown events.
+- The action queue is a bounded ten-command FIFO. At most one prevalidated
+  intent is considered at the start of each turn, and the connection loop does
+  not drain semantic combat intents between turns.
+- Action cooldowns crossing a combat boundary round conservatively to whole
+  semantic turns and are restored to ordinary MUD events when combat ends.
+- `LUMINARI_COMBAT_ROUNDS=compatibility` restores the three two-second phases
+  without changing encounter ownership. The two round models are exclusive.
+
+## Implementation Surface
+
+The encounter owner and semantic state live in
+`src/combat/combat_encounters.c`. The established attack mechanics remain in
+`src/combat/fight.c`, exposed through one semantic-round entry point. Action
+queries and cooldown admission route through the participant budget while that
+participant is managed by semantic combat. Once-per-round perk gates follow the
+same participant state.
+
+`eventdebug` reports the selected round mode, active encounters and
+participants, shared event count, semantic rounds and turns, intent outcomes,
+and action/reaction spends in width-bounded output. Player help is present in
+both the database migration and the legacy help file.
+
+## Adversarial Findings
+
+The first passive live fixture exposed an empty initial callback: the encounter
+round count advanced, but no participant turn was due. The timing-wheel facade
+had scheduled new compatibility-API events relative to the wheel's last
+dispatched tick. That internal tick can lag the live game pulse while the wheel
+is idle, causing a newly admitted event to wake early.
+
+The facade now converts a relative request to the absolute deadline
+`live pulse + delay` before scheduler admission. Callback recurrence remains
+relative to the callback's scheduler tick. A scheduler regression advances the
+live pulse across an idle gap before admission, and a combat integration
+regression proves that both participants receive their first turn exactly six
+seconds after such a join.
+
+The final source audit found that reactions and round flags were initially
+reset at each participant's turn. A lower-initiative defender could therefore
+spend a reaction or once-per-round defense against an earlier attacker, then
+receive a fresh budget at its own turn in the same shared round. One validated
+pre-initiative preparation pass now resets every active participant before any
+turn runs. Owner handles are resolved before that pass touches character
+memory. Come and Get Me's deliberate free counterattack now refunds the
+encounter-owned budget instead of changing only the legacy mirror counter. An
+initiative-order regression triggers both kinds of state before the defender's
+turn and proves they remain spent.
+
+An earlier live attempt used an aggressive production golem and was rejected
+as acceptance evidence because unrelated mobile AI altered the encounter. The
+accepted run uses two passive, uniquely named mobiles in the disposable world.
+
+## Automated Evidence
+
+The post-fix tree passed:
+
+- warning-clean production Autotools build;
+- authoritative `make test-all` against the disposable MariaDB runtime: 1,017
+  production-linked C tests, 504 world-tool tests, 29 protocol tests, 36 help
+  tests, process-memory and character-rename checks, and release installation;
+- CMake AddressSanitizer and UndefinedBehaviorSanitizer build with leak
+  detection and all 1,017 tests;
+- strict child-tracing Valgrind with all 1,017 tests, zero errors, and zero
+  definite, indirect, or possible leaks;
+- semantic/scheduler/libevent, semantic/legacy-backend/libevent, and
+  semantic/scheduler/select syntax boots; and
+- encounter compatibility and per-character rollback syntax smokes under the
+  scheduler/libevent production combination.
+
+The database help migrations were applied twice and verified idempotently in
+the disposable test database and the local development database. Semantic
+combat reported one expected entry, four expected keywords, and no keyword
+conflicts. The command-help sweep reported five entries, ten keywords, all ten
+content checks, no obsolete content, and no conflicts.
+
+Evidence logs are retained under `.ci-runtime/phase9-*` and are intentionally
+untracked. The authoritative post-audit logs are:
+
+- `phase9-test-all-postaudit.log`
+- `phase9-asan-postaudit.log`
+- `phase9-valgrind-postaudit.log`
+- `phase9-boot-*-postaudit.log`
+- `phase9-live-session-postaudit.log`
+- `phase9-live-server.log`
+
+## Live MUD Evidence
+
+The accepted session booted scheduler/libevent with semantic rounds on port
+4101, logged in as level-34 Ornir from an isolated copied player file, set an
+80-column client, read the combat and action-queue help, and started a passive
+dummy-versus-target encounter.
+
+`eventdebug` showed:
+
+| Observation | Result |
+|-------------|--------|
+| Initial state | 0 encounters, 0 participants, 0 shared events |
+| Active fight | 1 encounter, 2 participants, 1 shared event |
+| First boundary | 1 semantic round, 2 turns, 4 action spends |
+| Second boundary | 2 semantic rounds, 4 turns, 8 action spends |
+| Teardown | 0 encounters, 0 participants, 0 shared events |
+
+The harness asserted both help entries, semantic mode, one shared event, the
+first and second turn counts, and clean teardown. It used a disposable account
+row, disposable player copy, and disposable world prototypes. The real local
+account password and player file were not modified. The game, Discord bridge,
+and terrain API shut down normally; ports 4101, 8181, and 8182 were closed.
+
+## Coverage Policy
+
+Semantic encounter combat is the product path and receives full behavioral,
+gameplay, timing, database, live-MUD, sanitizer, and Valgrind coverage.
+Compatibility combat remains only until its removal gate, so it receives
+warning-clean compilation, syntax boot, and focused exclusivity/rollback smoke
+coverage. New feature work must not duplicate exhaustive behavior testing in a
+path scheduled for removal.
+
+The timed-event facade is also temporary, but it remains a shared admission
+boundary until all callers migrate to typed scheduler or domain-event APIs.
+Correctness defects in that boundary are fixed and regression-tested because
+they affect current event-driven gameplay.
+
+## Rollback And Next Phase
+
+Restart with `LUMINARI_COMBAT_ROUNDS=compatibility` to restore encounter-owned
+three-phase combat. `LUMINARI_COMBAT_EVENTS=legacy` remains the deeper
+per-character rollback. Live switching and conversion of active fights are
+unsupported.
+
+Phase 10 is next: define and approve the activity capability, trait,
+interruption, progress, and combat-time matrix, then implement the activity
+manager and migrate its first independently reviewed command set.

--- a/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_SPEC.md
+++ b/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_SPEC.md
@@ -1,10 +1,10 @@
 # Event-Driven Core Refactor Specification
 
-**Status:** In progress - Phases 1 through 8 accepted; Phase 9 next
-**Document version:** 1.14
+**Status:** In progress - Phases 1 through 9 accepted; Phase 10 next
+**Document version:** 1.15
 **Started:** 2026-08-29
 **Last source review:** 2026-08-31
-**Implementation status:** Phases 1 through 8 plus the dedicated immortal event-observability gate complete
+**Implementation status:** Phases 1 through 9 plus the dedicated immortal event-observability gate complete
 
 > This remains the controlling planning specification. The Phase 1 scheduler
 > now stores legacy timed events through the Phase 2 compatibility facade. The
@@ -13,8 +13,8 @@
 > ownership and lifecycle cancellation form the accepted scheduler foundation.
 > A private `libevent` compatibility reactor now owns production readiness and
 > signals, with boot-time `select()` rollback. Gameplay timing ownership is
-> migrating while semantic combat redesign remains gated. Versioned player-event
-> records now validate stable ownership and
+> migrating, and encounter-owned six-second semantic combat is now accepted.
+> Versioned player-event records now validate stable ownership and
 > rebuild fresh process-local timers, while transient and boot-reconstructed
 > work has an explicit policy.
 > The process now owns a boot-sealed typed domain-event registry with bounded
@@ -1812,8 +1812,20 @@ failed generation resolution feeds stale-owner telemetry. `eventdebug` reports
 the selected mode, encounter and participant counts, shared events, lifecycle,
 phase outcomes, and comparison invariants. Evidence is recorded in
 [`EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md`](EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md).
-Phase 9 semantic combat rounds are next and remain a separate gameplay-design
-gate.
+**Phase 9 accepted 2026-08-31.** Each encounter now resolves one shared
+six-second round in deterministic initiative, Dexterity, and runtime-ID order.
+Participants own explicit standard, move, swift, reaction, and once-per-round
+state. Reactions and round flags reset once before initiative so state spent by
+an earlier combatant cannot refresh at the defender's turn. One prevalidated
+FIFO intent dispatches at each turn boundary before
+automatic attacks; standard-only turns receive the first attack portion and
+standard-plus-move turns retain the established full rotation. Cooldowns,
+joins, and merges cross the shared clock conservatively. The default semantic
+path and `LUMINARI_COMBAT_ROUNDS=compatibility` rollback are exclusive, and
+compact diagnostics plus player help describe the selected behavior. Live
+adversarial testing also corrected scheduler-facade admission after an idle
+clock gap. Evidence is recorded in
+[`EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md`](EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md).
 
 ### Phase 8: Encounter-level combat compatibility
 
@@ -1855,6 +1867,16 @@ Rollback:
 
 - Return to encounter-owned compatibility phases without reverting the event
   backend.
+
+Acceptance:
+
+- Accepted on 2026-08-31. Semantic rounds are the default gameplay path, with
+  the implementation, balance contract, help, 1,017-test suite, sanitizer,
+  Valgrind, boot matrix, database, and isolated live-MUD evidence recorded in
+  [`EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md`](EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md).
+- Exhaustive gameplay and memory-safety validation follows the semantic path.
+  Compatibility phases retain compile, syntax-boot, and focused rollback smoke
+  coverage until Phase 11 removes them.
 
 ### Phase 10: Activity manager and command-time decomposition
 
@@ -2125,7 +2147,7 @@ working document is retired according to the ongoing-project policy.
 | D17 | Domain dispatch | Typed, synchronous, main-thread, immutable borrowed payload | Accepted in Phase 6a | Phase 6 |
 | D18 | Existing pub/sub | Replace runtime subsystem; deprecate data before reviewed removal | Accepted | Phase 6 |
 | D19 | Nested domain publication | Depth-first with hard depth and causal-count limits | Accepted | Phase 6 |
-| D20 | Active-world lifecycle | Active, cooling-down, and dormant | Provisional | Phase 7 |
+| D20 | Active-world lifecycle | Active, cooling-down, and dormant, with autonomous off-screen simulation remaining active | Accepted in Phase 7 | Phase 7 |
 | D21 | Primary activities | At most one primary intentional activity per character initially | Provisional | Phase 10 |
 | D22 | Residual heartbeat | Explicit global scheduled work only; remove compatibility pulse | Accepted | Phase 11 |
 | D23 | Workload measurement | Source-derived and synthetic in Phase 2; privacy-safe observed sample in Phase 4 | Accepted | Phase 4 |
@@ -2133,6 +2155,7 @@ working document is retired according to the ongoing-project policy.
 | D25 | Runtime clock | Monotonic pacing in Phase 3; wall clock only for calendar and durable semantics | Accepted | Phase 3 |
 | D26 | Copyover reactor lifecycle | Quiesce and destroy old process base before exec; rebuild and rebind after exec | Accepted | Phase 3 |
 | D27 | Migration CI matrix | Both timed backends by both I/O drivers while rollback paths remain supported | Accepted | Phase 3 |
+| D28 | Semantic combat model | One shared six-second encounter round; initiative/Dexterity/runtime-ID order; explicit action/reaction budgets; one FIFO intent per turn | Accepted | Phase 9 |
 
 ## 29. Risks and Mitigations
 
@@ -2260,3 +2283,4 @@ Before accepting version 1.0 of this specification, reviewers should confirm:
 | 1.12 | 2026-08-31 | Accepted the mud-hour point-update Phase 7 slice after replacing normal player/object discovery scans with one aligned service deadline and lifecycle-owned PC and active-object registries. Global-player-object ordering, timer/decay/corpse/idle gameplay, timer-trigger extraction, OLC/DG replacement safety, exclusive rollback, and compact diagnostics are preserved; the 991-test database/sanitizer/Valgrind, eight-mode syntax, and live-MUD gates pass. Immortal event observability is next before Phase 8. |
 | 1.13 | 2026-08-31 | Accepted the immortal observability gate after adding backend-neutral payload-free event inspection, readable paginated filters and profiles, complete scheduler queue/lifecycle/capacity telemetry, typed domain-handler views, and bounded I3 worker-ingress counters with an 80-column default and 120-column hard ceiling. Phase 8 encounter compatibility is next. |
 | 1.14 | 2026-08-31 | Accepted Phase 8 after replacing per-character combat clocks with one generation-aware event per encounter, preserving existing phase/action behavior, implementing safe joins, deferred mutation, encounter merges, all departure classes, typed lifecycle facts, compact diagnostics, and exclusive character-event rollback. Phase 9 semantic combat rounds are next. |
+| 1.15 | 2026-08-31 | Accepted Phase 9 after making six-second semantic encounter rounds authoritative, defining deterministic initiative and explicit action/reaction budgets, dispatching one bounded FIFO intent per turn, migrating round flags and cooldown boundaries, updating help and diagnostics, and passing the 1,017-test, boot-matrix, database, sanitizer, Valgrind, and isolated live-MUD gates. Adversarial testing fixed scheduler-facade admission against a stale internal tick and moved reaction/round-flag resets ahead of initiative so earlier combatants cannot grant a defender a second budget. Phase 10 activities are next. |

--- a/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_SPEC.md
+++ b/docs/ongoing-projects/EVENT_DRIVEN_CORE_REFACTOR_SPEC.md
@@ -1,10 +1,10 @@
 # Event-Driven Core Refactor Specification
 
-**Status:** In progress - Phase 7 and the immortal observability gate accepted; Phase 8 next
-**Document version:** 1.13
+**Status:** In progress - Phases 1 through 8 accepted; Phase 9 next
+**Document version:** 1.14
 **Started:** 2026-08-29
 **Last source review:** 2026-08-31
-**Implementation status:** Phases 1 through 7 plus the dedicated immortal event-observability gate complete
+**Implementation status:** Phases 1 through 8 plus the dedicated immortal event-observability gate complete
 
 > This remains the controlling planning specification. The Phase 1 scheduler
 > now stores legacy timed events through the Phase 2 compatibility facade. The
@@ -12,8 +12,9 @@
 > heartbeat remains only for unmigrated pulse work. Generation-aware MUD-event
 > ownership and lifecycle cancellation form the accepted scheduler foundation.
 > A private `libevent` compatibility reactor now owns production readiness and
-> signals, with boot-time `select()` rollback; gameplay semantics have not
-> migrated. Versioned player-event records now validate stable ownership and
+> signals, with boot-time `select()` rollback. Gameplay timing ownership is
+> migrating while semantic combat redesign remains gated. Versioned player-event
+> records now validate stable ownership and
 > rebuild fresh process-local timers, while transient and boot-reconstructed
 > work has an explicit policy.
 > The process now owns a boot-sealed typed domain-event registry with bounded
@@ -1794,7 +1795,25 @@ at 120. Compatibility owner teardown cancels before stale dispatch; typed
 consumers introduced from Phase 8 onward must count failed generation-aware
 resolution as a stale-owner outcome. Evidence is recorded in
 [`EVENT_DRIVEN_CORE_REFACTOR_OBSERVABILITY_VALIDATION.md`](EVENT_DRIVEN_CORE_REFACTOR_OBSERVABILITY_VALIDATION.md).
-Phase 8 encounter compatibility is next.
+
+**Phase 8 accepted 2026-08-31.** A generation-aware
+`combat_encounter_data` registry now gives each live fight one typed encounter
+event, independent of the existing wilderness `encounter_data`. Participants
+retain their individual compatibility phase and deadline under that shared
+clock. Hostile joins create, extend, or merge encounters; additions and merges
+during dispatch are deferred, due times survive merges, and an in-dispatch
+join receives a six-second not-before guard. Immediate inactive marking plus
+deferred compaction makes movement, death, extraction, combat stop, and
+callback mutation safe. The existing combat phase and action-queue routine is
+shared by the encounter path and the retained per-character rollback path, so
+cadence and mechanics do not execute twice or diverge. Typed death, movement,
+and extraction facts plus direct extraction cleanup enforce lifecycle, while
+failed generation resolution feeds stale-owner telemetry. `eventdebug` reports
+the selected mode, encounter and participant counts, shared events, lifecycle,
+phase outcomes, and comparison invariants. Evidence is recorded in
+[`EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md`](EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md).
+Phase 9 semantic combat rounds are next and remain a separate gameplay-design
+gate.
 
 ### Phase 8: Encounter-level combat compatibility
 
@@ -2097,10 +2116,10 @@ working document is retired according to the ongoing-project policy.
 | D8 | Owner registry | Typed runtime ID plus generation and owner index | Accepted for implementation | Phase 2.5 |
 | D9 | Persistent event store | Versioned per-type player records with stable owner validation, explicit offline policy, and fresh runtime rehydration; boot-derived world work remains reconstructable | Accepted | Phase 5 |
 | D10 | Old/new backend selection | Process environment, then `.env`; scheduler default, legacy rollback; immutable until shutdown | Accepted | Phase 2 |
-| D11 | Combat join eligibility | Next encounter round | Provisional | Phase 8 |
-| D12 | Encounter merge clock | Preserve survivor clock plus participant not-before guards | Provisional | Phase 8 |
-| D13 | Encounter splitting | Defer unless correctness or profiling requires it | Provisional | Phase 8 |
-| D14 | Linkdead combat policy | Preserve current behavior until separately reviewed | Provisional | Phase 8 |
+| D11 | Combat join eligibility | Preserve ordinary initial initiative deadlines; defer in-dispatch joins with a six-second not-before guard | Accepted | Phase 8 |
+| D12 | Encounter merge clock | Preserve the earliest live event plus every participant deadline and not-before guard | Accepted | Phase 8 |
+| D13 | Encounter splitting | Defer unless correctness or profiling requires it | Accepted | Phase 8 |
+| D14 | Linkdead combat policy | Preserve current continued-combat behavior until separately reviewed | Accepted | Phase 8 |
 | D15 | Reactor library | System libevent 2.1.12-stable or newer, core component, behind a Luminari-owned boundary | Accepted | Phase 3 |
 | D16 | Scheduler reactor timers | One wakeup armed from nearest deadline | Accepted | Phase 4 |
 | D17 | Domain dispatch | Typed, synchronous, main-thread, immutable borrowed payload | Accepted in Phase 6a | Phase 6 |
@@ -2204,8 +2223,8 @@ Before accepting version 1.0 of this specification, reviewers should confirm:
       rules are unambiguous.
 - [x] Existing pub/sub commands, data, documentation, and retirement obligations
       have an approved disposition.
-- [ ] Active/cooling-down/dormant wake and sleep rules cannot lose required work.
-- [ ] Encounter join, leave, merge, and termination rules are fair and complete.
+- [x] Active/cooling-down/dormant wake and sleep rules cannot lose required work.
+- [x] Encounter join, leave, merge, and termination rules are fair and complete.
 - [ ] Activity capability, trait, interruption, progress, and combat-time rules
       are coherent.
 - [ ] Migration phases are independently testable and reversible.
@@ -2240,3 +2259,4 @@ Before accepting version 1.0 of this specification, reviewers should confirm:
 | 1.11 | 2026-08-31 | Accepted the vessel Phase 7 slice after replacing Greyhawk fleet sweeps and converted-RoL object discovery with bounded lifecycle-owned deadlines, retaining exact half-second, 2.5-second, and mud-hour boundaries and established gameplay routines. One service event retains genuinely global vessel work, startup and boot-time rollback are all-or-nothing, diagnostics fit 80 columns, and the 987-test database/sanitizer/Valgrind plus eight-mode syntax and live-MUD gates pass. The mixed `point_update()` pulse is next. |
 | 1.12 | 2026-08-31 | Accepted the mud-hour point-update Phase 7 slice after replacing normal player/object discovery scans with one aligned service deadline and lifecycle-owned PC and active-object registries. Global-player-object ordering, timer/decay/corpse/idle gameplay, timer-trigger extraction, OLC/DG replacement safety, exclusive rollback, and compact diagnostics are preserved; the 991-test database/sanitizer/Valgrind, eight-mode syntax, and live-MUD gates pass. Immortal event observability is next before Phase 8. |
 | 1.13 | 2026-08-31 | Accepted the immortal observability gate after adding backend-neutral payload-free event inspection, readable paginated filters and profiles, complete scheduler queue/lifecycle/capacity telemetry, typed domain-handler views, and bounded I3 worker-ingress counters with an 80-column default and 120-column hard ceiling. Phase 8 encounter compatibility is next. |
+| 1.14 | 2026-08-31 | Accepted Phase 8 after replacing per-character combat clocks with one generation-aware event per encounter, preserving existing phase/action behavior, implementing safe joins, deferred mutation, encounter merges, all departure classes, typed lifecycle facts, compact diagnostics, and exclusive character-event rollback. Phase 9 semantic combat rounds are next. |

--- a/docs/ongoing-projects/README_ongoing-projects.md
+++ b/docs/ongoing-projects/README_ongoing-projects.md
@@ -20,7 +20,8 @@ their own analysis dates. Most retained legacy notes are grouped in
 
 | Document | Status | What remains |
 |----------|--------|--------------|
-| [EVENT_DRIVEN_CORE_REFACTOR_SPEC.md](EVENT_DRIVEN_CORE_REFACTOR_SPEC.md) | Controlling specification v1.13; Phases 1 through 7 plus the immortal observability gate accepted | Phase 8 encounter-level combat compatibility. |
+| [EVENT_DRIVEN_CORE_REFACTOR_SPEC.md](EVENT_DRIVEN_CORE_REFACTOR_SPEC.md) | Controlling specification v1.14; Phases 1 through 8 plus the immortal observability gate accepted | Phase 9 semantic combat rounds and gameplay-design approval. |
+| [EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md) | Phase 8 encounter compatibility acceptance evidence complete 2026-08-31 | One event per fight, compatibility cadence, safe joins/merges/departure, rollback, diagnostics, and full validation evidence. |
 | [EVENT_DRIVEN_CORE_REFACTOR_OBSERVABILITY_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_OBSERVABILITY_VALIDATION.md) | Immortal observability acceptance evidence complete 2026-08-31 | Backend-neutral queue inspection, compact metrics, safe filters, ingress visibility, redaction, and width bounds. |
 | [EVENT_DRIVEN_CORE_REFACTOR_PHASE7G_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_PHASE7G_VALIDATION.md) | Phase 7 mud-hour point-update acceptance evidence complete 2026-08-31 | Aligned service dispatch, PC and active-object registries, full timer/decay lifecycle, rollback, compact diagnostics, and validation evidence. |
 | [EVENT_DRIVEN_CORE_REFACTOR_PHASE7F_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_PHASE7F_VALIDATION.md) | Phase 7 vessel-owner acceptance evidence complete 2026-08-31 | Greyhawk and fixed-RoL ownership, global service work, exact cadence, lifecycle, rollback, diagnostics, and full validation evidence. |

--- a/docs/ongoing-projects/README_ongoing-projects.md
+++ b/docs/ongoing-projects/README_ongoing-projects.md
@@ -20,7 +20,8 @@ their own analysis dates. Most retained legacy notes are grouped in
 
 | Document | Status | What remains |
 |----------|--------|--------------|
-| [EVENT_DRIVEN_CORE_REFACTOR_SPEC.md](EVENT_DRIVEN_CORE_REFACTOR_SPEC.md) | Controlling specification v1.14; Phases 1 through 8 plus the immortal observability gate accepted | Phase 9 semantic combat rounds and gameplay-design approval. |
+| [EVENT_DRIVEN_CORE_REFACTOR_SPEC.md](EVENT_DRIVEN_CORE_REFACTOR_SPEC.md) | Controlling specification v1.15; Phases 1 through 9 plus the immortal observability gate accepted | Phase 10 activity manager and command-time decomposition. |
+| [EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_PHASE9_VALIDATION.md) | Phase 9 semantic-combat acceptance evidence complete 2026-08-31 | Shared six-second rounds, deterministic initiative, pre-initiative round/reaction state, one FIFO intent per turn, help, diagnostics, idle-clock repair, and full validation evidence. |
 | [EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_PHASE8_VALIDATION.md) | Phase 8 encounter compatibility acceptance evidence complete 2026-08-31 | One event per fight, compatibility cadence, safe joins/merges/departure, rollback, diagnostics, and full validation evidence. |
 | [EVENT_DRIVEN_CORE_REFACTOR_OBSERVABILITY_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_OBSERVABILITY_VALIDATION.md) | Immortal observability acceptance evidence complete 2026-08-31 | Backend-neutral queue inspection, compact metrics, safe filters, ingress visibility, redaction, and width bounds. |
 | [EVENT_DRIVEN_CORE_REFACTOR_PHASE7G_VALIDATION.md](EVENT_DRIVEN_CORE_REFACTOR_PHASE7G_VALIDATION.md) | Phase 7 mud-hour point-update acceptance evidence complete 2026-08-31 | Aligned service dispatch, PC and active-object registries, full timer/decay lifecycle, rollback, compact diagnostics, and validation evidence. |

--- a/docs/systems/COMBAT_SYSTEM.md
+++ b/docs/systems/COMBAT_SYSTEM.md
@@ -50,9 +50,9 @@ int get_initiative_modifier(struct char_data *ch);
 
 **Initiative Features:**
 - d20 roll + modifiers (DEX bonus, feats, etc.)
-- Combat list maintains initiative order
-- Event-driven timing based on initiative
-- Multiple combat phases for complex action resolution
+- Encounter participants retain the rolled initiative for the fight
+- One event resolves every due participant in deterministic initiative order
+- Dexterity and runtime identity resolve exact ties
 
 **Known Modifiers:**
 - Dexterity bonus
@@ -63,11 +63,19 @@ int get_initiative_modifier(struct char_data *ch);
 
 ### 3. Combat Round System
 
-Combat uses an event-driven system with multiple phases:
+Each live fight is a `combat_encounter_data` owner with one scheduled event.
+The event wakes once every six seconds, takes the due participant snapshot, and
+resolves turns by descending initiative, descending current Dexterity, and a
+stable runtime-ID tie-break. A participant admitted during resolution waits
+until the next encounter round. Merging fights preserves each participant's
+not-before deadline and then coalesces everyone onto the surviving clock.
 
 ```c
-// perform_violence() is the core combat execution function
-void perform_violence(struct char_data *ch, int phase) {
+// Abbreviated semantic-turn flow; perform_violence() remains the mechanics core.
+void combat_run_semantic_round(struct char_data *ch, bool was_hit) {
+    // Recover due action budgets and refresh reactions before this call.
+    execute_next_action(ch); // At most one validated FIFO intent.
+
     // Handle confused/feared states
     if (AFF_FLAGGED(ch, AFF_CONFUSED)) { /* confusion logic */ }
     if (AFF_FLAGGED(ch, AFF_FEAR)) { /* fear logic */ }
@@ -79,20 +87,29 @@ void perform_violence(struct char_data *ch, int phase) {
     if (!IS_CASTING(ch) && !AFF_FLAGGED(ch, AFF_TOTAL_DEFENSE) &&
         !(AFF_FLAGGED(ch, AFF_GRAPPLED) && /* grapple restrictions */)) {
         // Execute attack routine
-        perform_attacks(ch, NORMAL_ATTACK_ROUTINE, phase);
+        perform_attacks(ch, NORMAL_ATTACK_ROUTINE, PHASE_0);
 
         // Handle cleave attacks
-        if (phase == 1 && HAS_FEAT(ch, FEAT_CLEAVE))
+        if (HAS_FEAT(ch, FEAT_CLEAVE))
             handle_cleave(ch);
     }
 }
 ```
 
-**Combat Phases:**
-- PHASE_0: Full round actions
-- PHASE_1: Primary attacks
-- PHASE_2: Off-hand attacks
-- PHASE_3: Haste/extra attacks
+**Turn budgets:**
+- Standard plus move remaining after the queued intent: full attack rotation
+- Standard only, including staggered combatants: first attack portion
+- No standard action: no automatic attack
+- Swift action: independent budget
+- Reactions: refresh once at the shared round boundary, before initiative
+
+The action queue is bounded to 10 prevalidated FIFO commands. Exactly one head
+intent may dispatch at a semantic turn; the main connection loop does not poll
+or drain it between turns. Durations are rounded up to whole six-second turns.
+
+`LUMINARI_COMBAT_ROUNDS=compatibility` is the boot-time gameplay rollback. It
+keeps encounter ownership but runs the former three two-second phases. The
+semantic mode is the default and the two modes never execute together.
 
 ## Attack System
 

--- a/docs/systems/MUD_EVENTS.md
+++ b/docs/systems/MUD_EVENTS.md
@@ -17,6 +17,8 @@ Core source files:
 - [src/domain_event_runtime.c](../../src/domain_event_runtime.c)
 - [src/event_debug.h](../../src/event_debug.h)
 - [src/event_debug.c](../../src/event_debug.c)
+- [src/combat/combat_encounters.h](../../src/combat/combat_encounters.h)
+- [src/combat/combat_encounters.c](../../src/combat/combat_encounters.c)
 - [src/point_update_periodic.h](../../src/point_update_periodic.h)
 - [src/point_update_periodic.c](../../src/point_update_periodic.c)
 - [src/vessels/vessel_periodic.h](../../src/vessels/vessel_periodic.h)
@@ -394,6 +396,31 @@ retain their behavior. Current-owner extraction is iteration-safe, including
 idle rent and object timer triggers. `perfmon entities` reports this subsystem
 on five labeled rows bounded to the normal 80-column display.
 
+### 5.1 Combat Encounter Scheduling
+
+Combat defaults to one scheduled `combat_encounter_round` event per live fight.
+The process-local encounter registry supplies a typed ID and generation, while
+each participant stores its own next deadline and current compatibility phase.
+The one shared callback runs due participants in deadline and insertion order
+through `combat_run_compatibility_phase()`, the same routine used by the old
+per-character event. Existing two-second phases, six-second rounds, action
+queues, attacks, reactions, and effects therefore retain their behavior.
+
+Hostility creates, extends, or merges encounters. A join or merge during a
+callback is queued until the active participant iteration is safe to compact.
+Participant deadlines survive a merge, and an in-dispatch join has a
+six-second not-before guard. A participant leaving is inactive immediately;
+the event continues for the rest of the fight and is canceled exactly once
+when no active hostility remains. Movement, committed death, and extraction
+facts use generation-aware resolution, with direct extraction cleanup as an
+idempotent final guard.
+
+`eventdebug` includes a compact Combat encounters block. Use
+`eventdebug type combat_encounter_round` to inspect the shared event, owner ID,
+generation, and due time. The summary comparison count covers both the
+one-event-per-encounter invariant and phase terminal-accounting invariant.
+Payloads and participant identities are not displayed.
+
 ## 6. Table-Driven Registry (mud_event_index)
 
 - The registry lives in [C.mud_event_index[]](../../src/mud_event_list.c#L46)
@@ -548,6 +575,12 @@ on five labeled rows bounded to the normal 80-column display.
   - The selection jointly controls global, player, and object mud-hour point
     phases. Startup service-admission failure falls back to the whole legacy
     traversal; partial scheduled mode is not allowed.
+- Combat-round selection:
+  - Default: `LUMINARI_COMBAT_EVENTS=encounter`
+  - Rollback: `LUMINARI_COMBAT_EVENTS=legacy`
+  - The selection is immutable for the boot. Encounter mode owns one event per
+    fight; legacy mode owns one `eCOMBAT_ROUND` event per active character. The
+    paths never execute together and active fights are not converted live.
 - Startup logs one `Event backend initialized:` line naming the effective
   backend.
 - `perf event total` and the PERFMON CSV representation include lifecycle,

--- a/docs/systems/MUD_EVENTS.md
+++ b/docs/systems/MUD_EVENTS.md
@@ -81,6 +81,9 @@ game thread.
 
 - Create/schedule: [C.event_create_named_with_cleanup()](../../src/dgscript/dg_event.c)
   - Ensures a minimum delay of 1 pulse
+  - Converts the relative request to an absolute `live game pulse + delay`
+    scheduler deadline, so admission after an idle wheel interval cannot fire
+    early from a stale internal scheduler tick
   - Preserves the registered callback name for PERFMON even though all compatibility events share one internal scheduler event type
   - Returns a heap-allocated struct event whose payload is event_obj (type-specific)
 - Process every pulse: [C.event_process()](../../src/dgscript/dg_event.c)
@@ -281,12 +284,12 @@ this project means the socket connections between the MUD server and its
 players. It does not add web requests, internet gameplay, or a new command
 system.
 
-For a player, the intended result so far is deliberately boring: commands,
-round timing, cooldown messages, and copyover connections should behave as they
-did. The difference is reliability underneath. Timers cannot keep a deleted
-character or room alive, a burst of due timers cannot monopolize the server,
-and saved cooldowns now prove they belong to the character before returning
-after logout or reboot.
+Combat is now one player-visible use of that architecture. One event owns each
+fight and wakes a shared six-second round. Due combatants act by initiative;
+their standard, move, swift, and reaction resources are participant state, not
+independent timer callbacks. One prevalidated queued command runs at the start
+of a turn before automatic attacks. The connection loop does not poll that
+queue while the encounter owns it.
 
 The typed domain-event runtime now exists and owns one sealed main-thread
 registry from boot through world teardown. Eight foundational contracts cover
@@ -581,6 +584,14 @@ Payloads and participant identities are not displayed.
   - The selection is immutable for the boot. Encounter mode owns one event per
     fight; legacy mode owns one `eCOMBAT_ROUND` event per active character. The
     paths never execute together and active fights are not converted live.
+- Encounter-round rules:
+  - Default: `LUMINARI_COMBAT_ROUNDS=semantic`
+  - Rollback: `LUMINARI_COMBAT_ROUNDS=compatibility`
+  - Semantic mode resolves one initiative-ordered D20 round every six seconds
+    with participant-owned action, reaction, intent, and once-per-round state.
+    Compatibility mode retains the encounter-owned three-phase rules. This
+    selection is read only when encounter combat initializes and never converts
+    a live fight.
 - Startup logs one `Event backend initialized:` line naming the effective
   backend.
 - `perf event total` and the PERFMON CSV representation include lifecycle,

--- a/docs/systems/MUD_EVENTS.md
+++ b/docs/systems/MUD_EVENTS.md
@@ -402,12 +402,17 @@ on five labeled rows bounded to the normal 80-column display.
 ### 5.1 Combat Encounter Scheduling
 
 Combat defaults to one scheduled `combat_encounter_round` event per live fight.
-The process-local encounter registry supplies a typed ID and generation, while
-each participant stores its own next deadline and current compatibility phase.
-The one shared callback runs due participants in deadline and insertion order
-through `combat_run_compatibility_phase()`, the same routine used by the old
+The process-local encounter registry supplies a typed ID and generation. By
+default, `LUMINARI_COMBAT_ROUNDS=semantic` runs each six-second round through
+`combat_run_semantic_round()` in descending initiative order, with Dexterity
+and stable runtime identity breaking ties.
+
+With `LUMINARI_COMBAT_ROUNDS=compatibility`, each participant instead stores
+its own next deadline and current compatibility phase. The shared callback
+runs due participants in deadline and insertion order through
+`combat_run_compatibility_phase()`, the same routine used by the old
 per-character event. Existing two-second phases, six-second rounds, action
-queues, attacks, reactions, and effects therefore retain their behavior.
+queues, attacks, reactions, and effects retain their compatibility behavior.
 
 Hostility creates, extends, or merges encounters. A join or merge during a
 callback is queued until the active participant iteration is safe to compact.

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -623,7 +623,11 @@ action can enter the action queue only after a non-mutating availability check
 validates their current arguments. Commands without a safe advance check are
 not queued; retry those commands after the required action becomes available.
 
-QUEUE displays pending actions. QUEUE CLEAR removes all pending actions.
+The queue is first-in, first-out and holds at most 10 commands. During combat,
+one queued command is considered at the start of each six-second turn. If the
+first command still lacks its required action, it remains at the front. Queued
+commands do not drain between turns. QUEUE displays pending actions, and QUEUE
+CLEAR removes all pending actions.
 
 See also: ACTIONS, ATTACK-QUEUE, COMBAT
 #0
@@ -6547,25 +6551,23 @@ Combat may also be initiated via a CM, trip for example : trip <name>.  This
 command will initiate combat with a trip CM.
  
 Combat Rounds:
-The combat round lasts 6 seconds, divided into 3 2-second phases.  The attacks 
-in your attack rotation (help ATTACKS) are divided up between these phases in 
-the following way:
- 
-Phase 1: attacks 1, 4, 7
-Phase 2: attacks 2, 5, 8
-Phase 3: attacks 3, 6, 9
+One encounter round lasts 6 seconds. Everyone whose turn is ready acts from
+highest initiative to lowest. Ties use Dexterity and then a stable final order.
+Someone joining a fight becomes eligible on the encounter's next round; joining
+or merging fights never grants an extra early turn.
  
 You can check the number of attacks you have in your rotation by using the ATTACKS 
 command.  The number of attacks available is directly based on your Base Attack
 Bonus (BAB), which increases based on your class and level.
  
 Actions in Combat:
-Combat is directly affected by the actions you have available.  If you have 
-both a standard action and a move action available, you will automatically 
-perform a full attack every combat round, utilizing your entire attack rotation.
-If you have only a standard action, then only attacks in the first phase will be 
-performed.  If your character has neither a move nor a standard action, no 
-attacks will be made in this round.  See 'help ACTIONS' for more information.
+Your reaction allowance refreshes before initiative begins each round. At the
+start of your turn, due standard, move, and swift actions recover. One valid queued
+command is attempted first.
+Any actions it spends are unavailable to your automatic attack. If both your
+standard and move actions remain, you perform your full attack rotation. With
+only a standard action, you perform the first attack portion. With no standard
+action, you make no automatic attack. See 'help ACTIONS' and 'help ACTION-QUEUE'.
  
 Combat Modes:
 There are a number of combat modes available that change the way you fight.  

--- a/sql/components/ci_schema_manifest.txt
+++ b/sql/components/ci_schema_manifest.txt
@@ -26,6 +26,7 @@ apply help_race_half_ogre_entries.sql
 apply help_race_myconid_entries.sql
 apply help_race_wemic_entries.sql
 apply help_race_yuan_ti_entries.sql
+apply help_semantic_combat_entries.sql
 apply help_trelux_equipment_entries.sql
 apply help_specproc_entries.sql
 apply help_sync_schema.sql
@@ -61,6 +62,7 @@ skip verify_help_race_half_ogre_entries.sql
 skip verify_help_race_myconid_entries.sql
 skip verify_help_race_wemic_entries.sql
 skip verify_help_race_yuan_ti_entries.sql
+skip verify_help_semantic_combat_entries.sql
 skip verify_help_trelux_equipment_entries.sql
 skip verify_help_specproc_entries.sql
 skip verify_help_sync_schema.sql

--- a/sql/components/help_command_sweep_entries.sql
+++ b/sql/components/help_command_sweep_entries.sql
@@ -17,7 +17,11 @@ action can enter the action queue only after a non-mutating availability check
 validates their current arguments. Commands without a safe advance check are
 not queued; retry those commands after the required action becomes available.
 
-QUEUE displays pending actions. QUEUE CLEAR removes all pending actions.
+The queue is first-in, first-out and holds at most 10 commands. During combat,
+one queued command is considered at the start of each six-second turn. If the
+first command still lacks its required action, it remains at the front. Queued
+commands do not drain between turns. QUEUE displays pending actions, and QUEUE
+CLEAR removes all pending actions.
 
 See also: ACTIONS, ATTACK-QUEUE, COMBAT', 0, FALSE)
 ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),

--- a/sql/components/help_semantic_combat_entries.sql
+++ b/sql/components/help_semantic_combat_entries.sql
@@ -1,0 +1,43 @@
+-- Semantic encounter-round player help.
+--
+-- The database help system is authoritative. This migration is safe to run
+-- repeatedly and replaces the combat entry with the current round rules.
+
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated)
+VALUES ('combat', 'COMBAT
+
+Start combat with KILL <target>, HIT <target>, or a hostile combat maneuver.
+An attack maneuver already in your attack queue can replace a normal attack.
+
+COMBAT ROUNDS
+
+One encounter round lasts 6 seconds. Everyone whose turn is ready acts from
+highest initiative to lowest. Ties use Dexterity and then a stable final order.
+Someone joining a fight becomes eligible on the encounter''s next round;
+joining or merging fights never grants an extra early turn.
+
+ACTIONS IN COMBAT
+
+Your reaction allowance refreshes before initiative begins each round. At the
+start of your turn, due standard, move, and swift actions recover.
+One valid queued command is attempted first.
+Any actions it spends are unavailable to your automatic attack. If both your
+standard and move actions remain, you perform your full attack rotation. With
+only a standard action, you perform the first attack portion. With no standard
+action, you make no automatic attack.
+
+See also: ACTIONS, ACTION-QUEUE, ATTACK-QUEUE, ATTACKS, COMBAT-MODES', 0, FALSE)
+ON DUPLICATE KEY UPDATE entry = VALUES(entry), min_level = VALUES(min_level),
+  auto_generated = VALUES(auto_generated);
+
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN ('COMBAT', 'COMBAT-PHASE', 'COMBAT-ROUNDS', 'FIGHTING')
+  AND help_tag <> 'combat';
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES ('combat', 'COMBAT');
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES ('combat', 'COMBAT-PHASE');
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES ('combat', 'COMBAT-ROUNDS');
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES ('combat', 'FIGHTING');
+
+COMMIT;

--- a/sql/components/verify_help_command_sweep_entries.sql
+++ b/sql/components/verify_help_command_sweep_entries.sql
@@ -33,11 +33,13 @@ WHERE (help_tag, UPPER(keyword)) IN (
 SELECT
   'command_sweep_content' AS check_name,
   COUNT(*) AS actual,
-  8 AS expected,
-  IF(COUNT(*) = 8, 'PASS', 'FAIL') AS result
+  10 AS expected,
+  IF(COUNT(*) = 10, 'PASS', 'FAIL') AS result
 FROM help_entries AS h
 JOIN (
   SELECT 'action-queue' AS tag, 'non-mutating availability check' AS required_text
+  UNION ALL SELECT 'action-queue', 'holds at most 10 commands'
+  UNION ALL SELECT 'action-queue', 'do not drain between turns'
   UNION ALL SELECT 'autoblast', 'enabled or disabled'
   UNION ALL SELECT 'consumables', 'USESTOREDCONSUMABLES enables or disables'
   UNION ALL SELECT 'spellrecall', 'once per real-world day'

--- a/sql/components/verify_help_semantic_combat_entries.sql
+++ b/sql/components/verify_help_semantic_combat_entries.sql
@@ -1,0 +1,33 @@
+-- Read-only verification for help_semantic_combat_entries.sql.
+
+SELECT
+  'semantic_combat_entry' AS check_name,
+  COUNT(*) AS actual,
+  1 AS expected,
+  IF(COUNT(*) = 1, 'PASS', 'FAIL') AS result
+FROM help_entries
+WHERE tag = 'combat'
+  AND min_level = 0
+  AND auto_generated = FALSE
+  AND INSTR(entry, 'One encounter round lasts 6 seconds') > 0
+  AND INSTR(entry, 'highest initiative to lowest') > 0
+  AND INSTR(entry, 'One valid queued command is attempted first') > 0
+  AND INSTR(entry, 'full attack rotation') > 0;
+
+SELECT
+  'semantic_combat_keywords' AS check_name,
+  COUNT(*) AS actual,
+  4 AS expected,
+  IF(COUNT(*) = 4, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE help_tag = 'combat'
+  AND UPPER(keyword) IN ('COMBAT', 'COMBAT-PHASE', 'COMBAT-ROUNDS', 'FIGHTING');
+
+SELECT
+  'semantic_combat_keyword_conflicts' AS check_name,
+  COUNT(*) AS actual,
+  0 AS expected,
+  IF(COUNT(*) = 0, 'PASS', 'FAIL') AS result
+FROM help_keywords
+WHERE UPPER(keyword) IN ('COMBAT', 'COMBAT-PHASE', 'COMBAT-ROUNDS', 'FIGHTING')
+  AND help_tag <> 'combat';

--- a/src/actionqueues.c
+++ b/src/actionqueues.c
@@ -18,6 +18,7 @@
 #include "actionqueues.h"
 #include "mud_event.h"
 #include "actions.h"
+#include "combat/combat_encounters.h"
 
 /* Initialize the queue, must be performed on any new queues. */
 struct queue_type *create_queue()
@@ -233,6 +234,8 @@ void execute_next_action(struct char_data *ch)
     return;
 
   if (!command_actions_available(ch, action->actions_required))
+    return;
+  if (!combat_encounter_intent_claim(ch))
     return;
 
   action = dequeue_action(GET_QUEUE(ch));

--- a/src/actions.c
+++ b/src/actions.c
@@ -19,6 +19,7 @@
 #include "mud_event.h"
 #include "actions.h"
 #include "act.h"
+#include "combat/combat_encounters.h"
 #include "magic/domains_schools.h"
 
 /*  Attack action definitions - Define the relationships between
@@ -141,6 +142,20 @@ bool is_action_available(struct char_data *ch, action_type act_type, bool msg_to
 {
   bool result = TRUE;
 
+  if (combat_encounter_action_query(ch, act_type, &result))
+  {
+    if (!result && msg_to_char)
+    {
+      if (act_type == atSTANDARD)
+        send_to_char(ch, "You don't have a standard action.\r\n");
+      else if (act_type == atMOVE)
+        send_to_char(ch, "You don't have a move action.\r\n");
+      else if (act_type == atSWIFT)
+        send_to_char(ch, "You don't have a swift action.\r\n");
+    }
+    return result;
+  }
+
   if (act_type == atSTANDARD)
   {
     /* Is ch on standard action cooldown? */
@@ -217,6 +232,19 @@ void start_skill_cooldown(struct char_data *ch, int skill, int weapon)
 void start_action_cooldown(struct char_data *ch, action_type act_type, int duration)
 {
   char svar[50];
+
+  if (combat_encounter_action_consume(ch, act_type, duration))
+  {
+    if (AFF_FLAGGED(ch, AFF_STAGGERED))
+    {
+      if (act_type == atMOVE)
+        combat_encounter_action_consume(ch, atSTANDARD, duration);
+      else if (act_type == atSTANDARD)
+        combat_encounter_action_consume(ch, atMOVE, duration);
+    }
+    update_msdp_actions(ch);
+    return;
+  }
 
   /* Format the sVariables - Always duration first. */
   snprintf(svar, sizeof(svar), "%d", duration);

--- a/src/character/perks.c
+++ b/src/character/perks.c
@@ -22,6 +22,7 @@
 #include "class.h"
 #include "perks.h"
 #include "combat/assign_wpn_armor.h"
+#include "combat/combat_encounters.h"
 #include "combat/projectiles.h"
 
 /* Undefine NUM_ABILITIES before including spells.h to avoid redefinition warning */
@@ -3716,10 +3717,14 @@ bool has_blackguard_relentless_assault(struct char_data *ch)
  */
 bool can_trigger_relentless_assault(struct char_data *ch)
 {
+  bool used;
+
   if (!has_blackguard_relentless_assault(ch))
     return FALSE;
 
-  /* Check if already triggered this round */
+  if (combat_encounter_round_flag_query(
+          ch, COMBAT_ENCOUNTER_ROUND_RELENTLESS_ASSAULT_USED, &used))
+    return !used;
   return (char_has_mud_event(ch, eRELENTLESS_ASSAULT) == NULL);
 }
 
@@ -3740,8 +3745,9 @@ void trigger_relentless_assault(struct char_data *ch)
   /* Grant extra attack (implementation hook needed in combat code) */
   /* TODO: Hook into combat system to grant extra attack */
 
-  /* Set 1-round cooldown */
-  NEW_EVENT(eRELENTLESS_ASSAULT, ch, NULL, 6 * PASSES_PER_SEC); /* 1 round = 6 seconds */
+  if (!combat_encounter_round_flag_mark(
+          ch, COMBAT_ENCOUNTER_ROUND_RELENTLESS_ASSAULT_USED))
+    NEW_EVENT(eRELENTLESS_ASSAULT, ch, NULL, 6 * PASSES_PER_SEC);
 }
 
 /**

--- a/src/combat/combat_encounters.c
+++ b/src/combat/combat_encounters.c
@@ -1,0 +1,1083 @@
+#include "conf.h"
+#include "sysdep.h"
+#include "structs.h"
+#include "utils.h"
+#include "comm.h"
+#include "dotenv.h"
+#include "combat/combat_encounters.h"
+#include "combat/fight.h"
+#include "dgscript/dg_event.h"
+#include "domain_event_runtime.h"
+#include "domain_event_types.h"
+#include "domain_event_world.h"
+
+#define COMBAT_ENCOUNTER_MAX_ACTIVE 32768U
+#define COMBAT_ENCOUNTER_PHASE_DELAY ((uint64_t)(2 RL_SEC))
+#define COMBAT_ENCOUNTER_JOIN_GUARD ((uint64_t)(6 RL_SEC))
+
+struct combat_encounter_participant
+{
+  struct combat_encounter_data *encounter;
+  struct char_data *character;
+  struct domain_entity_handle character_handle;
+  struct combat_encounter_participant *previous;
+  struct combat_encounter_participant *next;
+  struct combat_encounter_participant *due_previous;
+  struct combat_encounter_participant *due_next;
+  uint64_t next_due;
+  uint64_t due_sequence;
+  unsigned int phase;
+  bool active;
+  bool pending_add;
+  bool pending_activation;
+  bool in_due_list;
+  bool dispatching;
+  bool departing;
+};
+
+struct combat_encounter_data
+{
+  uint64_t id;
+  uint64_t generation;
+  struct event *event;
+  struct combat_encounter_participant *participants;
+  struct combat_encounter_participant *participants_tail;
+  struct combat_encounter_participant *pending_additions;
+  struct combat_encounter_participant *pending_additions_tail;
+  struct combat_encounter_participant *due_head;
+  struct combat_encounter_participant *due_tail;
+  struct combat_encounter_data *registry_previous;
+  struct combat_encounter_data *registry_next;
+  struct combat_encounter_data *pending_merge_head;
+  struct combat_encounter_data *pending_merge_tail;
+  struct combat_encounter_data *pending_merge_next;
+  struct combat_encounter_data *pending_into;
+  uint64_t compatibility_phase;
+  uint64_t compatibility_round;
+  bool resolving;
+  bool terminal;
+};
+
+struct combat_encounter_slot
+{
+  struct combat_encounter_data *encounter;
+  uint64_t generation;
+  uint32_t next_free;
+};
+
+struct combat_encounter_event_payload
+{
+  uint64_t id;
+  uint64_t generation;
+};
+
+static struct combat_encounter_slot encounter_slots[COMBAT_ENCOUNTER_MAX_ACTIVE];
+static uint32_t free_slot_head;
+static struct combat_encounter_data *encounter_registry;
+static bool initialized;
+static bool encounter_mode;
+static bool shutting_down;
+static size_t active_encounter_count;
+static size_t active_participant_count;
+static size_t scheduled_event_count;
+static uint64_t next_due_sequence = 1U;
+static struct combat_encounter_stats cumulative_stats;
+static struct domain_event_bus *encounter_bus;
+
+#ifdef LUMINARI_CUTEST
+static bool test_selection_set;
+static bool test_encounter_mode;
+static combat_encounter_test_phase_callback test_phase_callback;
+static void *test_phase_context;
+#endif
+
+static bool configured_encounter_mode(void)
+{
+  const char *value;
+
+#ifdef LUMINARI_CUTEST
+  if (test_selection_set)
+    return test_encounter_mode;
+#endif
+  value = getenv("LUMINARI_COMBAT_EVENTS");
+  if (value == NULL || *value == '\0')
+    value = get_env_value("LUMINARI_COMBAT_EVENTS");
+  if (value == NULL || *value == '\0' || !strcasecmp(value, "encounter") ||
+      !strcasecmp(value, "scheduled") || !strcasecmp(value, "event"))
+    return true;
+  if (!strcasecmp(value, "legacy") || !strcasecmp(value, "character") ||
+      !strcasecmp(value, "off"))
+    return false;
+  log("WARNING: Unknown LUMINARI_COMBAT_EVENTS '%s'; using encounter events.", value);
+  return true;
+}
+
+static void counter_increment(uint64_t *counter)
+{
+  if (counter != NULL && *counter < UINT64_MAX)
+    (*counter)++;
+}
+
+static uint64_t allocate_due_sequence(void)
+{
+  uint64_t sequence = next_due_sequence;
+
+  if (next_due_sequence == UINT64_MAX)
+    next_due_sequence = 1U;
+  else
+    next_due_sequence++;
+  return sequence;
+}
+
+static struct combat_encounter_data *resolve_encounter(uint64_t id, uint64_t generation)
+{
+  struct combat_encounter_slot *slot;
+
+  if (id == 0U || id > COMBAT_ENCOUNTER_MAX_ACTIVE)
+    return NULL;
+  slot = &encounter_slots[id - 1U];
+  if (slot->encounter == NULL || slot->generation != generation)
+    return NULL;
+  return slot->encounter;
+}
+
+static bool allocate_encounter_slot(struct combat_encounter_data *encounter)
+{
+  struct combat_encounter_slot *slot;
+  uint32_t index;
+
+  if (encounter == NULL || free_slot_head == UINT32_MAX)
+    return false;
+  index = free_slot_head;
+  slot = &encounter_slots[index];
+  free_slot_head = slot->next_free;
+  if (slot->generation == 0U)
+    slot->generation = 1U;
+  slot->encounter = encounter;
+  slot->next_free = UINT32_MAX;
+  encounter->id = (uint64_t)index + 1U;
+  encounter->generation = slot->generation;
+  return true;
+}
+
+static void release_encounter_slot(struct combat_encounter_data *encounter)
+{
+  struct combat_encounter_slot *slot;
+  uint32_t index;
+
+  if (encounter == NULL || encounter->id == 0U ||
+      encounter->id > COMBAT_ENCOUNTER_MAX_ACTIVE)
+    return;
+  index = (uint32_t)(encounter->id - 1U);
+  slot = &encounter_slots[index];
+  if (slot->encounter != encounter)
+    return;
+  slot->encounter = NULL;
+  if (slot->generation == UINT64_MAX)
+    slot->generation = 1U;
+  else
+    slot->generation++;
+  slot->next_free = free_slot_head;
+  free_slot_head = index;
+}
+
+static void registry_link(struct combat_encounter_data *encounter)
+{
+  encounter->registry_previous = NULL;
+  encounter->registry_next = encounter_registry;
+  if (encounter_registry != NULL)
+    encounter_registry->registry_previous = encounter;
+  encounter_registry = encounter;
+  active_encounter_count++;
+  if (active_encounter_count > cumulative_stats.high_water_encounters)
+    cumulative_stats.high_water_encounters = active_encounter_count;
+}
+
+static void registry_unlink(struct combat_encounter_data *encounter)
+{
+  if (encounter->registry_previous != NULL)
+    encounter->registry_previous->registry_next = encounter->registry_next;
+  else if (encounter_registry == encounter)
+    encounter_registry = encounter->registry_next;
+  if (encounter->registry_next != NULL)
+    encounter->registry_next->registry_previous = encounter->registry_previous;
+  encounter->registry_previous = NULL;
+  encounter->registry_next = NULL;
+  if (active_encounter_count > 0U)
+    active_encounter_count--;
+}
+
+static void member_append(struct combat_encounter_data *encounter,
+                          struct combat_encounter_participant *participant)
+{
+  participant->previous = encounter->participants_tail;
+  participant->next = NULL;
+  if (encounter->participants_tail != NULL)
+    encounter->participants_tail->next = participant;
+  else
+    encounter->participants = participant;
+  encounter->participants_tail = participant;
+  participant->pending_add = false;
+}
+
+static void pending_append(struct combat_encounter_data *encounter,
+                           struct combat_encounter_participant *participant)
+{
+  participant->previous = encounter->pending_additions_tail;
+  participant->next = NULL;
+  if (encounter->pending_additions_tail != NULL)
+    encounter->pending_additions_tail->next = participant;
+  else
+    encounter->pending_additions = participant;
+  encounter->pending_additions_tail = participant;
+  participant->pending_add = true;
+}
+
+static void member_remove(struct combat_encounter_data *encounter,
+                          struct combat_encounter_participant *participant)
+{
+  struct combat_encounter_participant **head;
+  struct combat_encounter_participant **tail;
+
+  if (participant->pending_add)
+  {
+    head = &encounter->pending_additions;
+    tail = &encounter->pending_additions_tail;
+  }
+  else
+  {
+    head = &encounter->participants;
+    tail = &encounter->participants_tail;
+  }
+  if (participant->previous != NULL)
+    participant->previous->next = participant->next;
+  else if (*head == participant)
+    *head = participant->next;
+  if (participant->next != NULL)
+    participant->next->previous = participant->previous;
+  else if (*tail == participant)
+    *tail = participant->previous;
+  participant->previous = NULL;
+  participant->next = NULL;
+}
+
+static bool participant_due_before(const struct combat_encounter_participant *left,
+                                   const struct combat_encounter_participant *right)
+{
+  if (left->next_due != right->next_due)
+    return left->next_due < right->next_due;
+  if (left->due_sequence != right->due_sequence)
+    return left->due_sequence < right->due_sequence;
+  return left->character_handle.runtime_id < right->character_handle.runtime_id;
+}
+
+static void due_remove(struct combat_encounter_data *encounter,
+                       struct combat_encounter_participant *participant)
+{
+  if (encounter == NULL || participant == NULL || !participant->in_due_list)
+    return;
+  if (participant->due_previous != NULL)
+    participant->due_previous->due_next = participant->due_next;
+  else
+    encounter->due_head = participant->due_next;
+  if (participant->due_next != NULL)
+    participant->due_next->due_previous = participant->due_previous;
+  else
+    encounter->due_tail = participant->due_previous;
+  participant->due_previous = NULL;
+  participant->due_next = NULL;
+  participant->in_due_list = false;
+}
+
+static void due_insert(struct combat_encounter_data *encounter,
+                       struct combat_encounter_participant *participant)
+{
+  struct combat_encounter_participant *cursor;
+
+  if (encounter == NULL || participant == NULL || !participant->active ||
+      participant->pending_add || participant->pending_activation)
+    return;
+  due_remove(encounter, participant);
+  for (cursor = encounter->due_head; cursor != NULL; cursor = cursor->due_next)
+    if (participant_due_before(participant, cursor))
+      break;
+  if (cursor == NULL)
+  {
+    participant->due_previous = encounter->due_tail;
+    participant->due_next = NULL;
+    if (encounter->due_tail != NULL)
+      encounter->due_tail->due_next = participant;
+    else
+      encounter->due_head = participant;
+    encounter->due_tail = participant;
+  }
+  else
+  {
+    participant->due_previous = cursor->due_previous;
+    participant->due_next = cursor;
+    if (cursor->due_previous != NULL)
+      cursor->due_previous->due_next = participant;
+    else
+      encounter->due_head = participant;
+    cursor->due_previous = participant;
+  }
+  participant->in_due_list = true;
+}
+
+static void free_participant(struct combat_encounter_participant *participant)
+{
+  if (participant == NULL)
+    return;
+  if (participant->character != NULL &&
+      participant->character->combat_encounter_participant == participant)
+  {
+    participant->character->combat_encounter = NULL;
+    participant->character->combat_encounter_participant = NULL;
+  }
+  free(participant);
+  if (active_participant_count > 0U)
+    active_participant_count--;
+}
+
+static void detach_participant(struct combat_encounter_data *encounter,
+                               struct combat_encounter_participant *participant)
+{
+  due_remove(encounter, participant);
+  member_remove(encounter, participant);
+  free_participant(participant);
+}
+
+static struct combat_encounter_participant *add_participant(
+    struct combat_encounter_data *encounter, struct char_data *character)
+{
+  struct combat_encounter_participant *participant;
+
+  if (encounter == NULL || character == NULL || character->combat_encounter != NULL)
+    return NULL;
+  participant = calloc(1U, sizeof(*participant));
+  if (participant == NULL)
+    return NULL;
+  participant->encounter = encounter;
+  participant->character = character;
+  participant->character_handle = domain_event_character_handle(character);
+  participant->phase = 1U;
+  if (encounter->resolving)
+    pending_append(encounter, participant);
+  else
+    member_append(encounter, participant);
+  character->combat_encounter = encounter;
+  character->combat_encounter_participant = participant;
+  active_participant_count++;
+  if (active_participant_count > cumulative_stats.high_water_participants)
+    cumulative_stats.high_water_participants = active_participant_count;
+  counter_increment(&cumulative_stats.participants_joined);
+  return participant;
+}
+
+static void activate_participant(struct combat_encounter_participant *participant,
+                                 long initial_delay)
+{
+  uint64_t delay;
+  uint64_t due;
+
+  if (participant == NULL || participant->active || participant->pending_activation)
+    return;
+  delay = initial_delay > 0L ? (uint64_t)initial_delay : 1U;
+  due = (uint64_t)pulse + delay;
+  if (participant->encounter->resolving)
+  {
+    due = MAX(due, (uint64_t)pulse + COMBAT_ENCOUNTER_JOIN_GUARD);
+    participant->pending_activation = true;
+  }
+  else
+    participant->active = true;
+  participant->phase = 1U;
+  participant->next_due = due;
+  participant->due_sequence = allocate_due_sequence();
+  if (participant->active)
+    due_insert(participant->encounter, participant);
+}
+
+static struct combat_encounter_data *create_encounter(void)
+{
+  struct combat_encounter_data *encounter;
+
+  encounter = calloc(1U, sizeof(*encounter));
+  if (encounter == NULL || !allocate_encounter_slot(encounter))
+  {
+    free(encounter);
+    counter_increment(&cumulative_stats.admission_failures);
+    return NULL;
+  }
+  registry_link(encounter);
+  encounter->compatibility_phase = 1U;
+  encounter->compatibility_round = 1U;
+  counter_increment(&cumulative_stats.encounters_created);
+  return encounter;
+}
+
+static struct event *create_round_event(struct combat_encounter_data *encounter, uint64_t delay);
+static void destroy_encounter(struct combat_encounter_data *encounter, bool dispatching);
+
+static bool ensure_round_event(struct combat_encounter_data *encounter)
+{
+  struct event *replacement;
+  uint64_t delay;
+
+  if (encounter == NULL || encounter->terminal || encounter->due_head == NULL)
+    return false;
+  delay = encounter->due_head->next_due > (uint64_t)pulse
+              ? encounter->due_head->next_due - (uint64_t)pulse
+              : 1U;
+  if (encounter->event == NULL)
+  {
+    encounter->event = create_round_event(encounter, delay);
+    if (encounter->event == NULL)
+      return false;
+    scheduled_event_count++;
+    return true;
+  }
+  if (encounter->resolving || event_time(encounter->event) <= (long)delay)
+    return true;
+  replacement = create_round_event(encounter, delay);
+  if (replacement == NULL)
+    return true;
+  event_cancel(encounter->event);
+  encounter->event = replacement;
+  return true;
+}
+
+static bool has_pending_hostility(const struct combat_encounter_data *encounter)
+{
+  const struct combat_encounter_participant *participant;
+
+  for (participant = encounter->participants; participant != NULL;
+       participant = participant->next)
+    if (participant->active && participant->character != NULL &&
+        FIGHTING(participant->character) != NULL)
+      return true;
+  for (participant = encounter->pending_additions; participant != NULL;
+       participant = participant->next)
+    if ((participant->active || participant->pending_activation) &&
+        participant->character != NULL && FIGHTING(participant->character) != NULL)
+      return true;
+  return false;
+}
+
+static void maybe_end_encounter(struct combat_encounter_data *encounter)
+{
+  if (encounter == NULL || encounter->terminal || has_pending_hostility(encounter))
+    return;
+  encounter->terminal = true;
+  if (!encounter->resolving && encounter->pending_into == NULL)
+    destroy_encounter(encounter, false);
+}
+
+static void destroy_encounter(struct combat_encounter_data *encounter, bool dispatching)
+{
+  struct combat_encounter_participant *participant;
+  struct combat_encounter_participant *next;
+
+  if (encounter == NULL)
+    return;
+  if (encounter->event != NULL)
+  {
+    if (!dispatching)
+      event_cancel(encounter->event);
+    encounter->event = NULL;
+    if (scheduled_event_count > 0U)
+      scheduled_event_count--;
+  }
+  for (participant = encounter->participants; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    free_participant(participant);
+  }
+  for (participant = encounter->pending_additions; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    free_participant(participant);
+  }
+  encounter->participants = NULL;
+  encounter->participants_tail = NULL;
+  encounter->pending_additions = NULL;
+  encounter->pending_additions_tail = NULL;
+  encounter->due_head = NULL;
+  encounter->due_tail = NULL;
+  registry_unlink(encounter);
+  release_encounter_slot(encounter);
+  counter_increment(&cumulative_stats.encounters_ended);
+  free(encounter);
+}
+
+static struct combat_encounter_data *merge_root(struct combat_encounter_data *encounter)
+{
+  while (encounter != NULL && encounter->pending_into != NULL)
+    encounter = encounter->pending_into;
+  return encounter;
+}
+
+static void detach_terminal_membership(struct char_data *character)
+{
+  struct combat_encounter_participant *participant;
+  struct combat_encounter_data *encounter;
+
+  if (character == NULL || character->combat_encounter_participant == NULL ||
+      character->combat_encounter == NULL || !character->combat_encounter->terminal)
+    return;
+  participant = character->combat_encounter_participant;
+  encounter = participant->encounter;
+  participant->active = false;
+  participant->pending_activation = false;
+  participant->departing = true;
+  due_remove(encounter, participant);
+  character->combat_encounter = NULL;
+  character->combat_encounter_participant = NULL;
+  counter_increment(&cumulative_stats.participants_left);
+  counter_increment(
+      &cumulative_stats.departure_counts[COMBAT_ENCOUNTER_DEPARTURE_ADMINISTRATIVE]);
+  if (!encounter->resolving)
+    detach_participant(encounter, participant);
+}
+
+static void queue_merge(struct combat_encounter_data *survivor,
+                        struct combat_encounter_data *absorbed)
+{
+  if (survivor == NULL || absorbed == NULL || survivor == absorbed ||
+      absorbed->pending_into == survivor)
+    return;
+  absorbed->pending_into = survivor;
+  absorbed->pending_merge_next = NULL;
+  if (survivor->pending_merge_tail != NULL)
+    survivor->pending_merge_tail->pending_merge_next = absorbed;
+  else
+    survivor->pending_merge_head = absorbed;
+  survivor->pending_merge_tail = absorbed;
+}
+
+static void transfer_participant(struct combat_encounter_data *survivor,
+                                 struct combat_encounter_data *absorbed,
+                                 struct combat_encounter_participant *participant)
+{
+  due_remove(absorbed, participant);
+  member_remove(absorbed, participant);
+  participant->encounter = survivor;
+  if (participant->character != NULL &&
+      participant->character->combat_encounter_participant == participant)
+    participant->character->combat_encounter = survivor;
+  member_append(survivor, participant);
+  if (participant->active)
+    due_insert(survivor, participant);
+}
+
+static void merge_now(struct combat_encounter_data *survivor,
+                      struct combat_encounter_data *absorbed)
+{
+  struct combat_encounter_participant *participant;
+  struct combat_encounter_participant *next;
+
+  if (survivor == NULL || absorbed == NULL || survivor == absorbed)
+    return;
+  if (absorbed->event != NULL)
+  {
+    event_cancel(absorbed->event);
+    absorbed->event = NULL;
+    if (scheduled_event_count > 0U)
+      scheduled_event_count--;
+  }
+  for (participant = absorbed->participants; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    transfer_participant(survivor, absorbed, participant);
+  }
+  for (participant = absorbed->pending_additions; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    member_remove(absorbed, participant);
+    participant->encounter = survivor;
+    if (participant->character != NULL &&
+        participant->character->combat_encounter_participant == participant)
+      participant->character->combat_encounter = survivor;
+    pending_append(survivor, participant);
+  }
+  absorbed->participants = NULL;
+  absorbed->participants_tail = NULL;
+  absorbed->pending_additions = NULL;
+  absorbed->pending_additions_tail = NULL;
+  absorbed->due_head = NULL;
+  absorbed->due_tail = NULL;
+  absorbed->pending_into = NULL;
+  registry_unlink(absorbed);
+  release_encounter_slot(absorbed);
+  counter_increment(&cumulative_stats.encounters_merged);
+  free(absorbed);
+  (void)ensure_round_event(survivor);
+}
+
+static struct combat_encounter_data *merge_encounters(struct combat_encounter_data *left,
+                                                      struct combat_encounter_data *right)
+{
+  struct combat_encounter_data *survivor;
+  struct combat_encounter_data *absorbed;
+
+  left = merge_root(left);
+  right = merge_root(right);
+  if (left == NULL)
+    return right;
+  if (right == NULL || left == right)
+    return left;
+  if (left->resolving)
+  {
+    queue_merge(left, right);
+    return left;
+  }
+  if (right->resolving)
+  {
+    queue_merge(right, left);
+    return right;
+  }
+  if (left->due_head == NULL ||
+      (right->due_head != NULL && participant_due_before(right->due_head, left->due_head)))
+  {
+    survivor = right;
+    absorbed = left;
+  }
+  else
+  {
+    survivor = left;
+    absorbed = right;
+  }
+  merge_now(survivor, absorbed);
+  return survivor;
+}
+
+static void apply_pending_additions(struct combat_encounter_data *encounter)
+{
+  struct combat_encounter_participant *participant;
+  struct combat_encounter_participant *next;
+
+  for (participant = encounter->pending_additions; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    member_remove(encounter, participant);
+    member_append(encounter, participant);
+    if (participant->pending_activation)
+    {
+      participant->pending_activation = false;
+      participant->active = true;
+      participant->due_sequence = allocate_due_sequence();
+      due_insert(encounter, participant);
+    }
+  }
+  for (participant = encounter->participants; participant != NULL; participant = participant->next)
+  {
+    if (!participant->pending_activation)
+      continue;
+    participant->pending_activation = false;
+    participant->active = true;
+    participant->due_sequence = allocate_due_sequence();
+    due_insert(encounter, participant);
+  }
+}
+
+static void compact_inactive_participants(struct combat_encounter_data *encounter)
+{
+  struct combat_encounter_participant *participant;
+  struct combat_encounter_participant *next;
+
+  for (participant = encounter->participants; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    if (participant->departing)
+      detach_participant(encounter, participant);
+  }
+  for (participant = encounter->pending_additions; participant != NULL; participant = next)
+  {
+    next = participant->next;
+    if (participant->departing)
+      detach_participant(encounter, participant);
+  }
+}
+
+static bool apply_pending_merges(struct combat_encounter_data *encounter)
+{
+  struct combat_encounter_data *absorbed;
+  bool merged = false;
+
+  while (encounter->pending_merge_head != NULL)
+  {
+    absorbed = encounter->pending_merge_head;
+    encounter->pending_merge_head = absorbed->pending_merge_next;
+    if (encounter->pending_merge_head == NULL)
+      encounter->pending_merge_tail = NULL;
+    absorbed->pending_merge_next = NULL;
+    if (absorbed->terminal)
+      destroy_encounter(absorbed, false);
+    else
+      merge_now(encounter, absorbed);
+    merged = true;
+  }
+  return merged;
+}
+
+static bool run_compatibility_phase(struct char_data *character, unsigned int phase)
+{
+#ifdef LUMINARI_CUTEST
+  if (test_phase_callback != NULL)
+    return test_phase_callback(character, phase, test_phase_context);
+#endif
+  return combat_run_compatibility_phase(character, phase);
+}
+
+EVENTFUNC(combat_encounter_round_event)
+{
+  struct combat_encounter_event_payload *payload = event_obj;
+  struct combat_encounter_data *encounter;
+  struct combat_encounter_participant *participant;
+  bool completed;
+  bool merged;
+  uint64_t delay;
+
+  if (payload == NULL)
+    return 0;
+  encounter = resolve_encounter(payload->id, payload->generation);
+  if (encounter == NULL)
+  {
+    counter_increment(&cumulative_stats.stale_encounter_callbacks);
+    event_note_stale_owner_outcome();
+    free(payload);
+    return 0;
+  }
+  counter_increment(&cumulative_stats.encounter_callbacks);
+  encounter->resolving = true;
+  do
+  {
+  while (encounter->due_head != NULL &&
+           encounter->due_head->next_due <= (uint64_t)pulse)
+    {
+      participant = encounter->due_head;
+      due_remove(encounter, participant);
+      if (encounter_bus != NULL &&
+          domain_event_resolve(encounter_bus, participant->character_handle,
+                               DOMAIN_ENTITY_CHARACTER) != participant->character)
+      {
+        event_note_stale_owner_outcome();
+        counter_increment(&cumulative_stats.stale_encounter_callbacks);
+        participant->active = false;
+        participant->departing = true;
+        continue;
+      }
+      participant->dispatching = true;
+      counter_increment(&cumulative_stats.compatibility_attempts);
+      completed = run_compatibility_phase(participant->character, participant->phase);
+      participant->dispatching = false;
+      if (completed)
+        counter_increment(&cumulative_stats.compatibility_phases);
+      else
+        counter_increment(&cumulative_stats.compatibility_terminal);
+      if (participant->active && participant->encounter == encounter && completed)
+      {
+        participant->phase = participant->phase < 3U ? participant->phase + 1U : 1U;
+        participant->next_due = (uint64_t)pulse + COMBAT_ENCOUNTER_PHASE_DELAY;
+        participant->due_sequence = allocate_due_sequence();
+        due_insert(encounter, participant);
+      }
+      else if (participant->active && participant->encounter == encounter)
+      {
+        participant->active = false;
+        participant->departing = true;
+      }
+    }
+    compact_inactive_participants(encounter);
+    apply_pending_additions(encounter);
+    merged = apply_pending_merges(encounter);
+  } while (merged);
+  encounter->compatibility_phase = encounter->compatibility_phase < 3U
+                                       ? encounter->compatibility_phase + 1U
+                                       : 1U;
+  if (encounter->compatibility_phase == 1U)
+    counter_increment(&encounter->compatibility_round);
+  maybe_end_encounter(encounter);
+  encounter->resolving = false;
+  if (encounter->terminal || encounter->due_head == NULL)
+  {
+    destroy_encounter(encounter, true);
+    free(payload);
+    return 0;
+  }
+  delay = encounter->due_head->next_due > (uint64_t)pulse
+              ? encounter->due_head->next_due - (uint64_t)pulse
+              : 1U;
+  return delay > LONG_MAX ? LONG_MAX : (long)delay;
+}
+
+static struct event *create_round_event(struct combat_encounter_data *encounter, uint64_t delay)
+{
+  struct combat_encounter_event_payload *payload;
+  struct game_event_owner owner;
+  struct event *event;
+
+  payload = calloc(1U, sizeof(*payload));
+  if (payload == NULL)
+  {
+    counter_increment(&cumulative_stats.admission_failures);
+    return NULL;
+  }
+  payload->id = encounter->id;
+  payload->generation = encounter->generation;
+  owner.kind = GAME_EVENT_OWNER_ENCOUNTER;
+  owner.runtime_id = encounter->id;
+  owner.generation = encounter->generation;
+  event = event_create_owned_named(combat_encounter_round_event, payload,
+                                   delay > LONG_MAX ? LONG_MAX : (long)delay,
+                                   "combat_encounter_round", owner);
+  if (event == NULL)
+  {
+    free(payload);
+    counter_increment(&cumulative_stats.admission_failures);
+  }
+  return event;
+}
+
+bool combat_encounter_join(struct char_data *character, struct char_data *opponent,
+                           long initial_delay)
+{
+  struct combat_encounter_data *character_encounter;
+  struct combat_encounter_data *opponent_encounter;
+  struct combat_encounter_data *encounter;
+  struct combat_encounter_participant *participant;
+
+  if (!combat_encounter_events_enabled() || character == NULL || opponent == NULL ||
+      character == opponent || shutting_down)
+    return false;
+  detach_terminal_membership(character);
+  detach_terminal_membership(opponent);
+  character_encounter = character->combat_encounter;
+  opponent_encounter = opponent->combat_encounter;
+  if (character_encounter == NULL && opponent_encounter == NULL)
+  {
+    encounter = create_encounter();
+    if (encounter == NULL)
+      return false;
+    participant = add_participant(encounter, character);
+    if (participant == NULL || add_participant(encounter, opponent) == NULL)
+    {
+      destroy_encounter(encounter, false);
+      counter_increment(&cumulative_stats.admission_failures);
+      return false;
+    }
+  }
+  else
+  {
+    encounter = character_encounter != NULL ? character_encounter : opponent_encounter;
+    if (character_encounter != NULL && opponent_encounter != NULL &&
+        merge_root(character_encounter) != merge_root(opponent_encounter))
+      encounter = merge_encounters(character_encounter, opponent_encounter);
+    if (character->combat_encounter == NULL && add_participant(encounter, character) == NULL)
+    {
+      counter_increment(&cumulative_stats.admission_failures);
+      return false;
+    }
+    if (opponent->combat_encounter == NULL && add_participant(encounter, opponent) == NULL)
+    {
+      counter_increment(&cumulative_stats.admission_failures);
+      return false;
+    }
+  }
+  participant = character->combat_encounter_participant;
+  activate_participant(participant, initial_delay);
+  encounter = merge_root(character->combat_encounter);
+  if (encounter != NULL && !encounter->resolving && !ensure_round_event(encounter))
+  {
+    destroy_encounter(encounter, false);
+    return false;
+  }
+  return true;
+}
+
+void combat_encounter_leave(struct char_data *character,
+                            enum combat_encounter_departure_reason reason)
+{
+  struct combat_encounter_participant *participant;
+  struct combat_encounter_data *encounter;
+
+  if (character == NULL || character->combat_encounter_participant == NULL)
+    return;
+  participant = character->combat_encounter_participant;
+  encounter = participant->encounter;
+  participant->active = false;
+  participant->pending_activation = false;
+  participant->departing = true;
+  due_remove(encounter, participant);
+  character->combat_encounter = NULL;
+  character->combat_encounter_participant = NULL;
+  counter_increment(&cumulative_stats.participants_left);
+  if (reason >= COMBAT_ENCOUNTER_DEPARTURE_STOPPED &&
+      reason < COMBAT_ENCOUNTER_DEPARTURE_COUNT)
+    counter_increment(&cumulative_stats.departure_counts[reason]);
+  if (!encounter->resolving)
+    detach_participant(encounter, participant);
+  maybe_end_encounter(encounter);
+}
+
+void combat_encounter_forget_character(struct char_data *character,
+                                       enum combat_encounter_departure_reason reason)
+{
+  combat_encounter_leave(character, reason);
+}
+
+static void handle_character_moved(const struct domain_event_context *context,
+                                   void *handler_context)
+{
+  const struct domain_character_moved *event = context->payload;
+  struct char_data *character;
+
+  (void)handler_context;
+  character = domain_event_resolve(context->bus, event->character, DOMAIN_ENTITY_CHARACTER);
+  if (character == NULL)
+  {
+    event_note_stale_owner_outcome();
+    return;
+  }
+  if (character != NULL && character->combat_encounter != NULL &&
+      (FIGHTING(character) == NULL || IN_ROOM(character) != IN_ROOM(FIGHTING(character))))
+    combat_encounter_leave(character, COMBAT_ENCOUNTER_DEPARTURE_MOVED);
+}
+
+static void handle_character_died(const struct domain_event_context *context,
+                                  void *handler_context)
+{
+  const struct domain_character_died *event = context->payload;
+  struct char_data *character;
+
+  (void)handler_context;
+  character = domain_event_resolve(context->bus, event->character, DOMAIN_ENTITY_CHARACTER);
+  if (character == NULL)
+  {
+    event_note_stale_owner_outcome();
+    return;
+  }
+  combat_encounter_leave(character, COMBAT_ENCOUNTER_DEPARTURE_DIED);
+}
+
+static void handle_entity_extracted(const struct domain_event_context *context,
+                                    void *handler_context)
+{
+  const struct domain_entity_extracted *event = context->payload;
+  struct char_data *character;
+
+  (void)handler_context;
+  if (event->entity.kind != DOMAIN_ENTITY_CHARACTER)
+    return;
+  character = domain_event_resolve(context->bus, event->entity, DOMAIN_ENTITY_CHARACTER);
+  if (character == NULL)
+  {
+    event_note_stale_owner_outcome();
+    return;
+  }
+  combat_encounter_leave(character, COMBAT_ENCOUNTER_DEPARTURE_EXTRACTED);
+}
+
+enum domain_event_status combat_encounter_runtime_init(struct domain_event_bus *bus)
+{
+  static const struct domain_event_handler_config handlers[] = {
+      {DOMAIN_EVENT_CHARACTER_MOVED, "combat-encounter-character-moved", 20,
+       handle_character_moved, NULL},
+      {DOMAIN_EVENT_CHARACTER_DIED, "combat-encounter-character-died", 20,
+       handle_character_died, NULL},
+      {DOMAIN_EVENT_ENTITY_EXTRACTED, "combat-encounter-entity-extracted", 20,
+       handle_entity_extracted, NULL},
+  };
+  enum domain_event_status status;
+  size_t index;
+
+  if (initialized)
+    return DOMAIN_EVENT_BUSY;
+  memset(&cumulative_stats, 0, sizeof(cumulative_stats));
+  memset(encounter_slots, 0, sizeof(encounter_slots));
+  for (index = 0; index < COMBAT_ENCOUNTER_MAX_ACTIVE; index++)
+  {
+    encounter_slots[index].generation = 1U;
+    encounter_slots[index].next_free = index + 1U < COMBAT_ENCOUNTER_MAX_ACTIVE
+                                           ? (uint32_t)(index + 1U)
+                                           : UINT32_MAX;
+  }
+  free_slot_head = 0U;
+  encounter_registry = NULL;
+  active_encounter_count = 0U;
+  active_participant_count = 0U;
+  scheduled_event_count = 0U;
+  next_due_sequence = 1U;
+  encounter_bus = bus;
+  shutting_down = false;
+  encounter_mode = configured_encounter_mode();
+  initialized = true;
+  log("Combat round scheduling: %s.",
+      encounter_mode ? "encounter-owned compatibility events" : "legacy character events");
+  if (!encounter_mode || bus == NULL)
+    return DOMAIN_EVENT_OK;
+  for (index = 0; index < sizeof(handlers) / sizeof(handlers[0]); index++)
+  {
+    status = domain_event_register_handler(bus, &handlers[index]);
+    if (status != DOMAIN_EVENT_OK)
+      return status;
+  }
+  return DOMAIN_EVENT_OK;
+}
+
+void combat_encounter_runtime_shutdown(void)
+{
+  struct combat_encounter_data *encounter;
+
+  if (!initialized)
+    return;
+  shutting_down = true;
+  while ((encounter = encounter_registry) != NULL)
+    destroy_encounter(encounter, false);
+  initialized = false;
+  encounter_mode = false;
+  encounter_bus = NULL;
+  shutting_down = false;
+#ifdef LUMINARI_CUTEST
+  test_selection_set = false;
+  test_encounter_mode = true;
+  test_phase_callback = NULL;
+  test_phase_context = NULL;
+#endif
+}
+
+bool combat_encounter_events_enabled(void)
+{
+  return initialized && encounter_mode && !shutting_down;
+}
+
+void combat_encounter_get_stats(struct combat_encounter_stats *stats)
+{
+  if (stats == NULL)
+    return;
+  *stats = cumulative_stats;
+  stats->initialized = initialized;
+  stats->encounter_mode = encounter_mode;
+  stats->active_encounters = active_encounter_count;
+  stats->active_participants = active_participant_count;
+  stats->scheduled_events = scheduled_event_count;
+  if (active_encounter_count != scheduled_event_count ||
+      cumulative_stats.compatibility_attempts !=
+          cumulative_stats.compatibility_phases + cumulative_stats.compatibility_terminal)
+    stats->compatibility_mismatches++;
+}
+
+#ifdef LUMINARI_CUTEST
+void combat_encounter_test_select(bool selected_encounter_mode)
+{
+  test_selection_set = true;
+  test_encounter_mode = selected_encounter_mode;
+}
+
+void combat_encounter_test_set_phase_callback(combat_encounter_test_phase_callback callback,
+                                              void *context)
+{
+  test_phase_callback = callback;
+  test_phase_context = context;
+}
+#endif

--- a/src/combat/combat_encounters.c
+++ b/src/combat/combat_encounters.c
@@ -4,6 +4,7 @@
 #include "utils.h"
 #include "comm.h"
 #include "dotenv.h"
+#include "actions.h"
 #include "combat/combat_encounters.h"
 #include "combat/fight.h"
 #include "dgscript/dg_event.h"
@@ -14,6 +15,7 @@
 #define COMBAT_ENCOUNTER_MAX_ACTIVE 32768U
 #define COMBAT_ENCOUNTER_PHASE_DELAY ((uint64_t)(2 RL_SEC))
 #define COMBAT_ENCOUNTER_JOIN_GUARD ((uint64_t)(6 RL_SEC))
+#define COMBAT_ENCOUNTER_ROUND_DELAY ((uint64_t)(6 RL_SEC))
 
 struct combat_encounter_participant
 {
@@ -26,7 +28,17 @@ struct combat_encounter_participant
   struct combat_encounter_participant *due_next;
   uint64_t next_due;
   uint64_t due_sequence;
+  uint64_t turns_started;
+  uint64_t action_ready_turn[NUM_ACTIONS];
+  int initiative;
+  int dexterity_tiebreak;
   unsigned int phase;
+  int reactions_used;
+  uint32_t round_flags;
+  bool action_notice_pending[NUM_ACTIONS];
+  bool semantic_state_imported;
+  bool perfect_tempo_was_hit;
+  bool intent_dispatched;
   bool active;
   bool pending_add;
   bool pending_activation;
@@ -54,6 +66,8 @@ struct combat_encounter_data
   struct combat_encounter_data *pending_into;
   uint64_t compatibility_phase;
   uint64_t compatibility_round;
+  uint64_t semantic_round;
+  uint64_t next_round_due;
   bool resolving;
   bool terminal;
 };
@@ -76,6 +90,7 @@ static uint32_t free_slot_head;
 static struct combat_encounter_data *encounter_registry;
 static bool initialized;
 static bool encounter_mode;
+static bool semantic_rounds;
 static bool shutting_down;
 static size_t active_encounter_count;
 static size_t active_participant_count;
@@ -87,6 +102,8 @@ static struct domain_event_bus *encounter_bus;
 #ifdef LUMINARI_CUTEST
 static bool test_selection_set;
 static bool test_encounter_mode;
+static bool test_semantic_selection_set;
+static bool test_semantic_rounds;
 static combat_encounter_test_phase_callback test_phase_callback;
 static void *test_phase_context;
 #endif
@@ -109,6 +126,27 @@ static bool configured_encounter_mode(void)
       !strcasecmp(value, "off"))
     return false;
   log("WARNING: Unknown LUMINARI_COMBAT_EVENTS '%s'; using encounter events.", value);
+  return true;
+}
+
+static bool configured_semantic_rounds(void)
+{
+  const char *value;
+
+#ifdef LUMINARI_CUTEST
+  if (test_semantic_selection_set)
+    return test_semantic_rounds;
+#endif
+  value = getenv("LUMINARI_COMBAT_ROUNDS");
+  if (value == NULL || *value == '\0')
+    value = get_env_value("LUMINARI_COMBAT_ROUNDS");
+  if (value == NULL || *value == '\0' || !strcasecmp(value, "semantic") ||
+      !strcasecmp(value, "round") || !strcasecmp(value, "d20"))
+    return true;
+  if (!strcasecmp(value, "compatibility") || !strcasecmp(value, "phased") ||
+      !strcasecmp(value, "legacy"))
+    return false;
+  log("WARNING: Unknown LUMINARI_COMBAT_ROUNDS '%s'; using semantic rounds.", value);
   return true;
 }
 
@@ -266,6 +304,13 @@ static bool participant_due_before(const struct combat_encounter_participant *le
 {
   if (left->next_due != right->next_due)
     return left->next_due < right->next_due;
+  if (semantic_rounds && left->initiative != right->initiative)
+    return left->initiative > right->initiative;
+  if (semantic_rounds && left->dexterity_tiebreak != right->dexterity_tiebreak)
+    return left->dexterity_tiebreak > right->dexterity_tiebreak;
+  if (semantic_rounds &&
+      left->character_handle.runtime_id != right->character_handle.runtime_id)
+    return left->character_handle.runtime_id < right->character_handle.runtime_id;
   if (left->due_sequence != right->due_sequence)
     return left->due_sequence < right->due_sequence;
   return left->character_handle.runtime_id < right->character_handle.runtime_id;
@@ -322,6 +367,136 @@ static void due_insert(struct combat_encounter_data *encounter,
     cursor->due_previous = participant;
   }
   participant->in_due_list = true;
+}
+
+static void align_semantic_participants(struct combat_encounter_data *encounter,
+                                        uint64_t next_round_due)
+{
+  struct combat_encounter_participant *participant;
+
+  if (!semantic_rounds || encounter == NULL)
+    return;
+  for (participant = encounter->participants; participant != NULL;
+       participant = participant->next)
+  {
+    if (!participant->active || participant->pending_activation ||
+        participant->next_due >= next_round_due)
+      continue;
+    due_remove(encounter, participant);
+    participant->next_due = next_round_due;
+    participant->due_sequence = allocate_due_sequence();
+    due_insert(encounter, participant);
+  }
+}
+
+static const event_id action_event_ids[NUM_ACTIONS] = {
+    eSTANDARDACTION,
+    eMOVEACTION,
+    eSWIFTACTION,
+};
+
+static const event_id round_flag_event_ids[COMBAT_ENCOUNTER_ROUND_FLAG_COUNT] = {
+    ePERFECT_TEMPO_HIT_THIS_ROUND,
+    eDEFLECTIVE_SCREEN_HIT_THIS_ROUND,
+    eSMASH_DEFENSE,
+    eRELENTLESS_ASSAULT,
+};
+
+static uint64_t semantic_rounds_for_delay(long delay)
+{
+  uint64_t positive_delay;
+
+  positive_delay = delay > 0L ? (uint64_t)delay : 1U;
+  return (positive_delay + COMBAT_ENCOUNTER_ROUND_DELAY - 1U) /
+         COMBAT_ENCOUNTER_ROUND_DELAY;
+}
+
+static struct combat_encounter_participant *semantic_participant(struct char_data *character)
+{
+  struct combat_encounter_participant *participant;
+
+  if (!initialized || !encounter_mode || !semantic_rounds || shutting_down || character == NULL)
+    return NULL;
+  participant = character->combat_encounter_participant;
+  if (participant == NULL || participant->character != character || participant->departing ||
+      (!participant->active && !participant->pending_activation))
+    return NULL;
+  return participant;
+}
+
+static void import_semantic_state(struct combat_encounter_participant *participant)
+{
+  struct mud_event_data *event_data;
+  uint64_t rounds;
+  size_t index;
+
+  if (participant == NULL || participant->semantic_state_imported ||
+      participant->character == NULL)
+    return;
+  participant->semantic_state_imported = true;
+  for (index = 0U; index < NUM_ACTIONS; index++)
+  {
+    event_data = char_has_mud_event(participant->character, action_event_ids[index]);
+    if (event_data == NULL)
+      continue;
+    rounds = semantic_rounds_for_delay(event_time(event_data->pEvent));
+    participant->action_ready_turn[index] = participant->turns_started + rounds;
+    participant->action_notice_pending[index] = true;
+    event_cancel_specific(participant->character, action_event_ids[index]);
+  }
+  for (index = 0U; index < COMBAT_ENCOUNTER_ROUND_FLAG_COUNT; index++)
+  {
+    if (char_has_mud_event(participant->character, round_flag_event_ids[index]) == NULL)
+      continue;
+    participant->round_flags |= (uint32_t)1U << index;
+    event_cancel_specific(participant->character, round_flag_event_ids[index]);
+  }
+}
+
+static void restore_semantic_action_events(struct combat_encounter_participant *participant)
+{
+  char duration_text[32];
+  uint64_t remaining_rounds;
+  uint64_t delay;
+  size_t index;
+
+  if (participant == NULL || !participant->semantic_state_imported ||
+      participant->character == NULL || shutting_down)
+    return;
+  for (index = 0U; index < NUM_ACTIONS; index++)
+  {
+    if (participant->action_ready_turn[index] <= participant->turns_started)
+      continue;
+    remaining_rounds = participant->action_ready_turn[index] - participant->turns_started;
+    delay = remaining_rounds > UINT64_MAX / COMBAT_ENCOUNTER_ROUND_DELAY
+                ? UINT64_MAX
+                : remaining_rounds * COMBAT_ENCOUNTER_ROUND_DELAY;
+    snprintf(duration_text, sizeof(duration_text), "%ld",
+             delay > LONG_MAX ? LONG_MAX : (long)delay);
+    attach_mud_event(
+        new_mud_event(action_event_ids[index], participant->character, duration_text),
+        delay > LONG_MAX ? LONG_MAX : (long)delay);
+  }
+}
+
+static void announce_recovered_actions(struct combat_encounter_participant *participant)
+{
+  static const char *const messages[NUM_ACTIONS] = {
+      "You may perform another standard action.\r\n",
+      "You may perform another move action.\r\n",
+      "You may perform another swift action.\r\n",
+  };
+  size_t index;
+
+  for (index = 0U; index < NUM_ACTIONS; index++)
+  {
+    if (!participant->action_notice_pending[index] ||
+        participant->action_ready_turn[index] > participant->turns_started)
+      continue;
+    participant->action_notice_pending[index] = false;
+    send_to_char(participant->character, "%s", messages[index]);
+  }
+  update_msdp_actions(participant->character);
 }
 
 static void free_participant(struct combat_encounter_participant *participant)
@@ -382,11 +557,21 @@ static void activate_participant(struct combat_encounter_participant *participan
 
   if (participant == NULL || participant->active || participant->pending_activation)
     return;
+  if (semantic_rounds)
+    import_semantic_state(participant);
+  participant->initiative = GET_INITIATIVE(participant->character);
+  participant->dexterity_tiebreak = GET_DEX(participant->character);
   delay = initial_delay > 0L ? (uint64_t)initial_delay : 1U;
-  due = (uint64_t)pulse + delay;
+  if (semantic_rounds)
+    due = participant->encounter->next_round_due > (uint64_t)pulse
+              ? participant->encounter->next_round_due
+              : (uint64_t)pulse + COMBAT_ENCOUNTER_ROUND_DELAY;
+  else
+    due = (uint64_t)pulse + delay;
   if (participant->encounter->resolving)
   {
-    due = MAX(due, (uint64_t)pulse + COMBAT_ENCOUNTER_JOIN_GUARD);
+    due = MAX(due, (uint64_t)pulse + (semantic_rounds ? COMBAT_ENCOUNTER_ROUND_DELAY
+                                                      : COMBAT_ENCOUNTER_JOIN_GUARD));
     participant->pending_activation = true;
   }
   else
@@ -412,6 +597,10 @@ static struct combat_encounter_data *create_encounter(void)
   registry_link(encounter);
   encounter->compatibility_phase = 1U;
   encounter->compatibility_round = 1U;
+  encounter->semantic_round = 0U;
+  encounter->next_round_due = semantic_rounds
+                                  ? (uint64_t)pulse + COMBAT_ENCOUNTER_ROUND_DELAY
+                                  : 0U;
   counter_increment(&cumulative_stats.encounters_created);
   return encounter;
 }
@@ -426,9 +615,14 @@ static bool ensure_round_event(struct combat_encounter_data *encounter)
 
   if (encounter == NULL || encounter->terminal || encounter->due_head == NULL)
     return false;
-  delay = encounter->due_head->next_due > (uint64_t)pulse
-              ? encounter->due_head->next_due - (uint64_t)pulse
-              : 1U;
+  if (semantic_rounds)
+    delay = encounter->next_round_due > (uint64_t)pulse
+                ? encounter->next_round_due - (uint64_t)pulse
+                : 1U;
+  else
+    delay = encounter->due_head->next_due > (uint64_t)pulse
+                ? encounter->due_head->next_due - (uint64_t)pulse
+                : 1U;
   if (encounter->event == NULL)
   {
     encounter->event = create_round_event(encounter, delay);
@@ -491,11 +685,13 @@ static void destroy_encounter(struct combat_encounter_data *encounter, bool disp
   for (participant = encounter->participants; participant != NULL; participant = next)
   {
     next = participant->next;
+    restore_semantic_action_events(participant);
     free_participant(participant);
   }
   for (participant = encounter->pending_additions; participant != NULL; participant = next)
   {
     next = participant->next;
+    restore_semantic_action_events(participant);
     free_participant(participant);
   }
   encounter->participants = NULL;
@@ -527,6 +723,7 @@ static void detach_terminal_membership(struct char_data *character)
     return;
   participant = character->combat_encounter_participant;
   encounter = participant->encounter;
+  restore_semantic_action_events(participant);
   participant->active = false;
   participant->pending_activation = false;
   participant->departing = true;
@@ -567,7 +764,12 @@ static void transfer_participant(struct combat_encounter_data *survivor,
     participant->character->combat_encounter = survivor;
   member_append(survivor, participant);
   if (participant->active)
+  {
+    if (semantic_rounds && survivor->resolving)
+      participant->next_due =
+          MAX(participant->next_due, (uint64_t)pulse + COMBAT_ENCOUNTER_ROUND_DELAY);
     due_insert(survivor, participant);
+  }
 }
 
 static void merge_now(struct combat_encounter_data *survivor,
@@ -598,6 +800,9 @@ static void merge_now(struct combat_encounter_data *survivor,
     if (participant->character != NULL &&
         participant->character->combat_encounter_participant == participant)
       participant->character->combat_encounter = survivor;
+    if (semantic_rounds && survivor->resolving)
+      participant->next_due =
+          MAX(participant->next_due, (uint64_t)pulse + COMBAT_ENCOUNTER_ROUND_DELAY);
     pending_append(survivor, participant);
   }
   absorbed->participants = NULL;
@@ -729,6 +934,42 @@ static bool run_compatibility_phase(struct char_data *character, unsigned int ph
   return combat_run_compatibility_phase(character, phase);
 }
 
+static void prepare_semantic_round(struct combat_encounter_data *encounter)
+{
+  struct combat_encounter_participant *participant;
+
+  for (participant = encounter->participants; participant != NULL;
+       participant = participant->next)
+  {
+    if (!participant->active || participant->pending_activation ||
+        participant->character == NULL)
+      continue;
+    if (encounter_bus != NULL &&
+        domain_event_resolve(encounter_bus, participant->character_handle,
+                             DOMAIN_ENTITY_CHARACTER) != participant->character)
+      continue;
+    participant->perfect_tempo_was_hit =
+        (participant->round_flags &
+         ((uint32_t)1U << COMBAT_ENCOUNTER_ROUND_PERFECT_TEMPO_HIT)) != 0U;
+    participant->round_flags = 0U;
+    participant->reactions_used = 0;
+    GET_TOTAL_AOO(participant->character) = 0;
+  }
+}
+
+static bool run_semantic_round(struct combat_encounter_participant *participant)
+{
+  participant->turns_started++;
+  participant->intent_dispatched = false;
+  announce_recovered_actions(participant);
+#ifdef LUMINARI_CUTEST
+  if (test_phase_callback != NULL)
+    return test_phase_callback(participant->character, 0U, test_phase_context);
+#endif
+  return combat_run_semantic_round(participant->character,
+                                   participant->perfect_tempo_was_hit);
+}
+
 EVENTFUNC(combat_encounter_round_event)
 {
   struct combat_encounter_event_payload *payload = event_obj;
@@ -736,6 +977,7 @@ EVENTFUNC(combat_encounter_round_event)
   struct combat_encounter_participant *participant;
   bool completed;
   bool merged;
+  bool semantic_round_started = false;
   uint64_t delay;
 
   if (payload == NULL)
@@ -750,9 +992,15 @@ EVENTFUNC(combat_encounter_round_event)
   }
   counter_increment(&cumulative_stats.encounter_callbacks);
   encounter->resolving = true;
+  if (semantic_rounds && encounter->due_head != NULL &&
+      encounter->due_head->next_due <= (uint64_t)pulse)
+  {
+    prepare_semantic_round(encounter);
+    semantic_round_started = true;
+  }
   do
   {
-  while (encounter->due_head != NULL &&
+    while (encounter->due_head != NULL &&
            encounter->due_head->next_due <= (uint64_t)pulse)
     {
       participant = encounter->due_head;
@@ -768,17 +1016,31 @@ EVENTFUNC(combat_encounter_round_event)
         continue;
       }
       participant->dispatching = true;
-      counter_increment(&cumulative_stats.compatibility_attempts);
-      completed = run_compatibility_phase(participant->character, participant->phase);
-      participant->dispatching = false;
-      if (completed)
-        counter_increment(&cumulative_stats.compatibility_phases);
+      if (semantic_rounds)
+      {
+        completed = run_semantic_round(participant);
+        counter_increment(&cumulative_stats.semantic_turns_resolved);
+      }
       else
-        counter_increment(&cumulative_stats.compatibility_terminal);
+      {
+        counter_increment(&cumulative_stats.compatibility_attempts);
+        completed = run_compatibility_phase(participant->character, participant->phase);
+      }
+      participant->dispatching = false;
+      if (!semantic_rounds)
+      {
+        if (completed)
+          counter_increment(&cumulative_stats.compatibility_phases);
+        else
+          counter_increment(&cumulative_stats.compatibility_terminal);
+      }
       if (participant->active && participant->encounter == encounter && completed)
       {
-        participant->phase = participant->phase < 3U ? participant->phase + 1U : 1U;
-        participant->next_due = (uint64_t)pulse + COMBAT_ENCOUNTER_PHASE_DELAY;
+        if (!semantic_rounds)
+          participant->phase = participant->phase < 3U ? participant->phase + 1U : 1U;
+        participant->next_due =
+            (uint64_t)pulse +
+            (semantic_rounds ? COMBAT_ENCOUNTER_ROUND_DELAY : COMBAT_ENCOUNTER_PHASE_DELAY);
         participant->due_sequence = allocate_due_sequence();
         due_insert(encounter, participant);
       }
@@ -792,11 +1054,21 @@ EVENTFUNC(combat_encounter_round_event)
     apply_pending_additions(encounter);
     merged = apply_pending_merges(encounter);
   } while (merged);
-  encounter->compatibility_phase = encounter->compatibility_phase < 3U
-                                       ? encounter->compatibility_phase + 1U
-                                       : 1U;
-  if (encounter->compatibility_phase == 1U)
-    counter_increment(&encounter->compatibility_round);
+  if (semantic_rounds && semantic_round_started)
+  {
+    counter_increment(&encounter->semantic_round);
+    counter_increment(&cumulative_stats.semantic_rounds_resolved);
+    encounter->next_round_due = (uint64_t)pulse + COMBAT_ENCOUNTER_ROUND_DELAY;
+    align_semantic_participants(encounter, encounter->next_round_due);
+  }
+  else if (!semantic_rounds)
+  {
+    encounter->compatibility_phase = encounter->compatibility_phase < 3U
+                                         ? encounter->compatibility_phase + 1U
+                                         : 1U;
+    if (encounter->compatibility_phase == 1U)
+      counter_increment(&encounter->compatibility_round);
+  }
   maybe_end_encounter(encounter);
   encounter->resolving = false;
   if (encounter->terminal || encounter->due_head == NULL)
@@ -805,9 +1077,14 @@ EVENTFUNC(combat_encounter_round_event)
     free(payload);
     return 0;
   }
-  delay = encounter->due_head->next_due > (uint64_t)pulse
-              ? encounter->due_head->next_due - (uint64_t)pulse
-              : 1U;
+  if (semantic_rounds)
+    delay = encounter->next_round_due > (uint64_t)pulse
+                ? encounter->next_round_due - (uint64_t)pulse
+                : 1U;
+  else
+    delay = encounter->due_head->next_due > (uint64_t)pulse
+                ? encounter->due_head->next_due - (uint64_t)pulse
+                : 1U;
   return delay > LONG_MAX ? LONG_MAX : (long)delay;
 }
 
@@ -905,6 +1182,9 @@ void combat_encounter_leave(struct char_data *character,
     return;
   participant = character->combat_encounter_participant;
   encounter = participant->encounter;
+  if (reason != COMBAT_ENCOUNTER_DEPARTURE_DIED &&
+      reason != COMBAT_ENCOUNTER_DEPARTURE_EXTRACTED)
+    restore_semantic_action_events(participant);
   participant->active = false;
   participant->pending_activation = false;
   participant->departing = true;
@@ -924,6 +1204,127 @@ void combat_encounter_forget_character(struct char_data *character,
                                        enum combat_encounter_departure_reason reason)
 {
   combat_encounter_leave(character, reason);
+}
+
+bool combat_encounter_semantic_rounds_enabled(void)
+{
+  return combat_encounter_events_enabled() && semantic_rounds;
+}
+
+bool combat_encounter_semantic_manages(const struct char_data *character)
+{
+  const struct combat_encounter_participant *participant;
+
+  if (!combat_encounter_semantic_rounds_enabled() || character == NULL)
+    return false;
+  participant = character->combat_encounter_participant;
+  return participant != NULL && participant->character == character && !participant->departing &&
+         (participant->active || participant->pending_activation);
+}
+
+bool combat_encounter_action_query(struct char_data *character, action_type action,
+                                   bool *available)
+{
+  struct combat_encounter_participant *participant;
+
+  participant = semantic_participant(character);
+  if (participant == NULL || available == NULL || action < atSTANDARD || action > atSWIFT)
+    return false;
+  *available = participant->action_ready_turn[action] <= participant->turns_started;
+  return true;
+}
+
+bool combat_encounter_action_consume(struct char_data *character, action_type action,
+                                     int duration)
+{
+  struct combat_encounter_participant *participant;
+  uint64_t ready_turn;
+
+  participant = semantic_participant(character);
+  if (participant == NULL || action < atSTANDARD || action > atSWIFT)
+    return false;
+  ready_turn = participant->turns_started + semantic_rounds_for_delay(duration);
+  participant->action_ready_turn[action] = MAX(participant->action_ready_turn[action], ready_turn);
+  participant->action_notice_pending[action] = true;
+  counter_increment(&cumulative_stats.action_budgets_spent);
+  return true;
+}
+
+bool combat_encounter_intent_claim(struct char_data *character)
+{
+  struct combat_encounter_participant *participant;
+
+  participant = semantic_participant(character);
+  if (participant == NULL)
+    return true;
+  if (!participant->dispatching || participant->intent_dispatched)
+  {
+    counter_increment(&cumulative_stats.intent_dispatch_blocks);
+    return false;
+  }
+  participant->intent_dispatched = true;
+  counter_increment(&cumulative_stats.intents_dispatched);
+  return true;
+}
+
+bool combat_encounter_reaction_try_use(struct char_data *character, unsigned int limit,
+                                       bool *managed)
+{
+  struct combat_encounter_participant *participant;
+
+  if (managed != NULL)
+    *managed = false;
+  participant = semantic_participant(character);
+  if (participant == NULL)
+    return false;
+  if (managed != NULL)
+    *managed = true;
+  if (participant->reactions_used >= 0 &&
+      (unsigned int)participant->reactions_used >= limit)
+    return false;
+  participant->reactions_used++;
+  GET_TOTAL_AOO(character) = participant->reactions_used;
+  counter_increment(&cumulative_stats.reactions_spent);
+  return true;
+}
+
+bool combat_encounter_reaction_refund(struct char_data *character)
+{
+  struct combat_encounter_participant *participant;
+
+  participant = semantic_participant(character);
+  if (participant == NULL)
+    return false;
+  if (participant->reactions_used > INT_MIN)
+    participant->reactions_used--;
+  GET_TOTAL_AOO(character) = participant->reactions_used;
+  return true;
+}
+
+bool combat_encounter_round_flag_query(struct char_data *character,
+                                       enum combat_encounter_round_flag flag, bool *used)
+{
+  struct combat_encounter_participant *participant;
+
+  participant = semantic_participant(character);
+  if (participant == NULL || used == NULL || flag < COMBAT_ENCOUNTER_ROUND_PERFECT_TEMPO_HIT ||
+      flag >= COMBAT_ENCOUNTER_ROUND_FLAG_COUNT)
+    return false;
+  *used = (participant->round_flags & ((uint32_t)1U << flag)) != 0U;
+  return true;
+}
+
+bool combat_encounter_round_flag_mark(struct char_data *character,
+                                      enum combat_encounter_round_flag flag)
+{
+  struct combat_encounter_participant *participant;
+
+  participant = semantic_participant(character);
+  if (participant == NULL || flag < COMBAT_ENCOUNTER_ROUND_PERFECT_TEMPO_HIT ||
+      flag >= COMBAT_ENCOUNTER_ROUND_FLAG_COUNT)
+    return false;
+  participant->round_flags |= (uint32_t)1U << flag;
+  return true;
 }
 
 static void handle_character_moved(const struct domain_event_context *context,
@@ -1011,9 +1412,12 @@ enum domain_event_status combat_encounter_runtime_init(struct domain_event_bus *
   encounter_bus = bus;
   shutting_down = false;
   encounter_mode = configured_encounter_mode();
+  semantic_rounds = encounter_mode && configured_semantic_rounds();
   initialized = true;
   log("Combat round scheduling: %s.",
-      encounter_mode ? "encounter-owned compatibility events" : "legacy character events");
+      !encounter_mode ? "legacy character events"
+                      : semantic_rounds ? "encounter-owned six-second semantic rounds"
+                                        : "encounter-owned compatibility phases");
   if (!encounter_mode || bus == NULL)
     return DOMAIN_EVENT_OK;
   for (index = 0; index < sizeof(handlers) / sizeof(handlers[0]); index++)
@@ -1036,11 +1440,14 @@ void combat_encounter_runtime_shutdown(void)
     destroy_encounter(encounter, false);
   initialized = false;
   encounter_mode = false;
+  semantic_rounds = false;
   encounter_bus = NULL;
   shutting_down = false;
 #ifdef LUMINARI_CUTEST
   test_selection_set = false;
   test_encounter_mode = true;
+  test_semantic_selection_set = false;
+  test_semantic_rounds = true;
   test_phase_callback = NULL;
   test_phase_context = NULL;
 #endif
@@ -1058,6 +1465,7 @@ void combat_encounter_get_stats(struct combat_encounter_stats *stats)
   *stats = cumulative_stats;
   stats->initialized = initialized;
   stats->encounter_mode = encounter_mode;
+  stats->semantic_rounds = semantic_rounds;
   stats->active_encounters = active_encounter_count;
   stats->active_participants = active_participant_count;
   stats->scheduled_events = scheduled_event_count;
@@ -1072,6 +1480,12 @@ void combat_encounter_test_select(bool selected_encounter_mode)
 {
   test_selection_set = true;
   test_encounter_mode = selected_encounter_mode;
+}
+
+void combat_encounter_test_select_semantic(bool selected_semantic_rounds)
+{
+  test_semantic_selection_set = true;
+  test_semantic_rounds = selected_semantic_rounds;
 }
 
 void combat_encounter_test_set_phase_callback(combat_encounter_test_phase_callback callback,

--- a/src/combat/combat_encounters.h
+++ b/src/combat/combat_encounters.h
@@ -1,0 +1,63 @@
+#ifndef COMBAT_COMBAT_ENCOUNTERS_H
+#define COMBAT_COMBAT_ENCOUNTERS_H
+
+#include "domain_events.h"
+#include "structs.h"
+
+enum combat_encounter_departure_reason
+{
+  COMBAT_ENCOUNTER_DEPARTURE_STOPPED = 0,
+  COMBAT_ENCOUNTER_DEPARTURE_MOVED,
+  COMBAT_ENCOUNTER_DEPARTURE_FLED,
+  COMBAT_ENCOUNTER_DEPARTURE_TELEPORTED,
+  COMBAT_ENCOUNTER_DEPARTURE_DIED,
+  COMBAT_ENCOUNTER_DEPARTURE_EXTRACTED,
+  COMBAT_ENCOUNTER_DEPARTURE_DISCONNECTED,
+  COMBAT_ENCOUNTER_DEPARTURE_ADMINISTRATIVE,
+  COMBAT_ENCOUNTER_DEPARTURE_COUNT
+};
+
+struct combat_encounter_stats
+{
+  bool initialized;
+  bool encounter_mode;
+  size_t active_encounters;
+  size_t active_participants;
+  size_t scheduled_events;
+  uint64_t high_water_encounters;
+  uint64_t high_water_participants;
+  uint64_t encounters_created;
+  uint64_t encounters_ended;
+  uint64_t participants_joined;
+  uint64_t participants_left;
+  uint64_t encounters_merged;
+  uint64_t encounter_callbacks;
+  uint64_t compatibility_attempts;
+  uint64_t compatibility_phases;
+  uint64_t compatibility_terminal;
+  uint64_t compatibility_mismatches;
+  uint64_t admission_failures;
+  uint64_t stale_encounter_callbacks;
+  uint64_t departure_counts[COMBAT_ENCOUNTER_DEPARTURE_COUNT];
+};
+
+enum domain_event_status combat_encounter_runtime_init(struct domain_event_bus *bus);
+void combat_encounter_runtime_shutdown(void);
+bool combat_encounter_events_enabled(void);
+bool combat_encounter_join(struct char_data *character, struct char_data *opponent,
+                           long initial_delay);
+void combat_encounter_leave(struct char_data *character,
+                            enum combat_encounter_departure_reason reason);
+void combat_encounter_forget_character(struct char_data *character,
+                                       enum combat_encounter_departure_reason reason);
+void combat_encounter_get_stats(struct combat_encounter_stats *stats);
+
+#ifdef LUMINARI_CUTEST
+typedef bool (*combat_encounter_test_phase_callback)(struct char_data *character,
+                                                     unsigned int phase, void *context);
+void combat_encounter_test_select(bool encounter_mode);
+void combat_encounter_test_set_phase_callback(combat_encounter_test_phase_callback callback,
+                                              void *context);
+#endif
+
+#endif /* COMBAT_COMBAT_ENCOUNTERS_H */

--- a/src/combat/combat_encounters.h
+++ b/src/combat/combat_encounters.h
@@ -17,10 +17,20 @@ enum combat_encounter_departure_reason
   COMBAT_ENCOUNTER_DEPARTURE_COUNT
 };
 
+enum combat_encounter_round_flag
+{
+  COMBAT_ENCOUNTER_ROUND_PERFECT_TEMPO_HIT = 0,
+  COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED,
+  COMBAT_ENCOUNTER_ROUND_SMASH_DEFENSE_USED,
+  COMBAT_ENCOUNTER_ROUND_RELENTLESS_ASSAULT_USED,
+  COMBAT_ENCOUNTER_ROUND_FLAG_COUNT
+};
+
 struct combat_encounter_stats
 {
   bool initialized;
   bool encounter_mode;
+  bool semantic_rounds;
   size_t active_encounters;
   size_t active_participants;
   size_t scheduled_events;
@@ -36,6 +46,12 @@ struct combat_encounter_stats
   uint64_t compatibility_phases;
   uint64_t compatibility_terminal;
   uint64_t compatibility_mismatches;
+  uint64_t semantic_rounds_resolved;
+  uint64_t semantic_turns_resolved;
+  uint64_t intents_dispatched;
+  uint64_t intent_dispatch_blocks;
+  uint64_t action_budgets_spent;
+  uint64_t reactions_spent;
   uint64_t admission_failures;
   uint64_t stale_encounter_callbacks;
   uint64_t departure_counts[COMBAT_ENCOUNTER_DEPARTURE_COUNT];
@@ -44,6 +60,8 @@ struct combat_encounter_stats
 enum domain_event_status combat_encounter_runtime_init(struct domain_event_bus *bus);
 void combat_encounter_runtime_shutdown(void);
 bool combat_encounter_events_enabled(void);
+bool combat_encounter_semantic_rounds_enabled(void);
+bool combat_encounter_semantic_manages(const struct char_data *character);
 bool combat_encounter_join(struct char_data *character, struct char_data *opponent,
                            long initial_delay);
 void combat_encounter_leave(struct char_data *character,
@@ -51,11 +69,24 @@ void combat_encounter_leave(struct char_data *character,
 void combat_encounter_forget_character(struct char_data *character,
                                        enum combat_encounter_departure_reason reason);
 void combat_encounter_get_stats(struct combat_encounter_stats *stats);
+bool combat_encounter_action_query(struct char_data *character, action_type action,
+                                   bool *available);
+bool combat_encounter_action_consume(struct char_data *character, action_type action,
+                                     int duration);
+bool combat_encounter_intent_claim(struct char_data *character);
+bool combat_encounter_reaction_try_use(struct char_data *character, unsigned int limit,
+                                       bool *managed);
+bool combat_encounter_reaction_refund(struct char_data *character);
+bool combat_encounter_round_flag_query(struct char_data *character,
+                                       enum combat_encounter_round_flag flag, bool *used);
+bool combat_encounter_round_flag_mark(struct char_data *character,
+                                      enum combat_encounter_round_flag flag);
 
 #ifdef LUMINARI_CUTEST
 typedef bool (*combat_encounter_test_phase_callback)(struct char_data *character,
                                                      unsigned int phase, void *context);
 void combat_encounter_test_select(bool encounter_mode);
+void combat_encounter_test_select_semantic(bool semantic_rounds);
 void combat_encounter_test_set_phase_callback(combat_encounter_test_phase_callback callback,
                                               void *context);
 #endif

--- a/src/combat/fight.c
+++ b/src/combat/fight.c
@@ -6040,12 +6040,22 @@ static int damage_with_projectile(struct char_data *ch, struct char_data *victim
       (affected_by_spell(victim, PSIONIC_FORCE_SCREEN) ||
        affected_by_spell(victim, PSIONIC_INERTIAL_ARMOR)))
   {
-    if (!char_has_mud_event(victim, eDEFLECTIVE_SCREEN_HIT_THIS_ROUND))
+    bool semantic_used = false;
+    bool semantic_managed = combat_encounter_round_flag_query(
+        victim, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED, &semantic_used);
+
+    if ((semantic_managed && !semantic_used) ||
+        (!semantic_managed &&
+         !char_has_mud_event(victim, eDEFLECTIVE_SCREEN_HIT_THIS_ROUND)))
     {
       int dr = get_deflective_screen_first_hit_dr(victim);
       dam = MAX(0, dam - dr);
-      attach_mud_event(new_mud_event(eDEFLECTIVE_SCREEN_HIT_THIS_ROUND, victim, NULL),
-                       10 * PASSES_PER_SEC);
+      if (semantic_managed)
+        combat_encounter_round_flag_mark(
+            victim, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED);
+      else
+        attach_mud_event(new_mud_event(eDEFLECTIVE_SCREEN_HIT_THIS_ROUND, victim, NULL),
+                         10 * PASSES_PER_SEC);
     }
   }
 
@@ -6384,7 +6394,9 @@ static int damage_with_projectile(struct char_data *ch, struct char_data *victim
   /* Perfect Tempo perk: Track that this character was hit this round */
   if (dam > 0 && !IS_NPC(victim) && has_bard_perfect_tempo(victim))
   {
-    if (!char_has_mud_event(victim, ePERFECT_TEMPO_HIT_THIS_ROUND))
+    if (!combat_encounter_round_flag_mark(victim,
+                                          COMBAT_ENCOUNTER_ROUND_PERFECT_TEMPO_HIT) &&
+        !char_has_mud_event(victim, ePERFECT_TEMPO_HIT_THIS_ROUND))
     {
       /* Attach event to track that they were hit this round (lasts 1 round) */
       attach_mud_event(new_mud_event(ePERFECT_TEMPO_HIT_THIS_ROUND, victim, NULL),
@@ -12027,6 +12039,7 @@ int attack_roll_with_critical(struct char_data *ch,     /* Attacker */
 int attack_of_opportunity(struct char_data *ch, struct char_data *victim, int penalty)
 {
   int max_aoo = 1; /* Base 1 AoO per round */
+  bool reaction_managed;
 
   /* Ghost perk: immune to attacks of opportunity */
   if (!IS_NPC(victim) && has_ghost(victim))
@@ -12049,6 +12062,12 @@ int attack_of_opportunity(struct char_data *ch, struct char_data *victim, int pe
   /* Opportunist perk (Rogue) */
   if (!IS_NPC(ch))
     max_aoo += get_perk_aoo_bonus(ch);
+
+  if (combat_encounter_reaction_try_use(ch, (unsigned int)MAX(0, max_aoo),
+                                        &reaction_managed))
+    return hit(ch, victim, TYPE_ATTACK_OF_OPPORTUNITY, DAM_RESERVED_DBC, penalty, FALSE);
+  if (reaction_managed)
+    return 0;
 
   if (GET_TOTAL_AOO(ch) < max_aoo)
   {
@@ -13735,8 +13754,8 @@ int handle_successful_attack(struct char_data *ch, struct char_data *victim,
   if (ch != victim && affected_by_spell(victim, SKILL_COME_AND_GET_ME) &&
       affected_by_spell(victim, SKILL_RAGE))
   {
-    GET_TOTAL_AOO(victim)
-    --; /* free aoo and will be incremented in the function */
+    if (!combat_encounter_reaction_refund(victim))
+      GET_TOTAL_AOO(victim)--; /* free aoo and will be incremented in the function */
     attack_of_opportunity(victim, ch, 0);
 
     /* dummy check */
@@ -15426,6 +15445,9 @@ int perform_attacks(struct char_data *ch, int mode, int phase)
    *  attack mode) skip all phases but the first. */
   if ((mode == NORMAL_ATTACK_ROUTINE) && !is_action_available(ch, atSTANDARD, FALSE))
     return (0);
+  else if ((mode == NORMAL_ATTACK_ROUTINE) && phase == PHASE_0 &&
+           (AFF_FLAGGED(ch, AFF_STAGGERED) || !is_action_available(ch, atMOVE, FALSE)))
+    phase = PHASE_1;
   else if ((mode == NORMAL_ATTACK_ROUTINE) && (phase != PHASE_1) &&
            !is_action_available(ch, atMOVE, FALSE))
     return (0);
@@ -16555,6 +16577,80 @@ bool combat_run_compatibility_phase(struct char_data *ch, unsigned int phase)
   return true;
 }
 
+bool combat_run_semantic_round(struct char_data *ch, bool was_hit)
+{
+  struct affected_type af;
+
+  if (!ch || IN_ROOM(ch) == NOWHERE || GET_POS(ch) <= POS_DEAD)
+    return false;
+  if (!IS_NPC(ch) && PLR_FLAGGED(ch, PLR_NOTDEADYET))
+    return false;
+  if (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_NOTDEADYET))
+    return false;
+  if ((!IS_NPC(ch) && ch->desc != NULL && !IS_PLAYING(ch->desc)) || FIGHTING(ch) == NULL)
+  {
+    stop_fighting(ch);
+    return false;
+  }
+  if (GET_POS(FIGHTING(ch)) <= POS_DEAD || IN_ROOM(ch) != IN_ROOM(FIGHTING(ch)))
+  {
+    stop_fighting(ch);
+    return false;
+  }
+
+  PERF_combat_round_begin(ch);
+
+  if (AFF2_FLAGGED(ch, AFF2_COWERING) && rand_number(1, 100) <= 10)
+  {
+    send_to_char(ch, "\tRYou are too afraid to act!\tn\r\n");
+    act("$n cowers in fear, unable to act!", FALSE, ch, 0, 0, TO_ROOM);
+    USE_STANDARD_ACTION(ch);
+    USE_MOVE_ACTION(ch);
+    USE_SWIFT_ACTION(ch);
+  }
+
+  if (!IS_NPC(ch) && has_bard_perfect_tempo(ch) && !is_affected_by_perfect_tempo(ch) &&
+      !was_hit)
+  {
+    new_affect(&af);
+    af.spell = AFFECT_BARD_PERFECT_TEMPO;
+    af.duration = 2;
+    af.location = APPLY_HITROLL;
+    af.modifier = 4;
+    affect_to_char(ch, &af);
+    send_to_char(ch,
+                 "\tY[PERFECT TEMPO]\tn You flow perfectly with the combat, ready to strike!\r\n");
+    act("\tY[PERFECT TEMPO]\tn $n flows perfectly with the combat!", FALSE, ch, 0, 0,
+        TO_ROOM);
+  }
+
+  {
+    PERF_PROF_ENTER_SAMPLED(combat_action_queue, "combat.action_queue");
+    execute_next_action(ch);
+    PERF_PROF_EXIT(combat_action_queue);
+  }
+  {
+    PERF_PROF_ENTER_SAMPLED(combat_perform_violence, "combat.perform_violence");
+    perform_violence(ch, 0);
+    PERF_PROF_EXIT(combat_perform_violence);
+  }
+  {
+    PERF_PROF_ENTER_SAMPLED(combat_backlash, "combat.backlash");
+    if (is_alchemist_unstable_mutagen_on(ch) && affected_by_spell(ch, SKILL_MUTAGEN) &&
+        !has_alchemist_perfect_mutagen(ch) && rand_number(1, 100) <= 10)
+    {
+      int backlash = MAX(1, GET_LEVEL(ch));
+      send_to_char(ch, "Your unstable mutagen backlashes, harming you!\r\n");
+      act("$n winces as unstable mutagenic energies lash back.", FALSE, ch, 0, 0, TO_ROOM);
+      damage(ch, ch, backlash, TYPE_UNDEFINED, DAM_RESERVED_DBC, FALSE);
+    }
+    PERF_PROF_EXIT(combat_backlash);
+  }
+
+  PERF_combat_round_end();
+  return true;
+}
+
 /* Per-character rollback event for the compatibility combat phases. */
 EVENTFUNC(event_combat_round)
 {
@@ -16628,9 +16724,16 @@ void handle_cleave(struct char_data *ch)
 void handle_smash_defense(struct char_data *ch)
 {
   struct char_data *vict = FIGHTING(ch);
+  bool semantic_used = false;
+  bool semantic_managed;
 
   /* general dummy checks */
   if (IN_ROOM(ch) == NOWHERE || !vict || IN_ROOM(vict) != IN_ROOM(ch))
+    return;
+  semantic_managed = combat_encounter_round_flag_query(
+      ch, COMBAT_ENCOUNTER_ROUND_SMASH_DEFENSE_USED, &semantic_used);
+  if ((semantic_managed && semantic_used) ||
+      (!semantic_managed && char_has_mud_event(ch, eSMASH_DEFENSE)))
     return;
 
   /* some automatic disqualifiers, we will silently return from these */
@@ -16654,11 +16757,10 @@ void handle_smash_defense(struct char_data *ch)
   send_to_char(ch, "\tW[Smash Defense]\tn");
   perform_knockdown(ch, vict, SKILL_BASH, true, true);
 
-  /* tag with event to make sure this only happens once per round! */
-  if (!char_has_mud_event(ch, eSMASH_DEFENSE))
-  {
+  if (semantic_managed)
+    combat_encounter_round_flag_mark(ch, COMBAT_ENCOUNTER_ROUND_SMASH_DEFENSE_USED);
+  else
     attach_mud_event(new_mud_event(eSMASH_DEFENSE, ch, NULL), 6 * PASSES_PER_SEC);
-  }
 
   return;
 }
@@ -16724,7 +16826,8 @@ void perform_violence(struct char_data *ch, int phase)
   struct list_data *room_list = NULL;
 
   /* Reset combat data */
-  GET_TOTAL_AOO(ch) = 0;
+  if (!combat_encounter_semantic_manages(ch))
+    GET_TOTAL_AOO(ch) = 0;
   HAS_PERFORMED_DEMORALIZING_STRIKE(ch) = FALSE;
   REMOVE_BIT_AR(AFF_FLAGS(ch), AFF_FLAT_FOOTED);
 
@@ -16985,7 +17088,7 @@ void perform_violence(struct char_data *ch, int phase)
     return;
   }
 
-  if (IS_NPC(ch) && (phase == 1))
+  if (IS_NPC(ch) && (phase == 0 || phase == 1))
   {
     if (GET_MOB_WAIT(ch) > 0 || HAS_WAIT(ch))
     {
@@ -17180,9 +17283,12 @@ void perform_violence(struct char_data *ch, int phase)
 
   else
   {
+    bool had_move_action = is_action_available(ch, atMOVE, FALSE);
+    bool had_standard_action = is_action_available(ch, atSTANDARD, FALSE);
+
     /* handle smash defense */
     if (!IS_NPC(ch) && HAS_FEAT(ch, FEAT_SMASH_DEFENSE) && PRF_FLAGGED(ch, PRF_SMASH_DEFENSE) &&
-        affected_by_spell(ch, SKILL_DEFENSIVE_STANCE) && !char_has_mud_event(ch, eSMASH_DEFENSE))
+        affected_by_spell(ch, SKILL_DEFENSIVE_STANCE))
       handle_smash_defense(ch);
 
 #define NORMAL_ATTACK_ROUTINE 0
@@ -17193,8 +17299,15 @@ void perform_violence(struct char_data *ch, int phase)
     }
 #undef NORMAL_ATTACK_ROUTINE
 
+    if (combat_encounter_semantic_manages(ch) && had_standard_action)
+    {
+      USE_STANDARD_ACTION(ch);
+      if (had_move_action && !AFF_FLAGGED(ch, AFF_STAGGERED))
+        USE_MOVE_ACTION(ch);
+    }
+
     /* handle cleave - now includes Cleaving Strike perks */
-    if (phase == 1 &&
+    if ((phase == 0 || phase == 1) &&
         (HAS_FEAT(ch, FEAT_CLEAVE) || HAS_FEAT(ch, FEAT_GREAT_CLEAVE) ||
          has_perk(ch, PERK_FIGHTER_CLEAVING_STRIKE) || has_berserker_cleaving_strikes(ch)) &&
         !is_using_ranged_weapon(ch, TRUE) && !IS_THROWN_MODE(ch))

--- a/src/combat/fight.c
+++ b/src/combat/fight.c
@@ -61,6 +61,7 @@
 #include "rol_feats.h"
 #include "domain_event_runtime.h"
 #include "point_update_periodic.h"
+#include "combat/combat_encounters.h"
 
 /* toggle for debug mode
    true = annoying messages used for debugging
@@ -1714,7 +1715,7 @@ bool set_fighting(struct char_data *ch, struct char_data *vict)
     ;
   }
 
-  if (char_has_mud_event(ch, eCOMBAT_ROUND))
+  if (!combat_encounter_events_enabled() && char_has_mud_event(ch, eCOMBAT_ROUND))
   {
     return FALSE;
     ;
@@ -1854,8 +1855,18 @@ bool set_fighting(struct char_data *ch, struct char_data *vict)
     }
   }
 
-  /* start the combat loop, making sure we begin with phase "1" */
-  attach_mud_event(new_mud_event(eCOMBAT_ROUND, ch, "1"), delay);
+  /* Start the selected combat clock with phase one. */
+  if (combat_encounter_events_enabled())
+  {
+    if (!combat_encounter_join(ch, vict, delay))
+    {
+      log("SYSERR: Unable to admit %s to an encounter-owned combat event.", GET_NAME(ch));
+      stop_fighting(ch);
+      return FALSE;
+    }
+  }
+  else
+    attach_mud_event(new_mud_event(eCOMBAT_ROUND, ch, "1"), delay);
 
   HAS_PERFORMED_DEMORALIZING_STRIKE(ch) = FALSE;
 
@@ -1875,6 +1886,7 @@ void stop_fighting(struct char_data *ch)
   ch->next_fighting = NULL;
   FIGHTING(ch) = NULL;
   domain_event_runtime_combat_state_changed(ch, opponent, false);
+  combat_encounter_leave(ch, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
   GET_WARBEAT_USED(ch) = 0;
   clear_projectile_mode(ch);
   if (GET_POS(ch) == POS_FIGHTING) /* in case they are position fighting */
@@ -2442,6 +2454,8 @@ void raw_kill(struct char_data *ch, struct char_data *killer)
 {
   struct char_data *k, *temp;
   struct affected_type af = {0}; /* Zero-initialize to prevent stack garbage */
+
+  domain_event_runtime_character_died(ch, killer);
 
   /* stop relevant fighting */
   if (FIGHTING(ch))
@@ -16465,32 +16479,19 @@ void autoDiagnose(struct char_data *ch)
   }
 }
 
-/* Fight control event.  Replaces the violence loop. */
-EVENTFUNC(event_combat_round)
+bool combat_run_compatibility_phase(struct char_data *ch, unsigned int phase)
 {
-  struct char_data *ch = NULL;
-  struct mud_event_data *pMudEvent = NULL;
-
-  /*  This is just a dummy check, but we'll do it anyway */
-  if (event_obj == NULL)
-    return 0;
-
-  /*  For the sake of simplicity, we will place the event data in easily
-   * referenced pointers */
-  pMudEvent = (struct mud_event_data *)event_obj;
-  ch = (struct char_data *)pMudEvent->pStruct;
-
   /* Safety check: Validate character state before processing combat */
   if (!ch || IN_ROOM(ch) == NOWHERE || GET_POS(ch) <= POS_DEAD)
-    return 0;
+    return false;
 
   /* Check if character is pending extraction */
   if (!IS_NPC(ch) && PLR_FLAGGED(ch, PLR_NOTDEADYET))
-    return 0;
+    return false;
 
   /* Additional check for NPCs pending extraction */
   if (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_NOTDEADYET))
-    return 0;
+    return false;
 
   if ((!IS_NPC(ch) && (ch->desc != NULL && !IS_PLAYING(ch->desc))) || (FIGHTING(ch) == NULL))
   {
@@ -16499,24 +16500,22 @@ EVENTFUNC(event_combat_round)
       send_to_char(ch, "DEBUG: RETURNING 0 FROM COMBAT EVENT.\r\n");
     }
     stop_fighting(ch);
-    return 0;
+    return false;
   }
 
   if (FIGHTING(ch) == NULL)
-  {
-    return 0;
-  }
+    return false;
 
   if (GET_POS(FIGHTING(ch)) <= POS_DEAD || GET_POS(ch) <= POS_DEAD)
   {
     stop_fighting(ch);
-    return 0;
+    return false;
   }
 
   if (IN_ROOM(ch) != IN_ROOM(FIGHTING(ch)))
   {
     stop_fighting(ch);
-    return 0;
+    return false;
   }
 
   PERF_combat_round_begin(ch);
@@ -16530,9 +16529,7 @@ EVENTFUNC(event_combat_round)
   /* execute phase */
   {
     PERF_PROF_ENTER_SAMPLED(combat_perform_violence, "combat.perform_violence");
-    perform_violence(ch, (pMudEvent->sVariables != NULL && is_number(pMudEvent->sVariables)
-                              ? atoi(pMudEvent->sVariables)
-                              : 0));
+    perform_violence(ch, (int)phase);
     PERF_PROF_EXIT(combat_perform_violence);
   }
 
@@ -16554,12 +16551,28 @@ EVENTFUNC(event_combat_round)
     PERF_PROF_EXIT(combat_backlash);
   }
 
-  /* set the next phase */
-  if (pMudEvent->sVariables != NULL)
-    sprintf(pMudEvent->sVariables, "%d",
-            (atoi(pMudEvent->sVariables) < 3 ? atoi(pMudEvent->sVariables) + 1 : 1));
-
   PERF_combat_round_end();
+  return true;
+}
+
+/* Per-character rollback event for the compatibility combat phases. */
+EVENTFUNC(event_combat_round)
+{
+  struct char_data *ch;
+  struct mud_event_data *pMudEvent;
+  unsigned int phase;
+
+  if (event_obj == NULL)
+    return 0;
+  pMudEvent = event_obj;
+  ch = pMudEvent->pStruct;
+  phase = pMudEvent->sVariables != NULL && is_number(pMudEvent->sVariables)
+              ? (unsigned int)atoi(pMudEvent->sVariables)
+              : 0U;
+  if (!combat_run_compatibility_phase(ch, phase))
+    return 0;
+  if (pMudEvent->sVariables != NULL)
+    sprintf(pMudEvent->sVariables, "%u", phase < 3U ? phase + 1U : 1U);
   return 2 RL_SEC; /* 6 second rounds, hack! */
 }
 

--- a/src/combat/fight.c
+++ b/src/combat/fight.c
@@ -16657,19 +16657,32 @@ EVENTFUNC(event_combat_round)
 {
   struct char_data *ch;
   struct mud_event_data *pMudEvent;
+  char *phase_end;
+  char next_phase_text[2];
+  unsigned long parsed_phase;
   unsigned int phase;
+  unsigned int next_phase;
 
   if (event_obj == NULL)
     return 0;
   pMudEvent = event_obj;
   ch = pMudEvent->pStruct;
-  phase = pMudEvent->sVariables != NULL && is_number(pMudEvent->sVariables)
-              ? (unsigned int)atoi(pMudEvent->sVariables)
-              : 0U;
+  phase = 1U;
+  if (pMudEvent->sVariables != NULL)
+  {
+    errno = 0;
+    phase_end = NULL;
+    parsed_phase = strtoul(pMudEvent->sVariables, &phase_end, 10);
+    if (errno == 0 && phase_end != pMudEvent->sVariables && *phase_end == '\0' &&
+        parsed_phase >= 1U && parsed_phase <= 3U)
+      phase = (unsigned int)parsed_phase;
+  }
   if (!combat_run_compatibility_phase(ch, phase))
     return 0;
-  if (pMudEvent->sVariables != NULL)
-    sprintf(pMudEvent->sVariables, "%u", phase < 3U ? phase + 1U : 1U);
+  next_phase = phase < 3U ? phase + 1U : 1U;
+  snprintf(next_phase_text, sizeof(next_phase_text), "%u", next_phase);
+  free(pMudEvent->sVariables);
+  pMudEvent->sVariables = strdup(next_phase_text);
   return 2 RL_SEC; /* 6 second rounds, hack! */
 }
 

--- a/src/combat/fight.h
+++ b/src/combat/fight.h
@@ -86,6 +86,7 @@ int hit(struct char_data *ch, struct char_data *victim, int type, int dam_type, 
 void load_messages(void);
 void perform_violence(struct char_data *ch, int phase);
 bool combat_run_compatibility_phase(struct char_data *ch, unsigned int phase);
+bool combat_run_semantic_round(struct char_data *ch, bool was_hit);
 void raw_kill(struct char_data *ch, struct char_data *killer);
 bool set_fighting(struct char_data *ch, struct char_data *victim);
 int skill_message(int dam, struct char_data *ch, struct char_data *vict, int attacktype,

--- a/src/combat/fight.h
+++ b/src/combat/fight.h
@@ -85,6 +85,7 @@ int hit(struct char_data *ch, struct char_data *victim, int type, int dam_type, 
         int attack_type);
 void load_messages(void);
 void perform_violence(struct char_data *ch, int phase);
+bool combat_run_compatibility_phase(struct char_data *ch, unsigned int phase);
 void raw_kill(struct char_data *ch, struct char_data *killer);
 bool set_fighting(struct char_data *ch, struct char_data *victim);
 int skill_message(int dam, struct char_data *ch, struct char_data *vict, int attacktype,

--- a/src/comm.c
+++ b/src/comm.c
@@ -70,6 +70,7 @@
 #include "interpreter.h"
 #include "handler.h"
 #include "db.h"
+#include "combat/combat_encounters.h"
 #include "obj/house.h"
 #include "olc/oasis.h"
 #include "olc/genolc.h"
@@ -1560,7 +1561,8 @@ void game_loop(socket_t local_mother_desc)
         }
       }
       else if (d->character && STATE(d) == CON_PLAYING && pending_actions(d->character) &&
-               !d->showstr_count && !d->str)
+               !combat_encounter_semantic_manages(d->character) && !d->showstr_count &&
+               !d->str)
       {
         d->has_prompt = TRUE;
         execute_next_action(d->character);

--- a/src/dgscript/dg_event.c
+++ b/src/dgscript/dg_event.c
@@ -353,6 +353,7 @@ static struct event *event_create_internal(EVENTFUNC(*func), void *event_obj, lo
 {
   struct event *new_event = NULL;
   enum game_scheduler_status scheduler_status;
+  game_tick_t scheduler_deadline;
   game_event_id_t scheduler_id;
   long target_time;
 
@@ -411,13 +412,22 @@ static struct event *event_create_internal(EVENTFUNC(*func), void *event_obj, lo
 
   if (active_backend == EVENT_BACKEND_GAME_SCHEDULER)
   {
+    if ((game_tick_t)when > UINT64_MAX - (game_tick_t)pulse)
+    {
+      log("WARNING: event_create overflow prevented. Event scheduled for maximum future time.");
+      scheduler_deadline = UINT64_MAX;
+    }
+    else
+    {
+      scheduler_deadline = (game_tick_t)pulse + (game_tick_t)when;
+    }
     scheduler_id = 0;
     if (game_event_owner_is_none(owner))
-      scheduler_status = game_scheduler_schedule_after(event_scheduler, legacy_event_type,
-                                                       (game_tick_t)when, new_event, &scheduler_id);
+      scheduler_status = game_scheduler_schedule_at(event_scheduler, legacy_event_type,
+                                                    scheduler_deadline, new_event, &scheduler_id);
     else
-      scheduler_status = game_scheduler_schedule_owned_after(
-          event_scheduler, legacy_event_type, owner, (game_tick_t)when, new_event, &scheduler_id);
+      scheduler_status = game_scheduler_schedule_owned_at(
+          event_scheduler, legacy_event_type, owner, scheduler_deadline, new_event, &scheduler_id);
     if (scheduler_status != GAME_SCHEDULER_OK)
     {
       log("SYSERR: Unable to schedule legacy event '%s' (status %d).",

--- a/src/dgscript/dg_mobcmd.c
+++ b/src/dgscript/dg_mobcmd.c
@@ -1288,6 +1288,9 @@ ACMD(do_mtransform)
   mob_rnum this_rnum = GET_MOB_RNUM(ch);
   struct char_data *affected_next;
   struct char_data *affected_prev;
+  struct combat_encounter_data *combat_encounter;
+  struct combat_encounter_participant *combat_encounter_participant;
+  uint64_t domain_event_generation;
   int old_origin_zone_vnum;
   int old_create_reason;
   bool affected_registered;
@@ -1376,12 +1379,18 @@ ACMD(do_mtransform)
     affected_next = ch->affected_next;
     affected_prev = ch->affected_prev;
     affected_registered = ch->affected_registered;
+    combat_encounter = ch->combat_encounter;
+    combat_encounter_participant = ch->combat_encounter_participant;
+    domain_event_generation = ch->domain_event_generation;
 
     tmpmob.id = ch->id;
     tmpmob.affected = ch->affected;
     tmpmob.affected_next = affected_next;
     tmpmob.affected_prev = affected_prev;
     tmpmob.affected_registered = affected_registered;
+    tmpmob.combat_encounter = combat_encounter;
+    tmpmob.combat_encounter_participant = combat_encounter_participant;
+    tmpmob.domain_event_generation = domain_event_generation;
     tmpmob.perf_origin_zone_vnum = old_origin_zone_vnum;
     tmpmob.perf_create_reason = (unsigned char)old_create_reason;
     tmpmob.carrying = ch->carrying;

--- a/src/domain_event_runtime.c
+++ b/src/domain_event_runtime.c
@@ -3,6 +3,7 @@
 #include "active_world.h"
 #include "affected_owners.h"
 #include "character_periodic.h"
+#include "combat/combat_encounters.h"
 #include "domain_event_types.h"
 #include "domain_event_world.h"
 #include "periodic_owners.h"
@@ -30,6 +31,8 @@ enum domain_event_status domain_event_runtime_init(void)
   if (status == DOMAIN_EVENT_OK)
     status = domain_event_world_register_resolvers(runtime_bus);
   if (status == DOMAIN_EVENT_OK)
+    status = combat_encounter_runtime_init(runtime_bus);
+  if (status == DOMAIN_EVENT_OK)
     status = character_periodic_register_handlers(runtime_bus);
   if (status == DOMAIN_EVENT_OK)
     status = spatial_event_register_handlers(runtime_bus);
@@ -40,6 +43,7 @@ enum domain_event_status domain_event_runtime_init(void)
   if (status != DOMAIN_EVENT_OK)
   {
     active_world_shutdown();
+    combat_encounter_runtime_shutdown();
     periodic_owners_shutdown();
     affected_owners_shutdown();
     character_periodic_shutdown();
@@ -58,6 +62,7 @@ enum domain_event_status domain_event_runtime_shutdown(void)
   if (runtime_bus == NULL)
     return DOMAIN_EVENT_OK;
   active_world_shutdown();
+  combat_encounter_runtime_shutdown();
   periodic_owners_shutdown();
   affected_owners_shutdown();
   character_periodic_shutdown();
@@ -101,6 +106,18 @@ enum domain_event_status domain_event_runtime_combat_state_changed(struct char_d
   event.opponent = domain_event_character_handle(opponent);
   event.in_combat = in_combat;
   return DOMAIN_EVENT_PUBLISH(runtime_bus, DOMAIN_EVENT_COMBAT_STATE_CHANGED, &event);
+}
+
+enum domain_event_status domain_event_runtime_character_died(struct char_data *ch,
+                                                             struct char_data *killer)
+{
+  struct domain_character_died event;
+
+  if (runtime_bus == NULL || ch == NULL)
+    return DOMAIN_EVENT_NOT_FOUND;
+  event.character = domain_event_character_handle(ch);
+  event.killer = domain_event_character_handle(killer);
+  return DOMAIN_EVENT_PUBLISH(runtime_bus, DOMAIN_EVENT_CHARACTER_DIED, &event);
 }
 
 enum domain_event_status domain_event_runtime_character_extracted(struct char_data *ch,

--- a/src/domain_event_runtime.h
+++ b/src/domain_event_runtime.h
@@ -13,6 +13,8 @@ enum domain_event_status domain_event_runtime_character_moved(struct char_data *
 enum domain_event_status domain_event_runtime_combat_state_changed(struct char_data *ch,
                                                                    struct char_data *opponent,
                                                                    bool in_combat);
+enum domain_event_status domain_event_runtime_character_died(struct char_data *ch,
+                                                             struct char_data *killer);
 enum domain_event_status domain_event_runtime_character_extracted(struct char_data *ch,
                                                                   uint32_t reason);
 

--- a/src/event_debug.c
+++ b/src/event_debug.c
@@ -266,19 +266,37 @@ size_t event_debug_render_summary(char *buffer, size_t capacity, int width)
   combat_encounter_get_stats(&encounter_stats);
   debug_output_line(&output, "");
   debug_output_line(&output, "Combat encounters");
-  debug_output_line(&output, "  mode: %s",
-                    encounter_stats.encounter_mode ? "encounter" : "character rollback");
+  debug_output_line(
+      &output, "  mode: %s",
+      !encounter_stats.encounter_mode
+          ? "character rollback"
+          : encounter_stats.semantic_rounds ? "six-second semantic" : "compatibility phases");
   debug_output_line(&output, "  active: %zu encounters / %zu participants",
                     encounter_stats.active_encounters, encounter_stats.active_participants);
   debug_output_line(&output, "  scheduled events: %zu", encounter_stats.scheduled_events);
   debug_output_line(&output, "  created/ended/merged: %" PRIu64 "/%" PRIu64 "/%" PRIu64,
                     encounter_stats.encounters_created, encounter_stats.encounters_ended,
                     encounter_stats.encounters_merged);
-  debug_output_line(&output, "  callbacks/phases/terminal: %" PRIu64 "/%" PRIu64 "/%" PRIu64,
-                    encounter_stats.encounter_callbacks, encounter_stats.compatibility_phases,
-                    encounter_stats.compatibility_terminal);
-  debug_output_line(&output, "  compatibility attempts: %" PRIu64,
-                    encounter_stats.compatibility_attempts);
+  debug_output_line(&output, "  callbacks: %" PRIu64, encounter_stats.encounter_callbacks);
+  if (encounter_stats.semantic_rounds)
+  {
+    debug_output_line(&output, "  semantic rounds/turns: %" PRIu64 "/%" PRIu64,
+                      encounter_stats.semantic_rounds_resolved,
+                      encounter_stats.semantic_turns_resolved);
+    debug_output_line(&output, "  intents sent/held: %" PRIu64 "/%" PRIu64,
+                      encounter_stats.intents_dispatched,
+                      encounter_stats.intent_dispatch_blocks);
+    debug_output_line(&output, "  action/reaction spend: %" PRIu64 "/%" PRIu64,
+                      encounter_stats.action_budgets_spent, encounter_stats.reactions_spent);
+  }
+  else
+  {
+    debug_output_line(&output, "  phases/terminal: %" PRIu64 "/%" PRIu64,
+                      encounter_stats.compatibility_phases,
+                      encounter_stats.compatibility_terminal);
+    debug_output_line(&output, "  compatibility attempts: %" PRIu64,
+                      encounter_stats.compatibility_attempts);
+  }
   debug_output_line(&output, "  comparison mismatch: %" PRIu64,
                     encounter_stats.compatibility_mismatches);
   debug_output_line(&output, "  admission/stale: %" PRIu64 "/%" PRIu64,

--- a/src/event_debug.c
+++ b/src/event_debug.c
@@ -8,6 +8,7 @@
 #include "domain_event_runtime.h"
 #include "domain_events.h"
 #include "event_debug.h"
+#include "combat/combat_encounters.h"
 #include "net/i3_client.h"
 #include "perfmon.h"
 
@@ -168,6 +169,7 @@ size_t event_debug_render_summary(char *buffer, size_t capacity, int width)
   struct PERF_event_summary perf_stats;
   struct domain_event_bus_stats domain_stats;
   struct i3_ingress_stats ingress_stats;
+  struct combat_encounter_stats encounter_stats;
   struct domain_event_bus *bus;
 
   debug_output_init(&output, buffer, capacity, width);
@@ -260,6 +262,28 @@ size_t event_debug_render_summary(char *buffer, size_t capacity, int width)
   }
   else
     debug_output_line(&output, "Legacy storage metrics unavailable.");
+  memset(&encounter_stats, 0, sizeof(encounter_stats));
+  combat_encounter_get_stats(&encounter_stats);
+  debug_output_line(&output, "");
+  debug_output_line(&output, "Combat encounters");
+  debug_output_line(&output, "  mode: %s",
+                    encounter_stats.encounter_mode ? "encounter" : "character rollback");
+  debug_output_line(&output, "  active: %zu encounters / %zu participants",
+                    encounter_stats.active_encounters, encounter_stats.active_participants);
+  debug_output_line(&output, "  scheduled events: %zu", encounter_stats.scheduled_events);
+  debug_output_line(&output, "  created/ended/merged: %" PRIu64 "/%" PRIu64 "/%" PRIu64,
+                    encounter_stats.encounters_created, encounter_stats.encounters_ended,
+                    encounter_stats.encounters_merged);
+  debug_output_line(&output, "  callbacks/phases/terminal: %" PRIu64 "/%" PRIu64 "/%" PRIu64,
+                    encounter_stats.encounter_callbacks, encounter_stats.compatibility_phases,
+                    encounter_stats.compatibility_terminal);
+  debug_output_line(&output, "  compatibility attempts: %" PRIu64,
+                    encounter_stats.compatibility_attempts);
+  debug_output_line(&output, "  comparison mismatch: %" PRIu64,
+                    encounter_stats.compatibility_mismatches);
+  debug_output_line(&output, "  admission/stale: %" PRIu64 "/%" PRIu64,
+                    encounter_stats.admission_failures,
+                    encounter_stats.stale_encounter_callbacks);
   memset(&ingress_stats, 0, sizeof(ingress_stats));
   i3_get_ingress_stats(&ingress_stats);
   debug_output_line(&output, "");

--- a/src/handler.c
+++ b/src/handler.c
@@ -47,6 +47,7 @@
 #include "point_update_periodic.h"
 #include "affected_owners.h"
 #include "domain_event_runtime.h"
+#include "combat/combat_encounters.h"
 #include "vessels/vessels_rol.h"
 
 /* local file scope variables */
@@ -3115,6 +3116,7 @@ void extract_char_final(struct char_data *ch)
                                (enum perf_entity_reason)ch->perf_create_reason);
 
   domain_event_runtime_character_extracted(ch, 0U);
+  combat_encounter_forget_character(ch, COMBAT_ENCOUNTER_DEPARTURE_EXTRACTED);
   character_periodic_forget(ch);
   point_update_character_forget(ch);
   active_world_forget_character(ch);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -6153,7 +6153,7 @@ void command_interpreter(struct char_data *ch, char *argument)
        * admitted to the action queue. */
       return;
     }
-    else if (pending_actions(ch) > MAX_QUEUE_SIZE)
+    else if (pending_actions(ch) >= MAX_QUEUE_SIZE)
     {
       send_to_char(ch, "The action queue is full.\r\n");
     }

--- a/src/limits.c
+++ b/src/limits.c
@@ -21,6 +21,7 @@
 #include "dgscript/dg_scripts.h"
 #include "character/class.h"
 #include "combat/fight.h"
+#include "combat/combat_encounters.h"
 #include "combat/projectiles.h"
 #include "screen.h"
 #include "mud_event.h"
@@ -2168,7 +2169,8 @@ void proc_d20_round(void)
   for (i = character_list; i; i = i->next)
   {
     /* Cowering: 10% chance per round to be too afraid to act */
-    if (FIGHTING(i) && AFF2_FLAGGED(i, AFF2_COWERING) && rand_number(1, 100) <= 10)
+    if (!combat_encounter_semantic_manages(i) && FIGHTING(i) &&
+        AFF2_FLAGGED(i, AFF2_COWERING) && rand_number(1, 100) <= 10)
     {
       send_to_char(i, "\tRYou are too afraid to act!\tn\r\n");
       act("$n cowers in fear, unable to act!", FALSE, i, 0, 0, TO_ROOM);
@@ -2179,7 +2181,8 @@ void proc_d20_round(void)
     }
 
     /* Perfect Tempo perk: Apply buff if character avoided all hits this round */
-    if (FIGHTING(i) && has_bard_perfect_tempo(i) && !is_affected_by_perfect_tempo(i))
+    if (!combat_encounter_semantic_manages(i) && FIGHTING(i) && has_bard_perfect_tempo(i) &&
+        !is_affected_by_perfect_tempo(i))
     {
       /* Check if they were hit this round (ePERFECT_TEMPO_HIT_THIS_ROUND event) */
       if (!char_has_mud_event(i, ePERFECT_TEMPO_HIT_THIS_ROUND))

--- a/src/structs.h
+++ b/src/structs.h
@@ -33,6 +33,9 @@
 // code are defined in one place, so you can review and change them easily.
 #include "vnums.h"
 
+struct combat_encounter_data;
+struct combat_encounter_participant;
+
 /** Intended use of this macro is to allow external packages to work with a
  * variety of versions without modifications.  For instance, an IS_CORPSE()
  * macro was introduced in pl13.  Any future code add-ons could take into
@@ -7417,6 +7420,8 @@ struct char_data
   struct char_data *active_world_prev;    /**< Scheduled-mobile registry link. */
   struct event *active_world_event;       /**< Sole scheduled mobile-think event. */
   unsigned char active_world_state;       /**< Active, cooling, or dormant state. */
+  struct combat_encounter_data *combat_encounter; /**< Runtime fight-session owner. */
+  struct combat_encounter_participant *combat_encounter_participant; /**< Membership node. */
   struct obj_data *equipment[NUM_WEARS]; /**< Equipment array            */
 
   struct obj_data *carrying;    /**< List head for objects in inventory */

--- a/unittests/CuTest/test_combat_encounters.c
+++ b/unittests/CuTest/test_combat_encounters.c
@@ -1,0 +1,466 @@
+#include "CuTest.h"
+
+#include "../../src/conf.h"
+#include "../../src/sysdep.h"
+#include "../../src/structs.h"
+#include "../../src/comm.h"
+#include "../../src/db.h"
+#include "../../src/combat/combat_encounters.h"
+#include "../../src/combat/fight.h"
+#include "../../src/dgscript/dg_event.h"
+
+#include <string.h>
+
+#define ENCOUNTER_TRACE_CAPACITY 64U
+
+struct encounter_test_trace
+{
+  struct char_data *characters[ENCOUNTER_TRACE_CAPACITY];
+  unsigned int phases[ENCOUNTER_TRACE_CAPACITY];
+  size_t count;
+  struct char_data *mutation_trigger;
+  struct char_data *mutation_character;
+  struct char_data *mutation_opponent;
+  enum combat_encounter_departure_reason mutation_reason;
+  bool join_during_callback;
+  bool vanish_during_callback;
+  bool leave_only_mutation_character;
+  bool rejoin_after_vanish;
+  bool mutation_ran;
+  bool mutation_succeeded;
+};
+
+static void encounter_test_character(struct char_data *character, const char *name)
+{
+  clear_char(character);
+  character->player.name = (char *)name;
+}
+
+static unsigned long encounter_test_begin(CuTest *tc, bool encounter_mode,
+                                          unsigned long start_pulse,
+                                          struct encounter_test_trace *trace)
+{
+  unsigned long saved_pulse = pulse;
+
+  combat_encounter_runtime_shutdown();
+  event_free_all();
+  CuAssertIntEquals(tc, 1, event_test_select_backend(EVENT_BACKEND_GAME_SCHEDULER));
+  pulse = start_pulse;
+  event_init();
+  combat_encounter_test_select(encounter_mode);
+  CuAssertIntEquals(tc, DOMAIN_EVENT_OK, combat_encounter_runtime_init(NULL));
+  if (trace != NULL)
+  {
+    memset(trace, 0, sizeof(*trace));
+    combat_encounter_test_set_phase_callback(NULL, NULL);
+  }
+  return saved_pulse;
+}
+
+static void encounter_test_end(unsigned long saved_pulse)
+{
+  combat_encounter_runtime_shutdown();
+  event_free_all();
+  pulse = saved_pulse;
+}
+
+static bool encounter_test_record_phase(struct char_data *character,
+                                        unsigned int phase, void *context)
+{
+  struct encounter_test_trace *trace = context;
+
+  if (trace->count < ENCOUNTER_TRACE_CAPACITY)
+  {
+    trace->characters[trace->count] = character;
+    trace->phases[trace->count] = phase;
+    trace->count++;
+  }
+  if (trace->mutation_ran || character != trace->mutation_trigger)
+    return true;
+  trace->mutation_ran = true;
+  if (trace->join_during_callback)
+  {
+    FIGHTING(trace->mutation_character) = trace->mutation_opponent;
+    trace->mutation_succeeded = combat_encounter_join(
+        trace->mutation_character, trace->mutation_opponent, 1L);
+  }
+  if (trace->vanish_during_callback)
+  {
+    FIGHTING(trace->mutation_character) = NULL;
+    FIGHTING(trace->mutation_opponent) = NULL;
+    combat_encounter_leave(trace->mutation_character, trace->mutation_reason);
+    if (!trace->leave_only_mutation_character)
+      combat_encounter_leave(trace->mutation_opponent, trace->mutation_reason);
+    trace->mutation_succeeded = true;
+  }
+  if (trace->rejoin_after_vanish)
+  {
+    FIGHTING(trace->mutation_character) = trace->mutation_opponent;
+    trace->mutation_succeeded = combat_encounter_join(
+        trace->mutation_character, trace->mutation_opponent, 1 RL_SEC);
+  }
+  return true;
+}
+
+static void encounter_test_leave(struct char_data *character,
+                                 enum combat_encounter_departure_reason reason)
+{
+  FIGHTING(character) = NULL;
+  combat_encounter_leave(character, reason);
+}
+
+void Test_combat_encounter_uses_one_event_and_preserves_compatibility_cadence(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct combat_encounter_stats stats;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 1000U;
+
+  encounter_test_character(&first, "first combatant");
+  encounter_test_character(&second, "second combatant");
+  saved_pulse = encounter_test_begin(tc, true, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  FIGHTING(&second) = &first;
+
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 2 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second, &first, 4 RL_SEC));
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 1, (int)stats.active_encounters);
+  CuAssertIntEquals(tc, 2, (int)stats.active_participants);
+  CuAssertIntEquals(tc, 1, (int)stats.scheduled_events);
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  pulse = start_pulse + (2 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 1, (int)trace.count);
+  CuAssertPtrEquals(tc, &first, trace.characters[0]);
+  CuAssertIntEquals(tc, 1, (int)trace.phases[0]);
+
+  pulse = start_pulse + (4 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 3, (int)trace.count);
+  CuAssertPtrEquals(tc, &second, trace.characters[1]);
+  CuAssertIntEquals(tc, 1, (int)trace.phases[1]);
+  CuAssertPtrEquals(tc, &first, trace.characters[2]);
+  CuAssertIntEquals(tc, 2, (int)trace.phases[2]);
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 0, (int)stats.active_encounters);
+  CuAssertIntEquals(tc, 0, (int)stats.active_participants);
+  CuAssertIntEquals(tc, 0, (int)stats.scheduled_events);
+  CuAssertIntEquals(tc, 0, event_queue_depth());
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_guards_joins_during_dispatch_only(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data anchor;
+  struct char_data before;
+  struct char_data during;
+  struct char_data after;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  unsigned long current;
+  size_t index;
+  bool saw_during = false;
+  const unsigned long start_pulse = 2000U;
+
+  encounter_test_character(&first, "initial combatant");
+  encounter_test_character(&anchor, "encounter anchor");
+  encounter_test_character(&before, "pre-dispatch joiner");
+  encounter_test_character(&during, "in-dispatch joiner");
+  encounter_test_character(&after, "post-dispatch joiner");
+  saved_pulse = encounter_test_begin(tc, true, start_pulse, &trace);
+  trace.mutation_trigger = &before;
+  trace.mutation_character = &during;
+  trace.mutation_opponent = &anchor;
+  trace.join_during_callback = true;
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+
+  FIGHTING(&first) = &anchor;
+  FIGHTING(&before) = &anchor;
+  CuAssertTrue(tc, combat_encounter_join(&first, &anchor, 2 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&before, &anchor, 1 RL_SEC));
+  pulse = start_pulse + (1 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, trace.mutation_ran);
+  CuAssertTrue(tc, trace.mutation_succeeded);
+  CuAssertIntEquals(tc, 1, (int)trace.count);
+  CuAssertPtrEquals(tc, &before, trace.characters[0]);
+
+  FIGHTING(&after) = &anchor;
+  CuAssertTrue(tc, combat_encounter_join(&after, &anchor, 1 RL_SEC));
+  pulse = start_pulse + (2 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 3, (int)trace.count);
+  CuAssertPtrEquals(tc, &first, trace.characters[1]);
+  CuAssertPtrEquals(tc, &after, trace.characters[2]);
+
+  for (current = start_pulse + (3 RL_SEC); current <= start_pulse + (6 RL_SEC);
+       current += (1 RL_SEC))
+  {
+    pulse = current;
+    event_process();
+  }
+  for (index = 0U; index < trace.count; index++)
+    if (trace.characters[index] == &during)
+      saw_during = true;
+  CuAssertTrue(tc, !saw_during);
+
+  pulse = start_pulse + (7 RL_SEC);
+  event_process();
+  for (index = 0U; index < trace.count; index++)
+    if (trace.characters[index] == &during)
+      saw_during = true;
+  CuAssertTrue(tc, saw_during);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 1, (int)stats.active_encounters);
+  CuAssertIntEquals(tc, 5, (int)stats.active_participants);
+  CuAssertIntEquals(tc, 1, (int)stats.scheduled_events);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&anchor, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&before, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&during, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&after, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_merges_during_resolution_without_extra_turn(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data bridge;
+  struct char_data second;
+  struct char_data second_anchor;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 3000U;
+
+  encounter_test_character(&first, "first encounter actor");
+  encounter_test_character(&bridge, "encounter bridge");
+  encounter_test_character(&second, "second encounter actor");
+  encounter_test_character(&second_anchor, "second encounter anchor");
+  saved_pulse = encounter_test_begin(tc, true, start_pulse, &trace);
+  trace.mutation_trigger = &first;
+  trace.mutation_character = &bridge;
+  trace.mutation_opponent = &second;
+  trace.join_during_callback = true;
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+
+  FIGHTING(&first) = &bridge;
+  FIGHTING(&second) = &second_anchor;
+  CuAssertTrue(tc, combat_encounter_join(&first, &bridge, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second, &second_anchor, 1 RL_SEC));
+  CuAssertIntEquals(tc, 2, event_queue_depth());
+
+  pulse = start_pulse + (1 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, trace.mutation_succeeded);
+  CuAssertIntEquals(tc, 2, (int)trace.count);
+  CuAssertPtrEquals(tc, &first, trace.characters[0]);
+  CuAssertPtrEquals(tc, &second, trace.characters[1]);
+  CuAssertIntEquals(tc, 1, (int)trace.phases[0]);
+  CuAssertIntEquals(tc, 1, (int)trace.phases[1]);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 1, (int)stats.active_encounters);
+  CuAssertIntEquals(tc, 4, (int)stats.active_participants);
+  CuAssertIntEquals(tc, 1, (int)stats.scheduled_events);
+  CuAssertIntEquals(tc, 1, (int)stats.encounters_merged);
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  encounter_test_leave(&bridge, COMBAT_ENCOUNTER_DEPARTURE_MOVED);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 3, (int)stats.active_participants);
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second_anchor, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_callback_can_remove_every_participant(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 4000U;
+
+  encounter_test_character(&first, "departing actor");
+  encounter_test_character(&second, "departing target");
+  saved_pulse = encounter_test_begin(tc, true, start_pulse, &trace);
+  trace.mutation_trigger = &first;
+  trace.mutation_character = &first;
+  trace.mutation_opponent = &second;
+  trace.mutation_reason = COMBAT_ENCOUNTER_DEPARTURE_DIED;
+  trace.vanish_during_callback = true;
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  FIGHTING(&second) = &first;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second, &first, 1 RL_SEC));
+
+  pulse = start_pulse + (1 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, trace.mutation_succeeded);
+  CuAssertPtrEquals(tc, NULL, first.combat_encounter);
+  CuAssertPtrEquals(tc, NULL, second.combat_encounter);
+  CuAssertIntEquals(tc, 0, event_queue_depth());
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 0, (int)stats.active_encounters);
+  CuAssertIntEquals(tc, 0, (int)stats.active_participants);
+  CuAssertIntEquals(tc, 1, (int)stats.encounters_ended);
+  CuAssertIntEquals(tc, 2, (int)stats.departure_counts[COMBAT_ENCOUNTER_DEPARTURE_DIED]);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_reuses_ids_with_a_new_generation(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct char_data third;
+  struct char_data fourth;
+  struct encounter_test_trace trace;
+  struct event_debug_snapshot first_snapshot;
+  struct event_debug_snapshot second_snapshot;
+  size_t returned_count;
+  unsigned long saved_pulse;
+
+  encounter_test_character(&first, "first generation actor");
+  encounter_test_character(&second, "first generation target");
+  encounter_test_character(&third, "second generation actor");
+  encounter_test_character(&fourth, "second generation target");
+  saved_pulse = encounter_test_begin(tc, true, 5000U, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertIntEquals(tc, 1,
+                    (int)event_debug_inspect(NULL, &first_snapshot, 1U, &returned_count));
+  CuAssertIntEquals(tc, 1, (int)returned_count);
+  CuAssertIntEquals(tc, GAME_EVENT_OWNER_ENCOUNTER, first_snapshot.owner.kind);
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  CuAssertIntEquals(tc, 0, event_queue_depth());
+
+  FIGHTING(&third) = &fourth;
+  CuAssertTrue(tc, combat_encounter_join(&third, &fourth, 1 RL_SEC));
+  CuAssertIntEquals(tc, 1,
+                    (int)event_debug_inspect(NULL, &second_snapshot, 1U, &returned_count));
+  CuAssertIntEquals(tc, 1, (int)returned_count);
+  CuAssertIntEquals(tc, GAME_EVENT_OWNER_ENCOUNTER, second_snapshot.owner.kind);
+  CuAssertTrue(tc, first_snapshot.owner.runtime_id == second_snapshot.owner.runtime_id);
+  CuAssertTrue(tc, first_snapshot.owner.generation != second_snapshot.owner.generation);
+
+  encounter_test_leave(&third, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&fourth, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_terminal_session_is_not_revived_from_callback(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data passive;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 5500U;
+
+  encounter_test_character(&first, "terminal encounter actor");
+  encounter_test_character(&passive, "terminal encounter target");
+  saved_pulse = encounter_test_begin(tc, true, start_pulse, &trace);
+  trace.mutation_trigger = &first;
+  trace.mutation_character = &first;
+  trace.mutation_opponent = &passive;
+  trace.mutation_reason = COMBAT_ENCOUNTER_DEPARTURE_STOPPED;
+  trace.vanish_during_callback = true;
+  trace.leave_only_mutation_character = true;
+  trace.rejoin_after_vanish = true;
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &passive;
+  CuAssertTrue(tc, combat_encounter_join(&first, &passive, 1 RL_SEC));
+
+  pulse = start_pulse + (1 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, trace.mutation_succeeded);
+  CuAssertPtrNotNull(tc, first.combat_encounter);
+  CuAssertPtrEquals(tc, first.combat_encounter, passive.combat_encounter);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 1, (int)stats.active_encounters);
+  CuAssertIntEquals(tc, 2, (int)stats.active_participants);
+  CuAssertIntEquals(tc, 1, (int)stats.scheduled_events);
+  CuAssertIntEquals(tc, 2, (int)stats.encounters_created);
+  CuAssertIntEquals(tc, 1, (int)stats.encounters_ended);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&passive, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_tracks_departures_and_cancels_once(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  enum combat_encounter_departure_reason reason;
+  unsigned long saved_pulse;
+
+  encounter_test_character(&first, "departure actor");
+  encounter_test_character(&second, "departure target");
+  saved_pulse = encounter_test_begin(tc, true, 6000U, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+
+  for (reason = COMBAT_ENCOUNTER_DEPARTURE_STOPPED;
+       reason < COMBAT_ENCOUNTER_DEPARTURE_COUNT; reason++)
+  {
+    FIGHTING(&first) = &second;
+    FIGHTING(&second) = &first;
+    CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+    CuAssertTrue(tc, combat_encounter_join(&second, &first, 1 RL_SEC));
+    CuAssertIntEquals(tc, 1, event_queue_depth());
+    encounter_test_leave(&first, reason);
+    encounter_test_leave(&second, reason);
+    CuAssertIntEquals(tc, 0, event_queue_depth());
+  }
+  combat_encounter_get_stats(&stats);
+  for (reason = COMBAT_ENCOUNTER_DEPARTURE_STOPPED;
+       reason < COMBAT_ENCOUNTER_DEPARTURE_COUNT; reason++)
+    CuAssertIntEquals(tc, 2, (int)stats.departure_counts[reason]);
+  CuAssertIntEquals(tc, COMBAT_ENCOUNTER_DEPARTURE_COUNT,
+                    (int)stats.encounters_created);
+  CuAssertIntEquals(tc, COMBAT_ENCOUNTER_DEPARTURE_COUNT,
+                    (int)stats.encounters_ended);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_encounter_rollback_selector_keeps_legacy_path_exclusive(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+
+  encounter_test_character(&first, "legacy actor");
+  encounter_test_character(&second, "legacy target");
+  saved_pulse = encounter_test_begin(tc, false, 7000U, NULL);
+  FIGHTING(&first) = &second;
+
+  CuAssertTrue(tc, !combat_encounter_events_enabled());
+  CuAssertTrue(tc, !combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertPtrEquals(tc, NULL, first.combat_encounter);
+  CuAssertPtrEquals(tc, NULL, second.combat_encounter);
+  CuAssertIntEquals(tc, 0, event_queue_depth());
+  combat_encounter_get_stats(&stats);
+  CuAssertTrue(tc, !stats.encounter_mode);
+  CuAssertIntEquals(tc, 0, (int)stats.active_encounters);
+  encounter_test_end(saved_pulse);
+}

--- a/unittests/CuTest/test_combat_encounters.c
+++ b/unittests/CuTest/test_combat_encounters.c
@@ -5,9 +5,14 @@
 #include "../../src/structs.h"
 #include "../../src/comm.h"
 #include "../../src/db.h"
+#include "../../src/act.h"
+#include "../../src/actions.h"
+#include "../../src/actionqueues.h"
+#include "../../src/interpreter.h"
 #include "../../src/combat/combat_encounters.h"
 #include "../../src/combat/fight.h"
 #include "../../src/dgscript/dg_event.h"
+#include "../../src/domain_event_world.h"
 
 #include <string.h>
 
@@ -26,8 +31,17 @@ struct encounter_test_trace
   bool vanish_during_callback;
   bool leave_only_mutation_character;
   bool rejoin_after_vanish;
+  bool execute_queue;
   bool mutation_ran;
   bool mutation_succeeded;
+};
+
+struct semantic_boundary_trace
+{
+  struct char_data *first;
+  struct char_data *second;
+  bool second_flag_survived;
+  bool second_reaction_remained_spent;
 };
 
 static void encounter_test_character(struct char_data *character, const char *name)
@@ -36,9 +50,10 @@ static void encounter_test_character(struct char_data *character, const char *na
   character->player.name = (char *)name;
 }
 
-static unsigned long encounter_test_begin(CuTest *tc, bool encounter_mode,
-                                          unsigned long start_pulse,
-                                          struct encounter_test_trace *trace)
+static unsigned long encounter_test_begin_mode(CuTest *tc, bool encounter_mode,
+                                               bool semantic_rounds,
+                                               unsigned long start_pulse,
+                                               struct encounter_test_trace *trace)
 {
   unsigned long saved_pulse = pulse;
 
@@ -48,6 +63,7 @@ static unsigned long encounter_test_begin(CuTest *tc, bool encounter_mode,
   pulse = start_pulse;
   event_init();
   combat_encounter_test_select(encounter_mode);
+  combat_encounter_test_select_semantic(semantic_rounds);
   CuAssertIntEquals(tc, DOMAIN_EVENT_OK, combat_encounter_runtime_init(NULL));
   if (trace != NULL)
   {
@@ -55,6 +71,19 @@ static unsigned long encounter_test_begin(CuTest *tc, bool encounter_mode,
     combat_encounter_test_set_phase_callback(NULL, NULL);
   }
   return saved_pulse;
+}
+
+static unsigned long encounter_test_begin(CuTest *tc, bool encounter_mode,
+                                          unsigned long start_pulse,
+                                          struct encounter_test_trace *trace)
+{
+  return encounter_test_begin_mode(tc, encounter_mode, false, start_pulse, trace);
+}
+
+static unsigned long encounter_test_begin_semantic(CuTest *tc, unsigned long start_pulse,
+                                                   struct encounter_test_trace *trace)
+{
+  return encounter_test_begin_mode(tc, true, true, start_pulse, trace);
 }
 
 static void encounter_test_end(unsigned long saved_pulse)
@@ -75,6 +104,8 @@ static bool encounter_test_record_phase(struct char_data *character,
     trace->phases[trace->count] = phase;
     trace->count++;
   }
+  if (trace->execute_queue)
+    execute_next_action(character);
   if (trace->mutation_ran || character != trace->mutation_trigger)
     return true;
   trace->mutation_ran = true;
@@ -102,11 +133,46 @@ static bool encounter_test_record_phase(struct char_data *character,
   return true;
 }
 
+static bool encounter_test_round_boundary_state(struct char_data *character,
+                                                unsigned int phase, void *context)
+{
+  struct semantic_boundary_trace *trace = context;
+  bool managed;
+  bool used;
+
+  (void)phase;
+  if (character == trace->first)
+  {
+    combat_encounter_round_flag_mark(
+        trace->second, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED);
+    combat_encounter_reaction_try_use(trace->second, 1U, &managed);
+  }
+  else if (character == trace->second)
+  {
+    combat_encounter_round_flag_query(
+        trace->second, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED, &used);
+    trace->second_flag_survived = used;
+    trace->second_reaction_remained_spent =
+        !combat_encounter_reaction_try_use(trace->second, 1U, &managed) && managed;
+  }
+  return true;
+}
+
 static void encounter_test_leave(struct char_data *character,
                                  enum combat_encounter_departure_reason reason)
 {
   FIGHTING(character) = NULL;
   combat_encounter_leave(character, reason);
+}
+
+static void encounter_test_enqueue(struct char_data *character, const char *command)
+{
+  struct action_data *action;
+
+  action = calloc(1U, sizeof(*action));
+  action->argument = strdup(command);
+  action->actions_required = ACTION_NONE;
+  enqueue_action(GET_QUEUE(character), action);
 }
 
 void Test_combat_encounter_uses_one_event_and_preserves_compatibility_cadence(CuTest *tc)
@@ -462,5 +528,498 @@ void Test_combat_encounter_rollback_selector_keeps_legacy_path_exclusive(CuTest 
   combat_encounter_get_stats(&stats);
   CuAssertTrue(tc, !stats.encounter_mode);
   CuAssertIntEquals(tc, 0, (int)stats.active_encounters);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_batches_due_turns_in_initiative_order(CuTest *tc)
+{
+  struct char_data slower;
+  struct char_data faster;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 8000U;
+
+  encounter_test_character(&slower, "slower combatant");
+  encounter_test_character(&faster, "faster combatant");
+  GET_INITIATIVE(&slower) = 10;
+  GET_INITIATIVE(&faster) = 20;
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&slower) = &faster;
+  FIGHTING(&faster) = &slower;
+
+  CuAssertTrue(tc, combat_encounter_join(&slower, &faster, 2 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&faster, &slower, 4 RL_SEC));
+  pulse = start_pulse + (5 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 0, (int)trace.count);
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 2, (int)trace.count);
+  CuAssertPtrEquals(tc, &faster, trace.characters[0]);
+  CuAssertPtrEquals(tc, &slower, trace.characters[1]);
+  CuAssertIntEquals(tc, 0, (int)trace.phases[0]);
+  CuAssertIntEquals(tc, 0, (int)trace.phases[1]);
+  combat_encounter_get_stats(&stats);
+  CuAssertTrue(tc, stats.semantic_rounds);
+  CuAssertIntEquals(tc, 1, (int)stats.semantic_rounds_resolved);
+  CuAssertIntEquals(tc, 2, (int)stats.semantic_turns_resolved);
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  encounter_test_leave(&slower, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&faster, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_starts_six_seconds_after_idle_join(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 8500U;
+  const unsigned long joined_pulse = start_pulse + (3 RL_SEC);
+
+  encounter_test_character(&first, "idle join combatant");
+  encounter_test_character(&second, "idle join target");
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  pulse = joined_pulse;
+  FIGHTING(&first) = &second;
+  FIGHTING(&second) = &first;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second, &first, 1 RL_SEC));
+
+  pulse = joined_pulse + (5 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 0, (int)trace.count);
+  pulse = joined_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 2, (int)trace.count);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 1, (int)stats.semantic_rounds_resolved);
+  CuAssertIntEquals(tc, 2, (int)stats.semantic_turns_resolved);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_uses_dexterity_and_runtime_id_tiebreaks(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct char_data third;
+  struct char_data *lower_runtime_id;
+  struct char_data *higher_runtime_id;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 9000U;
+
+  encounter_test_character(&first, "first tied combatant");
+  encounter_test_character(&second, "dexterous tied combatant");
+  encounter_test_character(&third, "third tied combatant");
+  GET_INITIATIVE(&first) = GET_INITIATIVE(&second) = GET_INITIATIVE(&third) = 15;
+  GET_REAL_DEX(&first) = 10;
+  GET_REAL_DEX(&second) = 16;
+  GET_REAL_DEX(&third) = 10;
+  first.aff_abils.dex = GET_REAL_DEX(&first);
+  second.aff_abils.dex = GET_REAL_DEX(&second);
+  third.aff_abils.dex = GET_REAL_DEX(&third);
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  FIGHTING(&second) = &first;
+  FIGHTING(&third) = &first;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second, &first, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&third, &first, 1 RL_SEC));
+  if (domain_event_character_handle(&first).runtime_id <
+      domain_event_character_handle(&third).runtime_id)
+  {
+    lower_runtime_id = &first;
+    higher_runtime_id = &third;
+  }
+  else
+  {
+    lower_runtime_id = &third;
+    higher_runtime_id = &first;
+  }
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 3, (int)trace.count);
+  CuAssertPtrEquals(tc, &second, trace.characters[0]);
+  CuAssertPtrEquals(tc, lower_runtime_id, trace.characters[1]);
+  CuAssertPtrEquals(tc, higher_runtime_id, trace.characters[2]);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&third, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_owns_action_and_reaction_budgets(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  bool available;
+  bool managed;
+  const unsigned long start_pulse = 10000U;
+
+  encounter_test_character(&first, "budget combatant");
+  encounter_test_character(&second, "budget target");
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atSTANDARD, &available));
+  CuAssertTrue(tc, available);
+  CuAssertTrue(tc, combat_encounter_action_consume(&first, atSTANDARD, 6 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_action_consume(&first, atMOVE, 12 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atSTANDARD, &available));
+  CuAssertTrue(tc, !available);
+  CuAssertTrue(tc, combat_encounter_reaction_refund(&first));
+  CuAssertIntEquals(tc, -1, first.char_specials.attacks_of_opportunity);
+  CuAssertTrue(tc, combat_encounter_reaction_try_use(&first, 0U, &managed));
+  CuAssertIntEquals(tc, 0, first.char_specials.attacks_of_opportunity);
+  CuAssertTrue(tc, combat_encounter_reaction_try_use(&first, 2U, &managed));
+  CuAssertTrue(tc, managed);
+  CuAssertTrue(tc, combat_encounter_reaction_try_use(&first, 2U, &managed));
+  CuAssertTrue(tc, !combat_encounter_reaction_try_use(&first, 2U, &managed));
+  CuAssertTrue(tc, combat_encounter_reaction_refund(&first));
+  CuAssertTrue(tc, combat_encounter_reaction_try_use(&first, 2U, &managed));
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atSTANDARD, &available));
+  CuAssertTrue(tc, available);
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atMOVE, &available));
+  CuAssertTrue(tc, !available);
+  CuAssertTrue(tc, combat_encounter_reaction_try_use(&first, 2U, &managed));
+
+  pulse = start_pulse + (12 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atMOVE, &available));
+  CuAssertTrue(tc, available);
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 2, (int)stats.action_budgets_spent);
+  CuAssertIntEquals(tc, 5, (int)stats.reactions_spent);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_resets_shared_state_before_initiative(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct semantic_boundary_trace trace = {0};
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 10500U;
+
+  encounter_test_character(&first, "higher initiative combatant");
+  encounter_test_character(&second, "lower initiative combatant");
+  GET_INITIATIVE(&first) = 20;
+  GET_INITIATIVE(&second) = 10;
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, NULL);
+  trace.first = &first;
+  trace.second = &second;
+  combat_encounter_test_set_phase_callback(encounter_test_round_boundary_state, &trace);
+  FIGHTING(&first) = &second;
+  FIGHTING(&second) = &first;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second, &first, 1 RL_SEC));
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, trace.second_flag_survived);
+  CuAssertTrue(tc, trace.second_reaction_remained_spent);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_resets_participant_round_flags(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  bool used;
+  const unsigned long start_pulse = 11000U;
+
+  encounter_test_character(&first, "flag combatant");
+  encounter_test_character(&second, "flag target");
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_round_flag_mark(
+                       &first, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED));
+  CuAssertTrue(tc, combat_encounter_round_flag_query(
+                       &first, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED, &used));
+  CuAssertTrue(tc, used);
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, combat_encounter_round_flag_query(
+                       &first, COMBAT_ENCOUNTER_ROUND_DEFLECTIVE_SCREEN_USED, &used));
+  CuAssertTrue(tc, !used);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_staggered_spend_couples_standard_and_move(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  bool available;
+
+  encounter_test_character(&first, "staggered combatant");
+  encounter_test_character(&second, "staggered target");
+  SET_BIT_AR(AFF_FLAGS(&first), AFF_STAGGERED);
+  saved_pulse = encounter_test_begin_semantic(tc, 11500U, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+
+  start_action_cooldown(&first, atSTANDARD, 6 RL_SEC);
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atSTANDARD, &available));
+  CuAssertTrue(tc, !available);
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atMOVE, &available));
+  CuAssertTrue(tc, !available);
+  pulse = 11500U + (6 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atSTANDARD, &available));
+  CuAssertTrue(tc, available);
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atMOVE, &available));
+  CuAssertTrue(tc, available);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_defers_callback_joins_to_next_round(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data anchor;
+  struct char_data joiner;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  size_t index;
+  bool saw_joiner = false;
+  const unsigned long start_pulse = 12000U;
+
+  encounter_test_character(&first, "semantic actor");
+  encounter_test_character(&anchor, "semantic anchor");
+  encounter_test_character(&joiner, "semantic joiner");
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  trace.mutation_trigger = &first;
+  trace.mutation_character = &joiner;
+  trace.mutation_opponent = &anchor;
+  trace.join_during_callback = true;
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &anchor;
+  CuAssertTrue(tc, combat_encounter_join(&first, &anchor, 1 RL_SEC));
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertTrue(tc, trace.mutation_succeeded);
+  CuAssertIntEquals(tc, 1, (int)trace.count);
+  pulse = start_pulse + (11 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 1, (int)trace.count);
+  pulse = start_pulse + (12 RL_SEC);
+  event_process();
+  for (index = 0U; index < trace.count; index++)
+    if (trace.characters[index] == &joiner)
+      saw_joiner = true;
+  CuAssertTrue(tc, saw_joiner);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&anchor, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&joiner, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_transfers_action_cooldown_across_combat(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  struct mud_event_data *restored;
+  unsigned long saved_pulse;
+  bool available;
+
+  encounter_test_character(&first, "cooldown combatant");
+  encounter_test_character(&second, "cooldown target");
+  saved_pulse = encounter_test_begin_semantic(tc, 13000U, &trace);
+  start_action_cooldown(&first, atSTANDARD, 12 RL_SEC);
+  CuAssertPtrNotNull(tc, char_has_mud_event(&first, eSTANDARDACTION));
+  FIGHTING(&first) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertPtrEquals(tc, NULL, char_has_mud_event(&first, eSTANDARDACTION));
+  CuAssertTrue(tc, combat_encounter_action_query(&first, atSTANDARD, &available));
+  CuAssertTrue(tc, !available);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  restored = char_has_mud_event(&first, eSTANDARDACTION);
+  CuAssertPtrNotNull(tc, restored);
+  CuAssertTrue(tc, event_time(restored->pEvent) >= 12 RL_SEC);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_join_uses_next_shared_round(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data anchor;
+  struct char_data joiner;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  const unsigned long start_pulse = 14000U;
+
+  encounter_test_character(&first, "first combatant");
+  encounter_test_character(&anchor, "combat anchor");
+  encounter_test_character(&joiner, "mid-round joiner");
+  GET_INITIATIVE(&first) = 10;
+  GET_INITIATIVE(&joiner) = 20;
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &anchor;
+  CuAssertTrue(tc, combat_encounter_join(&first, &anchor, 1 RL_SEC));
+
+  pulse = start_pulse + (3 RL_SEC);
+  FIGHTING(&joiner) = &anchor;
+  CuAssertTrue(tc, combat_encounter_join(&joiner, &anchor, 1 RL_SEC));
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+
+  CuAssertIntEquals(tc, 2, (int)trace.count);
+  CuAssertPtrEquals(tc, &joiner, trace.characters[0]);
+  CuAssertPtrEquals(tc, &first, trace.characters[1]);
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&anchor, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&joiner, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_merge_coalesces_offset_clocks(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data first_anchor;
+  struct char_data second;
+  struct char_data second_anchor;
+  struct encounter_test_trace trace;
+  unsigned long saved_pulse;
+  size_t count_after_first_round;
+  const unsigned long start_pulse = 15000U;
+
+  encounter_test_character(&first, "first clock combatant");
+  encounter_test_character(&first_anchor, "first clock anchor");
+  encounter_test_character(&second, "second clock combatant");
+  encounter_test_character(&second_anchor, "second clock anchor");
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &first_anchor;
+  FIGHTING(&first_anchor) = &first;
+  CuAssertTrue(tc, combat_encounter_join(&first, &first_anchor, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&first_anchor, &first, 1 RL_SEC));
+
+  pulse = start_pulse + (2 RL_SEC);
+  FIGHTING(&second) = &second_anchor;
+  FIGHTING(&second_anchor) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&second, &second_anchor, 1 RL_SEC));
+  CuAssertTrue(tc, combat_encounter_join(&second_anchor, &second, 1 RL_SEC));
+  CuAssertIntEquals(tc, 2, event_queue_depth());
+
+  pulse = start_pulse + (3 RL_SEC);
+  FIGHTING(&first) = &second;
+  FIGHTING(&second) = &first;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  count_after_first_round = trace.count;
+  CuAssertIntEquals(tc, 2, (int)count_after_first_round);
+  pulse = start_pulse + (8 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, (int)count_after_first_round, (int)trace.count);
+  pulse = start_pulse + (12 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 6, (int)trace.count);
+  CuAssertIntEquals(tc, 1, event_queue_depth());
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&first_anchor, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second_anchor, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_end(saved_pulse);
+}
+
+void Test_combat_semantic_round_dispatches_one_buffered_intent(CuTest *tc)
+{
+  struct char_data first;
+  struct char_data second;
+  struct encounter_test_trace trace;
+  struct combat_encounter_stats stats;
+  unsigned long saved_pulse;
+  bool created_command_list = false;
+  const unsigned long start_pulse = 16000U;
+
+  encounter_test_character(&first, "intent combatant");
+  encounter_test_character(&second, "intent target");
+  if (complete_cmd_info == NULL)
+  {
+    create_command_list();
+    created_command_list = true;
+  }
+  GET_QUEUE(&first) = create_action_queue();
+  saved_pulse = encounter_test_begin_semantic(tc, start_pulse, &trace);
+  trace.execute_queue = true;
+  combat_encounter_test_set_phase_callback(encounter_test_record_phase, &trace);
+  FIGHTING(&first) = &second;
+  CuAssertTrue(tc, combat_encounter_join(&first, &second, 1 RL_SEC));
+  encounter_test_enqueue(&first, "not-a-real-command one");
+  encounter_test_enqueue(&first, "not-a-real-command two");
+
+  execute_next_action(&first);
+  CuAssertIntEquals(tc, 2, pending_actions(&first));
+  pulse = start_pulse + (6 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 1, pending_actions(&first));
+  execute_next_action(&first);
+  CuAssertIntEquals(tc, 1, pending_actions(&first));
+  pulse = start_pulse + (12 RL_SEC);
+  event_process();
+  CuAssertIntEquals(tc, 0, pending_actions(&first));
+  combat_encounter_get_stats(&stats);
+  CuAssertIntEquals(tc, 2, (int)stats.intents_dispatched);
+  CuAssertIntEquals(tc, 2, (int)stats.intent_dispatch_blocks);
+
+  encounter_test_leave(&first, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  encounter_test_leave(&second, COMBAT_ENCOUNTER_DEPARTURE_STOPPED);
+  free_action_queue(GET_QUEUE(&first));
+  GET_QUEUE(&first) = NULL;
+  if (created_command_list)
+    free_command_list();
   encounter_test_end(saved_pulse);
 }

--- a/unittests/CuTest/test_domain_events.c
+++ b/unittests/CuTest/test_domain_events.c
@@ -579,12 +579,12 @@ void TestDomainEventProductionRuntimeLifecycle(CuTest *tc)
   struct domain_event_bus_stats stats;
   struct char_data victim;
   struct char_data *saved_character_list;
+  int death_status;
 
   saved_character_list = character_list;
   clear_char(&victim);
   victim.player.name = "domain event death victim";
   victim.next = NULL;
-  character_list = &victim;
   domain_event_runtime_shutdown();
   active_world_reset_for_test();
   active_world_select_for_test(true);
@@ -594,8 +594,10 @@ void TestDomainEventProductionRuntimeLifecycle(CuTest *tc)
   CuAssertIntEquals(tc, 9, (int)stats.registered_type_count);
   CuAssertIntEquals(tc, 8, (int)stats.registered_handler_count);
   CuAssertTrue(tc, stats.sealed);
-  CuAssertIntEquals(tc, DOMAIN_EVENT_OK,
-                    domain_event_runtime_character_died(&victim, NULL));
+  character_list = &victim;
+  death_status = domain_event_runtime_character_died(&victim, NULL);
+  character_list = saved_character_list;
+  CuAssertIntEquals(tc, DOMAIN_EVENT_OK, death_status);
   domain_event_bus_get_stats(domain_event_runtime_bus(), &stats);
   CuAssertIntEquals(tc, 1, (int)stats.publications);
   CuAssertIntEquals(tc, DOMAIN_EVENT_BUSY, domain_event_runtime_init());
@@ -603,7 +605,6 @@ void TestDomainEventProductionRuntimeLifecycle(CuTest *tc)
   CuAssertPtrEquals(tc, NULL, domain_event_runtime_bus());
   CuAssertIntEquals(tc, DOMAIN_EVENT_OK, domain_event_runtime_shutdown());
   active_world_reset_for_test();
-  character_list = saved_character_list;
 }
 
 static void active_world_prepare_character(struct char_data *ch, bool npc, room_rnum room)

--- a/unittests/CuTest/test_domain_events.c
+++ b/unittests/CuTest/test_domain_events.c
@@ -536,7 +536,14 @@ void TestDomainEventPayloadIsBorrowedAndUnchanged(CuTest *tc)
 void TestDomainEventProductionRuntimeLifecycle(CuTest *tc)
 {
   struct domain_event_bus_stats stats;
+  struct char_data victim;
+  struct char_data *saved_character_list;
 
+  saved_character_list = character_list;
+  clear_char(&victim);
+  victim.player.name = "domain event death victim";
+  victim.next = NULL;
+  character_list = &victim;
   domain_event_runtime_shutdown();
   active_world_reset_for_test();
   active_world_select_for_test(true);
@@ -544,13 +551,18 @@ void TestDomainEventProductionRuntimeLifecycle(CuTest *tc)
   CuAssertPtrNotNull(tc, domain_event_runtime_bus());
   domain_event_bus_get_stats(domain_event_runtime_bus(), &stats);
   CuAssertIntEquals(tc, 9, (int)stats.registered_type_count);
-  CuAssertIntEquals(tc, 5, (int)stats.registered_handler_count);
+  CuAssertIntEquals(tc, 8, (int)stats.registered_handler_count);
   CuAssertTrue(tc, stats.sealed);
+  CuAssertIntEquals(tc, DOMAIN_EVENT_OK,
+                    domain_event_runtime_character_died(&victim, NULL));
+  domain_event_bus_get_stats(domain_event_runtime_bus(), &stats);
+  CuAssertIntEquals(tc, 1, (int)stats.publications);
   CuAssertIntEquals(tc, DOMAIN_EVENT_BUSY, domain_event_runtime_init());
   CuAssertIntEquals(tc, DOMAIN_EVENT_OK, domain_event_runtime_shutdown());
   CuAssertPtrEquals(tc, NULL, domain_event_runtime_bus());
   CuAssertIntEquals(tc, DOMAIN_EVENT_OK, domain_event_runtime_shutdown());
   active_world_reset_for_test();
+  character_list = saved_character_list;
 }
 
 static void active_world_prepare_character(struct char_data *ch, bool npc, room_rnum room)

--- a/unittests/CuTest/test_gameplay_e2e.c
+++ b/unittests/CuTest/test_gameplay_e2e.c
@@ -602,7 +602,8 @@ void Test_gameplay_e2e_staff_all_feats_melee_rotation_executes(CuTest *tc)
   struct gameplay_fixture fixture;
   struct char_data *staff;
   int expected_attacks;
-  int attempted_attacks;
+  int compatibility_attempts;
+  int semantic_attempts;
   int remaining_hit_points;
   int i;
 
@@ -655,11 +656,15 @@ void Test_gameplay_e2e_staff_all_feats_melee_rotation_executes(CuTest *tc)
   SET_BIT_AR(PRF_FLAGS(staff), PRF_CONDENSED);
   init_condensed_combat_data(staff);
 #define NORMAL_ATTACK_ROUTINE 0
+  perform_attacks(staff, NORMAL_ATTACK_ROUTINE, 0);
+  semantic_attempts = CNDNSD(staff)->num_times_attacking;
+  init_condensed_combat_data(staff);
+  GET_HIT(&fixture.victim) = 100000;
   perform_attacks(staff, NORMAL_ATTACK_ROUTINE, 1);
   perform_attacks(staff, NORMAL_ATTACK_ROUTINE, 2);
   perform_attacks(staff, NORMAL_ATTACK_ROUTINE, 3);
 #undef NORMAL_ATTACK_ROUTINE
-  attempted_attacks = CNDNSD(staff)->num_times_attacking;
+  compatibility_attempts = CNDNSD(staff)->num_times_attacking;
   remaining_hit_points = GET_HIT(&fixture.victim);
 
   FIGHTING(staff) = NULL;
@@ -672,7 +677,8 @@ void Test_gameplay_e2e_staff_all_feats_melee_rotation_executes(CuTest *tc)
   end_gameplay_fixture(&fixture);
 
   CuAssertTrue(tc, expected_attacks > 0);
-  CuAssertIntEquals(tc, expected_attacks, attempted_attacks);
+  CuAssertIntEquals(tc, expected_attacks, semantic_attempts);
+  CuAssertIntEquals(tc, expected_attacks, compatibility_attempts);
   CuAssertTrue(tc, remaining_hit_points < 100000);
 }
 

--- a/unittests/CuTest/test_legacy_event_adapter.c
+++ b/unittests/CuTest/test_legacy_event_adapter.c
@@ -203,6 +203,37 @@ void Test_legacy_event_backends_produce_identical_order_and_recurrence(CuTest *t
   pulse = saved_pulse;
 }
 
+void Test_legacy_event_scheduler_uses_live_pulse_after_idle(CuTest *tc)
+{
+  struct event_trace trace;
+  struct event_trace_payload *payload;
+  struct event *event;
+  unsigned long saved_pulse;
+
+  saved_pulse = pulse;
+  memset(&trace, 0, sizeof(trace));
+  begin_backend_test(tc, EVENT_BACKEND_GAME_SCHEDULER, 100U);
+  pulse = 500U;
+  payload = new_trace_payload(&trace, 'A', 1, 0);
+  CuAssertPtrNotNull(tc, payload);
+  event = event_create_named(event_trace_callback, payload, 6, "live-pulse-deadline");
+  CuAssertPtrNotNull(tc, event);
+  CuAssertIntEquals(tc, 6, (int)event_time(event));
+
+  pulse = 505U;
+  event_process();
+  CuAssertIntEquals(tc, 0, trace.count);
+  CuAssertIntEquals(tc, 1, (int)event_time(event));
+  pulse = 506U;
+  event_process();
+  CuAssertIntEquals(tc, 1, trace.count);
+  CuAssertTrue(tc, trace.pulses[0] == 506U);
+  CuAssertIntEquals(tc, 0, event_queue_depth());
+
+  event_free_all();
+  pulse = saved_pulse;
+}
+
 static void verify_external_cancel(CuTest *tc, enum event_backend_kind backend)
 {
   struct event *event;

--- a/unittests/CuTest/test_spec_command_pulse.c
+++ b/unittests/CuTest/test_spec_command_pulse.c
@@ -1257,6 +1257,34 @@ void Test_spec_iedit_owns_and_transfers_special_abilities(CuTest *tc)
   free(oasis_source);
 }
 
+void Test_spec_compatibility_combat_phase_defaults_and_rotates_safely(CuTest *tc)
+{
+  char *source = NULL;
+  char *callback;
+  char *callback_end;
+  char *default_phase;
+  char *parse_phase;
+  char *bounded_write;
+  char *replace_phase;
+
+  CuAssertTrue(tc, spec_pulse_read_source("src/combat/fight.c", &source));
+  callback = strstr(source, "EVENTFUNC(event_combat_round)");
+  callback_end = callback != NULL ? strstr(callback, "void handle_cleave(") : NULL;
+  default_phase = spec_pulse_find_in_region(callback, callback_end, "phase = 1U;");
+  parse_phase = spec_pulse_find_in_region(callback, callback_end, "strtoul(");
+  bounded_write = spec_pulse_find_in_region(
+      callback, callback_end, "snprintf(next_phase_text, sizeof(next_phase_text)");
+  replace_phase = spec_pulse_find_in_region(
+      callback, callback_end, "pMudEvent->sVariables = strdup(next_phase_text);");
+
+  CuAssertTrue(tc, callback != NULL && callback_end != NULL && default_phase != NULL &&
+                       parse_phase != NULL && bounded_write != NULL && replace_phase != NULL &&
+                       default_phase < parse_phase && parse_phase < bounded_write &&
+                       bounded_write < replace_phase &&
+                       spec_pulse_find_in_region(callback, callback_end, "sprintf(") == NULL);
+  free(source);
+}
+
 void Test_spec_character_periodic_control_transfers_resync_owners(CuTest *tc)
 {
   const char *paths[] = {"src/act.wizard.c", "src/magic/spells.c", "src/character/evolutions.c"};


### PR DESCRIPTION
Stack 07 of 14 for the event-driven core refactor.

Scope:
- Schedule combat by encounter.
- Implement semantic combat rounds.
- Add production-linked combat validation.

Depends on stack 06.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced encounter-based combat with shared six-second rounds, initiative ordering, action and reaction budgets, queued commands, and automatic attacks.
  * Added encounter lifecycle handling for joins, merges, departures, movement, and character death.
  * Added combat diagnostics and rollback support for compatibility with legacy combat timing.

* **Bug Fixes**
  * Prevented queued actions from executing when unavailable and enforced the queue’s maximum capacity.

* **Documentation**
  * Updated combat help, system documentation, changelog entries, and validation records.

* **Tests**
  * Added comprehensive encounter, scheduler, lifecycle, semantic-round, and compatibility regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->