### PR TITLE
Fix tracked golem fixture positions and close issue 133 leads

### DIFF
--- a/docs/testing/ISSUE_133_WORLD_FIXTURE_LEADS.md
+++ b/docs/testing/ISSUE_133_WORLD_FIXTURE_LEADS.md
@@ -1,0 +1,88 @@
+# Issue 133 world-fixture lead dispositions
+
+Historical event-core baseline and wakeup notes recorded four development-content
+leads. They are not production defects. This note records the current package,
+revision, and `wtool` result for each item. No replacement rooms, mobiles,
+objects, or triggers were manufactured to silence the historical text.
+
+Base inventory: `origin/master` `14dbdb969`. Tracked fixture correction is in
+this change. Validator of record: `python3 scripts/world/wtool.py`. Protected
+headers were not edited. Issue #123 is out of scope.
+
+Tracked supported packages are `lib/world/minimal` and `lib/world/artifacts`.
+Those bundles are flat directories (`index.mob` beside the data files), so
+validation uses the same entry point as the world-tool graph test:
+
+```sh
+python3 scripts/world/wtool.py validate --paths lib/world/minimal
+python3 scripts/world/wtool.py validate --paths lib/world/artifacts
+```
+
+`wtool show` with `--world-root lib/world/minimal` looks for `mob/index`, not
+this flat layout, and is not used as the gate for these bundles.
+
+Local OLC under `lib/world/{mob,obj,wld,zon,trg,...}` is gitignored and is not
+part of this change.
+
+## 16500-range wakeup golem
+
+- Package: tracked `lib/world/minimal/16.mob` (indexed by `index.mob`).
+- Absent from `lib/world/artifacts`. Local development `lib/world/mob/165.mob`
+  starts at animal prototypes `16501+` and has no mobile `16500`; that live
+  range was not overwritten.
+- Before this change, current and default position values included out-of-range
+  `10` and `POS_FIGHTING` (`8`). The wakeup visibility test had to `force golem
+  stand`, which took the "stops floating around" default path.
+- Intermediate `$` terminators after each record meant the parser and C boot
+  loaded only `16500`. Those extra terminators were removed so `16501`-`16511`
+  remain loadable records in the same file. One `$` remains at end of file.
+- After this change every remaining `16500`-`16511` record uses `POS_STANDING`
+  for current and default position (`9 9 1`).
+- Validator: `validate --paths lib/world/minimal` reports no `MOB016` error.
+  Direct `parse_mobile_file()` of `16.mob` loads vnums `16500`-`16511` with
+  in-range standing positions.
+
+## Zone 23 missing DG trigger references
+
+- Absent from tracked `lib/world/minimal` and `lib/world/artifacts`
+  (`show zone 23` is not found).
+- Present in gitignored local `lib/world/zon/23.zon` (package 23, "3.5E testing
+  zone"). Room attachments `T 2304`, `2305`, `2306`, `2307`, `2309`, and `2312`
+  exist in `lib/world/trg/23.trg`.
+- Validator: `wtool --world-root lib/world show/refs zone 23` and
+  `validate --zone 23` report no missing trigger references and no errors.
+  Remaining warnings (`SEM008`, `SEM009`, `REF025`) are unrelated to the named
+  lead and were left alone.
+- Disposition: closed as already repaired in local OLC; not in the supported
+  tracked packages.
+
+## Zone 1204 equipping object 120602
+
+- Absent from tracked supported packages.
+- Present in gitignored local `lib/world/obj/1204.obj` (object `120602`,
+  "obsidan broadsword") and `lib/world/zon/1204.zon` (`E` resets at lines 272
+  and 274).
+- Validator: `show`/`refs` find the object; incoming refs are the two `E`
+  resets. `validate --zone 1204` reports no missing-object references, no
+  `REF030` wear mismatch for `120602`, and no errors.
+- Disposition: closed as already repaired in local OLC; not in the supported
+  tracked packages.
+
+## Mobile 200103 SPEC flag without a procedure
+
+- Absent from tracked supported packages.
+- Present in gitignored local `lib/world/mob/2001.mob` as Brother Spire
+  (package 2001). Action flags `253962` decode to sentinel/ISNPC/immunities
+  and do not include `MOB_SPEC`. `spec_proc` is unset.
+- Validator: `show`/`refs` find the mobile. `validate --zone 2001` reports no
+  SPEC-without-procedure finding and no errors. One unrelated warning,
+  `SEM012`, notes the level-34 mobile is outside zone 2001's 1..30 band.
+- Disposition: closed as already repaired in local OLC (SPEC flag absent);
+  not in the supported tracked packages. No procedure was invented.
+
+## Boot-log corroboration
+
+No live `luminari` process was running during this inventory. Retained
+development `log/syslog*` and `log/errors` from 2026-09-05 through 2026-09-09
+contain no `MOB ERROR`, no `SPEC flag` complaints, and no `ZONE ERROR` lines
+for 23 / 1204 / 120602. Optional Ollama/I3 noise is ignored.

--- a/lib/world/minimal/16.mob
+++ b/lib/world/minimal/16.mob
@@ -11,10 +11,9 @@ its surface, glowing faintly with magical energy.
 103 0 0 0 0 0 0 0 0 E
 1 15 8 5d8+20 1d6+0
 50 50 1
-10 10 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16501
 wood golem medium~
 a medium wooden golem~
@@ -28,10 +27,9 @@ arcane markings run across its surface, glowing with magical energy.
 103 0 0 0 0 0 0 0 0 E
 1 20 10 8d10+50 1d8+0
 80 80 1
-15 15 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16502
 wood golem large~
 a large wooden golem~
@@ -46,10 +44,9 @@ glowing with magical energy that sustains its form.
 103 0 0 0 0 0 0 0 0 E
 1 25 12 12d10+100 1d10+2
 120 120 1
-20 20 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16503
 wood golem huge~
 a huge wooden golem~
@@ -64,10 +61,9 @@ cover its surface, glowing brilliantly with magical energy.
 103 0 0 0 0 0 0 0 0 E
 1 30 14 16d10+150 2d8+2
 160 160 1
-25 25 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16504
 stone golem small~
 a small stone golem~
@@ -81,10 +77,9 @@ glowing with mystical power that animates the stone construct.
 103 0 0 0 0 0 0 0 0 E
 1 25 6 6d8+30 1d4+0
 60 60 1
-8 8 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16505
 stone golem medium~
 a medium stone golem~
@@ -99,10 +94,9 @@ construct. It emanates an aura of solidity and permanence.
 103 0 0 0 0 0 0 0 0 E
 1 30 8 10d10+70 1d8+0
 100 100 1
-12 12 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16506
 stone golem large~
 a large stone golem~
@@ -117,10 +111,9 @@ with the magical power that sustains its form.
 103 0 0 0 0 0 0 0 0 E
 1 35 10 14d10+130 1d10+2
 150 150 1
-18 18 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16507
 stone golem huge~
 a huge stone golem~
@@ -135,10 +128,9 @@ glowing brilliantly with the powerful magic that animates this construct.
 103 0 0 0 0 0 0 0 0 E
 1 40 12 18d10+200 2d8+2
 200 200 1
-25 25 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16508
 iron golem small~
 a small iron golem~
@@ -153,10 +145,9 @@ animation that drives its movement.
 103 0 0 0 0 0 0 0 0 E
 1 35 5 7d8+40 1d6+0
 70 70 1
-8 8 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16509
 iron golem medium~
 a medium iron golem~
@@ -171,10 +162,9 @@ animation that drives its precise movements.
 103 0 0 0 0 0 0 0 0 E
 1 40 7 12d10+90 1d8+0
 120 120 1
-12 12 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16510
 iron golem large~
 a large iron golem~
@@ -189,10 +179,9 @@ Extensive arcane runes glow brilliantly across its surface.
 103 0 0 0 0 0 0 0 0 E
 1 45 9 16d10+160 1d10+2
 180 180 1
-18 18 1
+9 9 1
 BareHandAttack: 0
 E
-$
 #16511
 iron golem huge~
 a huge iron golem~
@@ -208,7 +197,7 @@ surface, glowing with tremendous power.
 103 0 0 0 0 0 0 0 0 E
 1 50 11 20d10+250 2d8+4
 250 250 1
-25 25 1
+9 9 1
 BareHandAttack: 0
 E
 $

--- a/scripts/world/tests/test_graph.py
+++ b/scripts/world/tests/test_graph.py
@@ -75,7 +75,7 @@ class FullGraphTests(unittest.TestCase):
     self.assertEqual(before, tree_hash(root))
 
   def test_tracked_real_bundles_have_stable_phase2_results_and_are_read_only(self) -> None:
-    expected_errors = {"artifacts": set(), "minimal": {"MOB016"}}
+    expected_errors = {"artifacts": set(), "minimal": set()}
     for name, expected in expected_errors.items():
       with self.subTest(bundle=name):
         root = self.repo_root / "lib/world" / name

--- a/scripts/world/tests/test_mobiles.py
+++ b/scripts/world/tests/test_mobiles.py
@@ -76,6 +76,30 @@ class MobileParserTests(unittest.TestCase):
     invalid = self.parse(mobile_record(enhanced="SpellRes: 101\n"))
     self.assertEqual(["MOB026"], [item.code for item in invalid.findings])
 
+  def test_tracked_minimal_golem_records_have_in_range_standing_positions(self) -> None:
+    path = self.repo_root / "lib/world/minimal/16.mob"
+    result = parse_mobile_file(path, "lib/world/minimal/16.mob", self.manifest, self.spec_names)
+    positions = self.manifest["tables"]["positions"]["entries"]
+    position_count = len(positions)
+    standing = next(entry["index"] for entry in positions if entry["macro"] == "POS_STANDING")
+    records = [record for record in result.records if 16500 <= record.vnum <= 16511]
+
+    self.assertTrue(path.is_file())
+    self.assertEqual(
+        [],
+        [item.code for item in result.findings if item.code in {"MOB016", "MOB017"}],
+    )
+    self.assertEqual(list(range(16500, 16512)), [record.vnum for record in records])
+    for record in records:
+      self.assertIsNotNone(record.position)
+      self.assertIsNotNone(record.default_position)
+      self.assertGreaterEqual(record.position, 0)
+      self.assertLess(record.position, position_count)
+      self.assertGreaterEqual(record.default_position, 0)
+      self.assertLess(record.default_position, position_count)
+      self.assertEqual(standing, record.position)
+      self.assertEqual(standing, record.default_position)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Fixes https://github.com/LuminariMUD/Luminari-Source/issues/133

Historical event-core/wakeup notes recorded four development-content leads. This PR corrects the one that still lived in a tracked supported package and records validator dispositions for the rest. No replacement world content was manufactured, and protected local headers were not edited. #123 is out of scope.

## Dispositions

1. **16500-range wakeup golem** (`lib/world/minimal/16.mob`, this change on top of `14dbdb969`): current and default position are now `POS_STANDING`. Intermediate `$` terminators that hid `16501`-`16511` from the parser are removed so those records stay loadable. `wtool validate --paths lib/world/minimal` no longer reports `MOB016`. Direct `parse_mobile_file()` of the fixture asserts vnums `16500`-`16511` with in-range standing positions.

2. **Zone 23 missing DG trigger references**: absent from tracked `minimal`/`artifacts`. Present in gitignored local OLC; `wtool show/refs zone 23` and `validate --zone 23` report no missing trigger refs and no errors. Closed as already repaired.

3. **Zone 1204 equipping object 120602**: absent from tracked packages. Local object `120602` exists; the two `E` resets resolve; `validate --zone 1204` has no missing-object finding and no errors. Closed as already repaired.

4. **Mobile 200103 SPEC without a procedure**: absent from tracked packages. Local Brother Spire flags `253962` do not include `MOB_SPEC`; `spec_proc` is unset; `validate --zone 2001` has no SPEC-without-procedure finding. Closed as already repaired. No procedure was invented.

Evidence: `docs/testing/ISSUE_133_WORLD_FIXTURE_LEADS.md`.

## Tests

- `python3 -m unittest discover -s scripts/world/tests -t scripts/world -p 'test_graph.py' -v`
- `python3 -m unittest discover -s scripts/world/tests -t scripts/world -p 'test_mobiles.py' -v`
- `python3 scripts/world/wtool.py validate --paths lib/world/minimal` (twice)
- `python3 scripts/world/wtool.py validate --paths lib/world/artifacts` (twice)