### PR TITLE
Persist temporary summon expiry and define durable follower categories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1260,6 +1260,7 @@ set(CUTEST_TEST_SOURCES
     unittests/CuTest/test_necromancer.c
     unittests/CuTest/test_pet_persistence.c
     unittests/CuTest/test_pet_policy.c
+    unittests/CuTest/test_pet_lifetime.c
     unittests/CuTest/test_study_pet_menus.c
     unittests/CuTest/test_bounds_checking.c
     unittests/CuTest/test_help_sync.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -402,6 +402,7 @@ cutest_SOURCES = \
 	unittests/CuTest/test_necromancer.c \
 	unittests/CuTest/test_pet_persistence.c \
 	unittests/CuTest/test_pet_policy.c \
+	unittests/CuTest/test_pet_lifetime.c \
 	unittests/CuTest/test_study_pet_menus.c \
 	unittests/CuTest/CuTest.c \
 	unittests/CuTest/test_bounds_checking.c \
@@ -474,6 +475,7 @@ cutest_test_files = \
 	unittests/CuTest/test_necromancer.c \
 	unittests/CuTest/test_pet_persistence.c \
 	unittests/CuTest/test_pet_policy.c \
+	unittests/CuTest/test_pet_lifetime.c \
 	unittests/CuTest/test_study_pet_menus.c \
 	unittests/CuTest/test_artifacts.c \
 	unittests/CuTest/test_artifact_integration.c \

--- a/docs/systems/SAVE_SYSTEMS_BREAKDOWN.md
+++ b/docs/systems/SAVE_SYSTEMS_BREAKDOWN.md
@@ -196,12 +196,26 @@ repeated renaming does not accumulate prior custom names. Saved eidolon identity
 is restored before considering legacy owner-description defaults. Malformed
 records remain saved for recovery; `pets restore` offers a bounded retry and skips already published pet IDs.
 
-Timed affects currently retain remaining duration but pause while stored/offline.
-The runtime-state record does not preserve natural/control event deadlines.
-`ePURGEMOB` is the short follower-loss cleanup, not a general natural lifetime.
-Absolute deadlines, expiry gear handling, and uncertain-commit reconciliation
-remain open in `docs/ongoing-projects/PET_SYSTEM_REFACTOR_PLAN.md`. Save/load tests
-do not replace the plan's executable copyover acceptance gate.
+Follower persistence follows an explicit policy (`pet_lifetime_kind()` in
+`src/utils.c`). Durable followers persist until dismissed, killed, or stored.
+Timed control is carried by the saved charm affect; its remaining duration
+pauses while stored or offline. Deadline followers are those with a live
+`ePURGEMOB` event, plus illusory decoys, which never persist without one. The
+runtime-state record (version 4, `T <kind> <epoch>`) stores the absolute
+real-time deadline rather than the scheduler handle. The deadline keeps
+elapsing offline: restore rejects an expired record, discards the roomless
+copy, and lets the next snapshot drop the row; a live record gets a fresh
+native `ePURGEMOB` event for the remaining time; if that event cannot be
+scheduled the record is rejected rather than restored without an expiry.
+Session followers are spell summons outside the kept families (companion,
+familiar, mount, dragon mount, eidolon, golem, mercenary, animated dead,
+lycanthrope, totem spirit); they are skipped by the snapshot and a saved record
+of one is rejected on restore. The keeper boards only durable and timed-control
+followers; reclaiming a stored row whose lifetime has ended deletes that row
+and its objects inside the reclaim transaction. `pets` shows each pet's
+policy and remaining real time. Expiry gear handling and uncertain-commit
+reconciliation remain open in `docs/ongoing-projects/PET_SYSTEM_REFACTOR_PLAN.md`.
+Save/load tests do not replace the plan's executable copyover acceptance gate.
 
 #### 3. Wilderness System Data
 - **Tables**: `region_data`, `path_data`, `region_index`, `path_index`

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -9826,7 +9826,10 @@ reclaim each one.
 STABLE STORE hands one charmed follower in your room to the keeper. You may
 use its name or its assigned ID from PETS, such as stable store #123. You cannot
 stable a follower while either of you is fighting, or while it is being ridden.
-The keeper holds up to 10 followers for you.
+The keeper boards only followers that stay with you: durable pets and timed
+control. Timed summons and ordinary spell summons are refused. A stabled
+follower whose time ran out before the policy existed is released when you try
+to reclaim it, freeing its slot. The keeper holds up to 10 followers for you.
 
 STABLE RECLAIM returns a stabled follower by its listed number - the small
 number shown beside it, such as 'stable reclaim 1'. The longer stable ID in the
@@ -23691,6 +23694,17 @@ to protect you using normal rescue rules and your charmie-rescue preference.
 Changing behavior does not stop an existing fight or prevent direct orders.
 Behavior is saved with eligible pets. Explicit summon recalls waiting pets;
 automatic travel does not.
+
+PETS also shows each pet's persistence policy. Durable pets (companions,
+familiars, mounts, eidolons, mercenaries, golems, animated dead, and other
+kept followers) stay saved until dismissed, killed, or stored. Timed control,
+such as a charm whose control has a duration, is saved with its remaining time
+and that time pauses while you are offline. Timed summons such as an illusory
+decoy keep a real-time deadline: it keeps counting while you are offline,
+across reboots and copyovers, and a pet whose deadline has passed is gone
+when you return. Ordinary spell summons, such as summoned creatures, allies,
+and genies, last only for your current session: they are never saved and do
+not return after you log out, a reboot, or a copyover.
 
 Use pets <pet|#id> name <name> to name one loyal pet in your room. Names are
 3-24 ASCII letters, with optional internal apostrophes or hyphens; spaces,

--- a/sql/components/help_pet_entries.sql
+++ b/sql/components/help_pet_entries.sql
@@ -103,6 +103,17 @@ Changing behavior does not stop an existing fight or prevent direct orders.
 Behavior is saved with eligible pets. Explicit summon recalls waiting pets;
 automatic travel does not.
 
+PETS also shows each pet''s persistence policy. Durable pets (companions,
+familiars, mounts, eidolons, mercenaries, golems, animated dead, and other
+kept followers) stay saved until dismissed, killed, or stored. Timed control,
+such as a charm whose control has a duration, is saved with its remaining time
+and that time pauses while you are offline. Timed summons such as an illusory
+decoy keep a real-time deadline: it keeps counting while you are offline,
+across reboots and copyovers, and a pet whose deadline has passed is gone
+when you return. Ordinary spell summons, such as summoned creatures, allies,
+and genies, last only for your current session: they are never saved and do
+not return after you log out, a reboot, or a copyover.
+
 Use pets <pet|#id> name <name> to name one loyal pet in your room. Names are
 3-24 ASCII letters, with optional internal apostrophes or hyphens; spaces,
 color codes, parser words such as the, with, all, self, or someone, and the
@@ -170,7 +181,10 @@ reclaim each one.
 STABLE STORE hands one charmed follower in your room to the keeper. You may
 use its name or its assigned ID from PETS, such as stable store #123. You cannot
 stable a follower while either of you is fighting, or while it is being ridden.
-The keeper holds up to 10 followers for you.
+The keeper boards only followers that stay with you: durable pets and timed
+control. Timed summons and ordinary spell summons are refused. A stabled
+follower whose time ran out before the policy existed is released when you try
+to reclaim it, freeing its slot. The keeper holds up to 10 followers for you.
 
 STABLE RECLAIM returns a stabled follower by its listed number - the small
 number shown beside it, such as ''stable reclaim 1''. The longer stable ID in the

--- a/src/players.c
+++ b/src/players.c
@@ -63,7 +63,7 @@
 #define PLAYER_AFFECT_FILE_VERSION 1
 #define BOARDING_ABILITY_PFILE_VERSION 1
 
-#define PET_RUNTIME_STATE_VERSION 3
+#define PET_RUNTIME_STATE_VERSION 4
 #define PET_RUNTIME_STATE_INITIAL_SIZE 4096
 #define PET_RUNTIME_STATE_MAX_SIZE 65535
 
@@ -181,7 +181,14 @@ struct pet_runtime_state
   bool mercenary_proc_fired;
   int source_spell;
   int behavior;
+  int lifetime_kind;    /* PET_SAVED_LIFETIME_* */
+  long long expires_at; /* Real-time epoch for deadline records; zero otherwise. */
 };
+
+/* Persisted lifetime kinds.  Timed control affects are already carried by
+ * the affect records, so only the event deadline needs its own marker. */
+#define PET_SAVED_LIFETIME_DURABLE 0
+#define PET_SAVED_LIFETIME_DEADLINE 1
 
 static char *serialize_pet_runtime_state(struct char_data *pet);
 static bool parse_pet_runtime_state(const char *serialized, struct pet_runtime_state *state);
@@ -5939,6 +5946,16 @@ static char *serialize_pet_runtime_state(struct char_data *pet)
   state.mercenary_proc_fired = state.hired_mercenary && PROC_FIRED(pet);
   state.source_spell = pet->pet_source_spell;
   state.behavior = pet->pet_behavior;
+  /* The scheduler handle is runtime-only; persist the absolute deadline it
+   * represents.  A deadline-class follower without a live event is already
+   * spent, so it is saved as expired rather than promoted to durable. */
+  if (pet_lifetime_kind(pet) == PET_LIFETIME_DEADLINE)
+  {
+    state.lifetime_kind = PET_SAVED_LIFETIME_DEADLINE;
+    state.expires_at = pet_lifetime_deadline(pet);
+    if (state.expires_at <= 0)
+      state.expires_at = (long long)time(NULL);
+  }
   for (i = 0; i < NUM_OF_SAVING_THROWS; i++)
     state.saves[i] = GET_REAL_SAVE(pet, i);
   for (i = 0; i < 10; i++)
@@ -5962,11 +5979,13 @@ static char *serialize_pet_runtime_state(struct char_data *pet)
       goto serialize_failure;                                                                      \
   } while (0)
 
-  /* V=version, B=affect bits, M=mobile bits, S=stats, R=saves, L=spell slots,
+  /* V=version, P=source spell, H=behavior, T=lifetime kind and deadline,
+   * B=affect bits, M=mobile bits, S=stats, R=saves, L=spell slots,
    * F=feat override, A=timed affect, and E=end. */
   PET_STATE_APPEND("V %d\n", PET_RUNTIME_STATE_VERSION);
   PET_STATE_APPEND("P %d\n", state.source_spell);
   PET_STATE_APPEND("H %d\n", state.behavior);
+  PET_STATE_APPEND("T %d %lld\n", state.lifetime_kind, state.expires_at);
   PET_STATE_APPEND("B %d %d %d %d %d %d %d %d\n", state.extra_aff[0], state.extra_aff[1],
                    state.extra_aff[2], state.extra_aff[3], state.extra_aff2[0], state.extra_aff2[1],
                    state.extra_aff2[2], state.extra_aff2[3]);
@@ -6043,6 +6062,10 @@ static bool pet_state_values_are_valid(const struct pet_runtime_state *state)
       state->source_spell < 0 || state->source_spell >= MAX_SPELLS || state->behavior < 0 ||
       state->behavior >= NUM_PET_BEHAVIORS)
     return false;
+  if (state->lifetime_kind == PET_SAVED_LIFETIME_DURABLE
+          ? state->expires_at != 0
+          : state->lifetime_kind != PET_SAVED_LIFETIME_DEADLINE || state->expires_at <= 0)
+    return false;
 
   for (i = 0; i < NUM_OF_SAVING_THROWS; i++)
     if (state->saves[i] < SHRT_MIN || state->saves[i] > SHRT_MAX)
@@ -6073,6 +6096,7 @@ static bool parse_pet_runtime_state(const char *serialized, struct pet_runtime_s
   int consumed, feat, feat_value, hired, proc_fired, version;
   int saw_version, saw_base, saw_mob, saw_stats, saw_saves, saw_slots, saw_end, saw_source;
   bool saw_behavior;
+  bool saw_lifetime;
   int affect_values[14];
   int values[20];
 
@@ -6090,6 +6114,7 @@ static bool parse_pet_runtime_state(const char *serialized, struct pet_runtime_s
   saw_version = saw_base = saw_mob = saw_stats = saw_saves = saw_slots = saw_end = false;
   saw_source = false;
   saw_behavior = false;
+  saw_lifetime = false;
   version = 0;
 
   for (line = strtok_r(copy, "\n", &saveptr); line; line = strtok_r(NULL, "\n", &saveptr))
@@ -6121,6 +6146,14 @@ static bool parse_pet_runtime_state(const char *serialized, struct pet_runtime_s
           !pet_state_line_is_complete(line, consumed))
         goto parse_failure;
       saw_behavior = true;
+    }
+    else if (line[0] == 'T')
+    {
+      if (!saw_version || version < 4 || saw_lifetime ||
+          sscanf(line, "T %d %lld %n", &state->lifetime_kind, &state->expires_at, &consumed) != 2 ||
+          !pet_state_line_is_complete(line, consumed))
+        goto parse_failure;
+      saw_lifetime = true;
     }
     else if (line[0] == 'B')
     {
@@ -6237,7 +6270,7 @@ static bool parse_pet_runtime_state(const char *serialized, struct pet_runtime_s
   free(copy);
   if (!saw_version || !saw_base || !saw_mob || !saw_stats || !saw_saves || !saw_slots || !saw_end ||
       (version >= 2 && !saw_source) || (version >= 3 && !saw_behavior) ||
-      !pet_state_values_are_valid(state))
+      (version >= 4 && !saw_lifetime) || !pet_state_values_are_valid(state))
     return false;
 
   mask_pet_state_bits(state->extra_aff, AF_ARRAY_MAX, NUM_AFF_FLAGS);
@@ -6309,6 +6342,40 @@ static void apply_pet_runtime_state(struct char_data *pet, const struct pet_runt
     SET_BIT_AR(AFF_FLAGS(pet), AFF_CHARM);
 }
 
+/* Rebuild the follower's lifetime from its saved record.  Deadlines are real
+ * time, so offline time counts against them; an elapsed deadline, or a
+ * deadline-class follower saved without one, is rejected.  A NULL state is a
+ * legacy row and is durable unless its category requires a deadline. */
+static bool restore_pet_lifetime(struct char_data *pet, const struct pet_runtime_state *state,
+                                 time_t now)
+{
+  enum pet_lifetime_kind kind;
+  long long remaining;
+
+  if (!pet)
+    return false;
+  if (!state || state->lifetime_kind == PET_SAVED_LIFETIME_DURABLE)
+  {
+    /* Session summons and decoys saved before the policy existed are spent. */
+    kind = pet_lifetime_kind(pet);
+    return kind == PET_LIFETIME_DURABLE || kind == PET_LIFETIME_CONTROL;
+  }
+  remaining = state->expires_at - (long long)now;
+  if (remaining <= 0)
+    return false;
+  if (remaining > LONG_MAX / PASSES_PER_SEC)
+    remaining = LONG_MAX / PASSES_PER_SEC;
+  attach_mud_event(new_mud_event(ePURGEMOB, pet, NULL), (long)remaining * PASSES_PER_SEC);
+  /* Admission can fail; a deadline follower without its event would be immortal. */
+  if (!mud_event_is_live(char_has_mud_event(pet, ePURGEMOB)))
+  {
+    log("SYSERR: %s: Could not schedule the expiry of saved follower %ld", __func__,
+        pet->pet_data_id);
+    return false;
+  }
+  return true;
+}
+
 #ifdef LUMINARI_CUTEST
 char *serialize_pet_runtime_state_for_test(struct char_data *pet)
 {
@@ -6322,7 +6389,7 @@ bool restore_pet_runtime_state_for_test(struct char_data *pet, const char *seria
   if (!parse_pet_runtime_state(serialized, &state))
     return false;
   apply_pet_runtime_state(pet, &state);
-  return true;
+  return restore_pet_lifetime(pet, &state, time(NULL));
 }
 #endif
 
@@ -6863,7 +6930,7 @@ bool save_char_pets(struct char_data *ch)
   for (f = ch->followers; f; f = f->next)
   {
     if (!f->follower || !IS_NPC(f->follower) || !AFF_FLAGGED(f->follower, AFF_CHARM) ||
-        MOB_FLAGGED(f->follower, MOB_NOTDEADYET))
+        MOB_FLAGGED(f->follower, MOB_NOTDEADYET) || !pet_lifetime_persists(f->follower))
       continue;
 
     current = prepare_pet_save_record(ch, f->follower, escaped_owner, PET_STATE_ACTIVE);
@@ -6992,9 +7059,12 @@ static bool pet_row_already_published(struct char_data *ch, long int pet_idnum)
   return false;
 }
 
+/* Returns the staged, roomless follower, or NULL.  A row that failed to decode
+ * sets *restore_failed and is retained; a row whose lifetime has ended sets
+ * *expired so the caller can drop it. */
 static struct char_data *prepare_saved_pet_row(struct char_data *ch, MYSQL_ROW row,
                                                long int owner_id, long long owner_created,
-                                               bool *restore_failed)
+                                               bool *restore_failed, bool *expired)
 {
   struct pet_runtime_state runtime_state;
   struct char_data *mob = NULL;
@@ -7193,6 +7263,16 @@ static struct char_data *prepare_saved_pet_row(struct char_data *ch, MYSQL_ROW r
     extract_char(mob);
     return NULL;
   }
+  /* Nothing else about the roster failed; the active snapshot drops the row on
+   * the next save and the keeper releases a stored one on reclaim. */
+  if (!restore_pet_lifetime(mob, has_runtime_state ? &runtime_state : NULL, time(NULL)))
+  {
+    log("Info: %s: Discarding expired saved follower %ld for %s (vnum %d)", __func__, pet_idnum,
+        GET_NAME(ch), atoi(row[0]));
+    *expired = true;
+    extract_char(mob);
+    return NULL;
+  }
   if (pet_load_objs(mob, ch, pet_idnum) == PET_OBJECT_LOAD_FAILED)
   {
     *restore_failed = true;
@@ -7262,6 +7342,7 @@ void load_char_pets(struct char_data *ch)
   long int owner_id;
   long long owner_created;
   bool restore_failed = false;
+  bool expired = false;
   enum perf_entity_reason previous_entity_reason;
 
   if (!ch || IS_NPC(ch))
@@ -7314,7 +7395,7 @@ void load_char_pets(struct char_data *ch)
   owner_handle = domain_event_character_handle(ch);
   while ((row = mysql_fetch_row(result)))
   {
-    pet = prepare_saved_pet_row(ch, row, owner_id, owner_created, &restore_failed);
+    pet = prepare_saved_pet_row(ch, row, owner_id, owner_created, &restore_failed, &expired);
     if (pet && !publish_saved_pet(ch, pet))
       restore_failed = true;
     ch = domain_event_world_resolve_character(owner_handle);
@@ -7496,6 +7577,10 @@ bool pet_store_pet(struct char_data *owner, struct char_data *pet)
   bool transaction_started = false;
 
   if (!owner || IS_NPC(owner) || !GET_NAME(owner) || !pet || !IS_NPC(pet))
+    return false;
+  /* Session summons and timed summons end on their own; the keeper boards
+   * only followers that keep. */
+  if (!pet_keeper_accepts(pet))
     return false;
   if (owner->pet_roster_load_state != PET_ROSTER_LOADED)
   {
@@ -7702,6 +7787,7 @@ struct char_data *pet_retrieve_stored(struct char_data *owner, long int pet_id, 
   long long owner_created;
   bool restored;
   bool restore_failed = false;
+  bool expired = false;
   enum perf_entity_reason previous_entity_reason;
 
   if (reason)
@@ -7754,10 +7840,33 @@ struct char_data *pet_retrieve_stored(struct char_data *owner, long int pet_id, 
   }
   {
     previous_entity_reason = PERF_entity_scope_set(PERF_ENTITY_PET_RESTORE);
-    mob = prepare_saved_pet_row(owner, row, owner_id, owner_created, &restore_failed);
+    mob = prepare_saved_pet_row(owner, row, owner_id, owner_created, &restore_failed, &expired);
     PERF_entity_scope_restore(previous_entity_reason);
   }
   mysql_free_result(result);
+  if (!mob && expired)
+  {
+    /* The row is locked by the SELECT above; release the spent follower so the
+     * stable slot is not held forever. */
+    snprintf(query, sizeof(query), "DELETE FROM pet_save_objs WHERE pet_idnum = %ld", pet_id);
+    if (mysql_query(conn, query))
+      goto release_failed;
+    snprintf(query, sizeof(query),
+             "DELETE FROM pet_data WHERE pet_data_id = %ld AND owner_name = '%s' AND "
+             "pet_state = %d",
+             pet_id, escaped_owner, PET_STATE_STORED);
+    if (mysql_query(conn, query) || mysql_query(conn, "COMMIT"))
+      goto release_failed;
+    free(escaped_owner);
+    if (reason)
+      *reason = "That follower's time ran out while it was stabled; the keeper has released it.";
+    return NULL;
+
+  release_failed:
+    log("SYSERR: %s: Unable to release expired stored pet %ld for %s: %s", __func__, pet_id,
+        GET_NAME(owner), mysql_error(conn));
+    goto rollback;
+  }
   if (!mob)
   {
     if (reason)

--- a/src/spec/spec_mobiles.c
+++ b/src/spec/spec_mobiles.c
@@ -457,6 +457,12 @@ SPECIAL(pet_keeper)
       send_to_char(ch, "Dismount first.\r\n");
       return (TRUE);
     }
+    if (!pet_keeper_accepts(pet))
+    {
+      act("$N will not last; the keeper boards only followers that stay with you.", FALSE, ch, 0,
+          pet, TO_CHAR);
+      return (TRUE);
+    }
     stored = pet_stored_count(ch);
     if (stored < 0)
     {

--- a/src/utils.c
+++ b/src/utils.c
@@ -1410,6 +1410,7 @@ int check_npc_followers(struct char_data *ch, int mode, int variable)
   struct char_data *pet;
   const char *location;
   char identity[40];
+  char lifetime[64];
   room_rnum room;
   int number = 0, spare;
   size_t category;
@@ -1440,13 +1441,18 @@ int check_npc_followers(struct char_data *ch, int mode, int variable)
       identity[0] = '\0';
       if (pet->pet_data_id > 0)
         snprintf(identity, sizeof(identity), " [#%ld]", pet->pet_data_id);
-      send_to_char(ch, "\tC%-2d\tw) %s - %s - %s [%s]%s\tn\r\n", ++number,
+      pet_lifetime_status(pet, lifetime, sizeof(lifetime));
+      send_to_char(ch, "\tC%-2d\tw) %s - %s - %s [%s]%s - %s\tn\r\n", ++number,
                    GET_NAME(pet) != NULL ? GET_NAME(pet) : "Unnamed pet",
                    location != NULL ? location : "Away",
                    follower_rules[follower_category(pet, follower_vnum(pet))].name,
-                   pet_behavior_name(pet->pet_behavior), identity);
+                   pet_behavior_name(pet->pet_behavior), identity, lifetime);
     }
     draw_line(ch, 80, '-', '-');
+    send_to_char(ch, "Durable pets and timed control are saved with you; control time pauses "
+                     "while you are offline.\r\nTimed summons keep a real-time deadline and are "
+                     "gone if it passes while you are away.\r\nOrdinary spell summons last only "
+                     "for this session and are never saved.\r\n");
     send_to_char(ch,
                  "\tC%d pets. General slots: %d/%d used, %d available. "
                  "Ordinary summons: %d/%d.\tn\r\n"
@@ -1498,6 +1504,102 @@ bool is_illusory_pet(struct char_data *pet)
 {
   return pet != NULL && IS_NPC(pet) &&
          (pet->pet_source_spell == SPELL_MISLEAD || follower_vnum(pet) == PET_MISLEAD_DECOY);
+}
+
+/* Illusory decoys exist only for their event lifetime; a record without a
+ * valid deadline is expired rather than durable. */
+bool pet_lifetime_requires_deadline(struct char_data *pet)
+{
+  return is_illusory_pet(pet);
+}
+
+/* Real-time epoch when the follower's ePURGEMOB event fires; zero without one. */
+long long pet_lifetime_deadline(struct char_data *pet)
+{
+  struct mud_event_data *event;
+  long remaining;
+
+  event = pet != NULL ? char_has_mud_event(pet, ePURGEMOB) : NULL;
+  if (!mud_event_is_live(event))
+    return 0;
+  remaining = mud_event_remaining(event);
+  if (remaining < 0)
+    remaining = 0;
+  return (long long)time(NULL) + (remaining + PASSES_PER_SEC - 1) / PASSES_PER_SEC;
+}
+
+/* Kept families are class features, crafted, hired, or permanent creations.
+ * They persist even when a spell created them; any other spell summon lasts
+ * only for the owner's session. */
+static bool pet_is_kept_family(struct char_data *pet)
+{
+  static const int kept_flags[] = {
+      MOB_C_ANIMAL,        MOB_C_FAMILIAR,    MOB_C_MOUNT,
+      MOB_C_DRAGON,        MOB_EIDOLON,       MOB_GOLEM,
+      MOB_MERCENARY,       MOB_ANIMATED_DEAD, MOB_ROL_LYCANTHROPE_SUMMON,
+      MOB_ROL_TOTEM_SPIRIT};
+  size_t i;
+
+  for (i = 0; i < sizeof(kept_flags) / sizeof(kept_flags[0]); i++)
+    if (MOB_FLAGGED(pet, kept_flags[i]))
+      return true;
+  return false;
+}
+
+enum pet_lifetime_kind pet_lifetime_kind(struct char_data *pet)
+{
+  struct affected_type *af;
+
+  if (pet == NULL || !IS_NPC(pet))
+    return PET_LIFETIME_DURABLE;
+  if (pet_lifetime_requires_deadline(pet) || pet_lifetime_deadline(pet) > 0)
+    return PET_LIFETIME_DEADLINE;
+  for (af = pet->affected; af != NULL; af = af->next)
+    if (IS_SET_AR(af->bitvector, AFF_CHARM) && af->duration >= 0)
+      return PET_LIFETIME_CONTROL;
+  if (pet->pet_source_spell != 0 && !pet_is_kept_family(pet))
+    return PET_LIFETIME_SESSION;
+  return PET_LIFETIME_DURABLE;
+}
+
+bool pet_lifetime_persists(struct char_data *pet)
+{
+  return pet_lifetime_kind(pet) != PET_LIFETIME_SESSION;
+}
+
+bool pet_keeper_accepts(struct char_data *pet)
+{
+  enum pet_lifetime_kind kind = pet_lifetime_kind(pet);
+
+  return kind == PET_LIFETIME_DURABLE || kind == PET_LIFETIME_CONTROL;
+}
+
+void pet_lifetime_status(struct char_data *pet, char *buffer, size_t size)
+{
+  long long remaining;
+
+  switch (pet_lifetime_kind(pet))
+  {
+  case PET_LIFETIME_CONTROL:
+    snprintf(buffer, size, "timed control, pauses offline");
+    break;
+  case PET_LIFETIME_DEADLINE:
+    remaining = pet_lifetime_deadline(pet) - (long long)time(NULL);
+    if (remaining <= 0)
+      snprintf(buffer, size, "expiring");
+    else if (remaining >= 60)
+      snprintf(buffer, size, "expires in %lldm %llds, real time", remaining / 60, remaining % 60);
+    else
+      snprintf(buffer, size, "expires in %llds, real time", remaining);
+    break;
+  case PET_LIFETIME_SESSION:
+    snprintf(buffer, size, "this session only, not saved");
+    break;
+  case PET_LIFETIME_DURABLE:
+  default:
+    snprintf(buffer, size, "durable");
+    break;
+  }
 }
 
 const char *pet_behavior_name(int behavior)

--- a/src/utils.h
+++ b/src/utils.h
@@ -258,6 +258,27 @@ bool pet_guards_owner(struct char_data *pet, struct char_data *owner, struct cha
 const char *pet_behavior_name(int behavior);
 struct char_data *get_pet_command_target(struct char_data *owner, char *target);
 bool is_illusory_pet(struct char_data *pet);
+/* Follower persistence policy.  Durable followers persist until dismissed,
+ * killed, or stored.  Timed control is held by a charm affect whose remaining
+ * duration is saved and paused while the owner is offline.  Deadline
+ * followers end with an ePURGEMOB event; the deadline is real time and keeps
+ * elapsing offline.  Session followers are ordinary spell summons outside the
+ * kept families; they last while the owner plays and are never saved. */
+enum pet_lifetime_kind
+{
+  PET_LIFETIME_DURABLE,
+  PET_LIFETIME_CONTROL,
+  PET_LIFETIME_DEADLINE,
+  PET_LIFETIME_SESSION
+};
+enum pet_lifetime_kind pet_lifetime_kind(struct char_data *pet);
+bool pet_lifetime_requires_deadline(struct char_data *pet);
+/* Saved with the owner: every kind except session. */
+bool pet_lifetime_persists(struct char_data *pet);
+/* Boarded by the keeper: only durable and timed-control followers. */
+bool pet_keeper_accepts(struct char_data *pet);
+long long pet_lifetime_deadline(struct char_data *pet);
+void pet_lifetime_status(struct char_data *pet, char *buffer, size_t size);
 bool pet_order_check(struct char_data *ch, struct char_data *vict);
 /* Takes a staged, roomless NPC; destroys it if placement fails. Admission is the caller's job. */
 bool place_pet_follower(struct char_data *owner, struct char_data *pet);

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -14,6 +14,9 @@
 #include "../../src/net/protocol.h"
 #include "../../src/db_init.h"
 #include "../../src/mudlim.h"
+#include "../../src/mud_event.h"
+#include "../../src/domain_event_world.h"
+#include "../../src/pet_vnums.h"
 #include "../../src/magic/spells.h"
 #include "../../src/dgscript/dg_event.h"
 #include "../../src/event_runtime.h"
@@ -1623,6 +1626,288 @@ void Test_pet_snapshot_lifecycle_handles_disconnect_and_follower_removal(CuTest 
   CuAssertIntEquals(tc, 0, final_object_rows);
 }
 
+/* Real prototypes, one room, and the database: the deadline round trip,
+ * expired active and stored rows, session summons, and keeper refusal all run
+ * through save_char_pets(), load_char_pets(), pet_store_pet(), and
+ * pet_retrieve_stored(), the same path disconnect, reboot, and copyover use. */
+struct pet_lifetime_world
+{
+  struct char_data prototypes[2];
+  struct index_data indexes[2];
+  struct room_data room;
+  struct zone_data zone;
+  struct char_data *saved_proto;
+  struct index_data *saved_index;
+  struct room_data *saved_world;
+  struct zone_data *saved_zones;
+  mob_rnum saved_top;
+  room_rnum saved_top_of_world;
+  zone_rnum saved_top_of_zone;
+};
+
+static void begin_pet_lifetime_world(struct pet_lifetime_world *w)
+{
+  int i;
+
+  memset(w, 0, sizeof(*w));
+  w->saved_proto = mob_proto;
+  w->saved_index = mob_index;
+  w->saved_world = world;
+  w->saved_zones = zone_table;
+  w->saved_top = top_of_mobt;
+  w->saved_top_of_world = top_of_world;
+  w->saved_top_of_zone = top_of_zone_table;
+  if (!event_runtime_is_initialized())
+    event_init();
+  /* real_mobile() searches a sorted index; the decoy vnum is the larger one. */
+  w->indexes[0].vnum = 1;
+  w->indexes[1].vnum = PET_MISLEAD_DECOY;
+  for (i = 0; i < 2; i++)
+  {
+    clear_char(&w->prototypes[i]);
+    SET_BIT_AR(MOB_FLAGS(&w->prototypes[i]), MOB_ISNPC);
+    GET_MOB_RNUM(&w->prototypes[i]) = i;
+    w->prototypes[i].player.name = (char *)(i == 0 ? "lifetime hound" : "lifetime decoy");
+    w->prototypes[i].player.short_descr = (char *)(i == 0 ? "a lifetime hound" : "a decoy");
+    w->prototypes[i].player.long_descr = (char *)"A lifetime fixture stands here.";
+    GET_LEVEL(&w->prototypes[i]) = 5;
+    GET_HIT(&w->prototypes[i]) = 10;
+    GET_PSP(&w->prototypes[i]) = 10;
+    GET_MAX_HIT(&w->prototypes[i]) = 10;
+    GET_POS(&w->prototypes[i]) = POS_STANDING;
+  }
+  w->room.number = 100;
+  w->room.zone = 0;
+  w->room.sector_type = SECT_INSIDE;
+  w->room.name = (char *)"Lifetime room";
+  w->room.description = (char *)"A lifetime fixture room.\r\n";
+  w->zone.number = 0;
+  w->zone.bot = 0;
+  w->zone.top = 30000;
+  mob_proto = w->prototypes;
+  mob_index = w->indexes;
+  top_of_mobt = 1;
+  world = &w->room;
+  top_of_world = 0;
+  zone_table = &w->zone;
+  top_of_zone_table = 0;
+}
+
+static void end_pet_lifetime_world(struct pet_lifetime_world *w)
+{
+  mob_proto = w->saved_proto;
+  mob_index = w->saved_index;
+  top_of_mobt = w->saved_top;
+  world = w->saved_world;
+  top_of_world = w->saved_top_of_world;
+  zone_table = w->saved_zones;
+  top_of_zone_table = w->saved_top_of_zone;
+}
+
+static int count_followers(struct char_data *owner)
+{
+  struct follow_type *f;
+  int count = 0;
+
+  for (f = owner->followers; f; f = f->next)
+    count++;
+  return count;
+}
+
+static void extract_all_followers(struct char_data *owner)
+{
+  struct follow_type *f;
+  struct follow_type *next;
+
+  for (f = owner->followers; f; f = next)
+  {
+    next = f->next;
+    if (f->follower)
+      extract_char(f->follower);
+  }
+  extract_pending_chars();
+}
+
+void Test_pet_lifetime_survives_snapshot_restore_and_keeper_release(CuTest *tc)
+{
+  struct pet_save_fixture fixture;
+  struct pet_lifetime_world w;
+  struct char_data session_pet;
+  struct follow_type session_follower;
+  struct char_data *saved_characters = character_list;
+  struct char_data *pet;
+  struct char_data *reclaimed;
+  struct follow_type *f;
+  struct mud_event_data *event;
+  MYSQL *connection;
+  MYSQL *saved_conn;
+  const char *enabled;
+  const char *reason;
+  char query[512];
+  long long now;
+  long remaining = -1;
+  int restored_control_duration = -1;
+  bool saved_available;
+  bool schema_created;
+  bool initial_saved;
+  bool session_not_saved;
+  bool deadline_saved;
+  bool restored_pair;
+  bool expired_marked;
+  bool expired_dropped;
+  bool expired_row_removed;
+  bool keeper_refuses_deadline;
+  bool keeper_refuses_session;
+  bool stable_rows_seeded;
+  bool spent_stored_released;
+  bool live_stored_reclaimed;
+
+  enabled = getenv("LUMINARI_TEST_MYSQL_ENABLE");
+  if (enabled == NULL || strcmp(enabled, "1") != 0)
+  {
+    CuAssertTrue(tc, 1);
+    return;
+  }
+  connection = open_test_database();
+  if (connection == NULL)
+  {
+    CuFail(tc, "could not connect to the explicitly configured test database");
+    return;
+  }
+
+  saved_conn = conn;
+  saved_available = mysql_available;
+  conn = connection;
+  mysql_available = true;
+  begin_pet_lifetime_world(&w);
+  initialize_pet_save_fixture(&fixture);
+  /* Restore creates real objects; keep this roster gear-free. */
+  fixture.first_pet.equipment[0] = NULL;
+  fixture.second_pet.carrying = NULL;
+  fixture.inventory_object.carried_by = NULL;
+  fixture.owner.desc = NULL;
+  fixture.descriptor.character = NULL;
+  IN_ROOM(&fixture.owner) = 0;
+  w.room.people = &fixture.owner;
+  GET_MOB_RNUM(&fixture.first_pet) = 0;
+  GET_MOB_RNUM(&fixture.second_pet) = 0;
+  /* first_pet: timed control (charm affect).  second_pet: 90 second deadline.
+   * session_pet: an ordinary summon with neither. */
+  attach_mud_event(new_mud_event(ePURGEMOB, &fixture.second_pet, NULL), 90 * PASSES_PER_SEC);
+  clear_char(&session_pet);
+  SET_BIT_AR(MOB_FLAGS(&session_pet), MOB_ISNPC);
+  SET_BIT_AR(AFF_FLAGS(&session_pet), AFF_CHARM);
+  GET_MOB_RNUM(&session_pet) = 0;
+  session_pet.player.name = (char *)"session summon";
+  session_pet.pet_source_spell = SPELL_SUMMON_CREATURE_1;
+  memset(&session_follower, 0, sizeof(session_follower));
+  session_follower.follower = &session_pet;
+  fixture.second_follower.next = &session_follower;
+  now = (long long)time(NULL);
+
+  schema_created = create_pet_snapshot_temporary_schema(connection);
+  initial_saved = schema_created && save_char_pets(&fixture.owner);
+  session_not_saved = query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 2;
+  /* Exactly one row carries a deadline, and it is the absolute real time. */
+  snprintf(query, sizeof(query),
+           "SELECT COUNT(*) FROM pet_data WHERE CAST(SUBSTRING(REGEXP_SUBSTR(runtime_state, "
+           "'T 1 [0-9]+'), 5) AS SIGNED) BETWEEN %lld AND %lld",
+           now + 89, now + 92);
+  deadline_saved = query_single_int(connection, query, -1) == 1;
+
+  /* Relog: the deadline follower returns with a fresh event, control intact. */
+  fixture.owner.followers = NULL;
+  fixture.owner.pet_roster_load_state = PET_ROSTER_UNLOADED;
+  load_char_pets(&fixture.owner);
+  restored_pair = fixture.owner.pet_roster_load_state == PET_ROSTER_LOADED &&
+                  count_followers(&fixture.owner) == 2;
+  for (f = fixture.owner.followers; f; f = f->next)
+  {
+    pet = f->follower;
+    event = char_has_mud_event(pet, ePURGEMOB);
+    if (mud_event_is_live(event))
+      remaining = mud_event_remaining(event);
+    else if (pet->affected && IS_SET_AR(pet->affected->bitvector, AFF_CHARM))
+      restored_control_duration = pet->affected->duration;
+  }
+  extract_all_followers(&fixture.owner);
+
+  /* The deadline passes offline: the row is refused and the next snapshot
+   * drops it while the roster is still considered fully restored. */
+  snprintf(query, sizeof(query),
+           "UPDATE pet_data SET runtime_state = REGEXP_REPLACE(runtime_state, 'T 1 [0-9]+', "
+           "'T 1 %lld') WHERE pet_state = %d",
+           now - 5, PET_STATE_ACTIVE);
+  expired_marked = mysql_query(connection, query) == 0 && mysql_affected_rows(connection) == 1;
+  fixture.owner.followers = NULL;
+  fixture.owner.pet_roster_load_state = PET_ROSTER_UNLOADED;
+  load_char_pets(&fixture.owner);
+  expired_dropped = fixture.owner.pet_roster_load_state == PET_ROSTER_LOADED &&
+                    count_followers(&fixture.owner) == 1 &&
+                    query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 2;
+  expired_row_removed = save_char_pets(&fixture.owner) &&
+                        query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 1;
+  extract_all_followers(&fixture.owner);
+  fixture.owner.followers = NULL;
+
+  /* The keeper boards neither a deadline follower nor a session summon. */
+  keeper_refuses_deadline = !pet_store_pet(&fixture.owner, &fixture.second_pet);
+  keeper_refuses_session = !pet_store_pet(&fixture.owner, &session_pet);
+  keeper_refuses_session = keeper_refuses_session &&
+                           query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 1;
+
+  /* A decoy stabled before the policy existed is spent: reclaiming it releases
+   * the slot.  A durable stored follower still comes back. */
+  snprintf(query, sizeof(query),
+           "INSERT INTO pet_data (pet_data_id, owner_name, vnum, level, hp, max_hp, str, con, "
+           "dex, ac, intel, wis, cha, pet_state) VALUES "
+           "(900, 'SnapshotOwner', %d, 1, 10, 10, 10, 10, 10, 10, 10, 10, 10, %d), "
+           "(901, 'SnapshotOwner', 1, 1, 10, 10, 10, 10, 10, 10, 10, 10, 10, %d)",
+           PET_MISLEAD_DECOY, PET_STATE_STORED, PET_STATE_STORED);
+  stable_rows_seeded = mysql_query(connection, query) == 0;
+  reason = NULL;
+  reclaimed = pet_retrieve_stored(&fixture.owner, 900, &reason);
+  spent_stored_released =
+      reclaimed == NULL && reason != NULL && strstr(reason, "released") != NULL &&
+      query_single_int(connection, "SELECT COUNT(*) FROM pet_data WHERE pet_data_id = 900", -1) ==
+          0;
+  reason = NULL;
+  reclaimed = pet_retrieve_stored(&fixture.owner, 901, &reason);
+  snprintf(query, sizeof(query),
+           "SELECT COUNT(*) FROM pet_data WHERE pet_data_id = 901 AND pet_state = %d",
+           PET_STATE_ACTIVE);
+  live_stored_reclaimed = reclaimed != NULL && reason == NULL &&
+                          reclaimed->master == &fixture.owner && IN_ROOM(reclaimed) == 0 &&
+                          query_single_int(connection, query, -1) == 1;
+  extract_all_followers(&fixture.owner);
+  fixture.owner.followers = NULL;
+
+  clear_char_event_list(&fixture.second_pet);
+  domain_event_world_forget_character(&fixture.owner);
+  w.room.people = NULL;
+  character_list = saved_characters;
+  end_pet_lifetime_world(&w);
+  conn = saved_conn;
+  mysql_available = saved_available;
+  mysql_close(connection);
+
+  CuAssertTrue(tc, schema_created);
+  CuAssertTrue(tc, initial_saved);
+  CuAssertTrue(tc, session_not_saved);
+  CuAssertTrue(tc, deadline_saved);
+  CuAssertTrue(tc, restored_pair);
+  CuAssertTrue(tc, remaining >= 85L * PASSES_PER_SEC && remaining <= 92L * PASSES_PER_SEC);
+  CuAssertIntEquals(tc, 12, restored_control_duration);
+  CuAssertTrue(tc, expired_marked);
+  CuAssertTrue(tc, expired_dropped);
+  CuAssertTrue(tc, expired_row_removed);
+  CuAssertTrue(tc, keeper_refuses_deadline);
+  CuAssertTrue(tc, keeper_refuses_session);
+  CuAssertTrue(tc, stable_rows_seeded);
+  CuAssertTrue(tc, spent_stored_released);
+  CuAssertTrue(tc, live_stored_reclaimed);
+}
+
 void Test_follower_runtime_state_round_trip(CuTest *tc)
 {
   struct affected_type charm;
@@ -1759,7 +2044,9 @@ void Test_follower_runtime_source_supports_legacy_and_rejects_invalid_source(CuT
   clear_char(&restored);
   SET_BIT_AR(MOB_FLAGS(&source), MOB_ISNPC);
   SET_BIT_AR(MOB_FLAGS(&restored), MOB_ISNPC);
-  source.pet_source_spell = SPELL_SHAMBLER;
+  /* A kept family: an ordinary spell summon would be rejected as session-bound. */
+  SET_BIT_AR(MOB_FLAGS(&source), MOB_ANIMATED_DEAD);
+  source.pet_source_spell = SPELL_ANIMATE_DEAD;
   serialized = serialize_pet_runtime_state_for_test(&source);
   if (serialized == NULL)
   {
@@ -1778,10 +2065,20 @@ void Test_follower_runtime_source_supports_legacy_and_rejects_invalid_source(CuT
   next = strchr(line + 1, '\n');
   memmove(line, next, strlen(next) + 1);
   missing_behavior = !restore_pet_runtime_state_for_test(&restored, serialized);
+  /* Version 2 records predate the lifetime marker; drop it before downgrading. */
+  line = strstr(serialized, "\nT ");
+  if (line == NULL)
+  {
+    free(serialized);
+    CuFail(tc, "missing lifetime marker");
+    return;
+  }
+  next = strchr(line + 1, '\n');
+  memmove(line, next, strlen(next) + 1);
   serialized[2] = '2';
   restored.pet_behavior = PET_BEHAVIOR_WAIT;
   previous = restore_pet_runtime_state_for_test(&restored, serialized) &&
-             restored.pet_source_spell == SPELL_SHAMBLER &&
+             restored.pet_source_spell == SPELL_ANIMATE_DEAD &&
              restored.pet_behavior == PET_BEHAVIOR_FOLLOW;
   line = strstr(serialized, "\nP ");
   if (line == NULL)

--- a/unittests/CuTest/test_pet_lifetime.c
+++ b/unittests/CuTest/test_pet_lifetime.c
@@ -1,0 +1,349 @@
+#include "CuTest.h"
+
+#include "../../src/conf.h"
+#include "../../src/sysdep.h"
+#include "../../src/structs.h"
+#include "../../src/utils.h"
+#include "../../src/db.h"
+#include "../../src/handler.h"
+#include "../../src/magic/spells.h"
+#include "../../src/mud_event.h"
+#include "../../src/dgscript/dg_event.h"
+#include "../../src/event_runtime.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+extern char *serialize_pet_runtime_state_for_test(struct char_data *pet);
+extern bool restore_pet_runtime_state_for_test(struct char_data *pet, const char *serialized);
+
+static void begin_lifetime_pet(struct char_data *pet)
+{
+  if (!event_runtime_is_initialized())
+    event_init();
+  clear_char(pet);
+  SET_BIT_AR(MOB_FLAGS(pet), MOB_ISNPC);
+  SET_BIT_AR(AFF_FLAGS(pet), AFF_CHARM);
+}
+
+static void end_lifetime_pet(struct char_data *pet)
+{
+  struct affected_type *affect;
+
+  clear_char_event_list(pet);
+  while (pet->affected)
+  {
+    affect = pet->affected;
+    pet->affected = affect->next;
+    free(affect);
+  }
+}
+
+/* Returns a copy of serialized with its T line replaced (or removed when
+ * replacement is NULL).  Returns NULL when there is no T line. */
+static char *with_lifetime_line(const char *serialized, const char *replacement)
+{
+  const char *line;
+  const char *next;
+  size_t prefix;
+  size_t size;
+  char *copy;
+
+  line = strstr(serialized, "\nT ");
+  if (line == NULL)
+    return NULL;
+  line++;
+  next = strchr(line, '\n');
+  if (next == NULL)
+    return NULL;
+  next++;
+  prefix = (size_t)(line - serialized);
+  size = strlen(serialized) + (replacement ? strlen(replacement) + 2 : 1);
+  copy = malloc(size);
+  if (copy == NULL)
+    return NULL;
+  memcpy(copy, serialized, prefix);
+  copy[prefix] = '\0';
+  if (replacement)
+  {
+    strlcat(copy, replacement, size);
+    strlcat(copy, "\n", size);
+  }
+  strlcat(copy, next, size);
+  return copy;
+}
+
+static long long saved_deadline(const char *serialized)
+{
+  const char *line;
+  int kind;
+  long long deadline;
+
+  line = strstr(serialized, "\nT ");
+  if (line == NULL || sscanf(line, "\nT %d %lld", &kind, &deadline) != 2 || kind != 1)
+    return -1;
+  return deadline;
+}
+
+void Test_pet_lifetime_deadline_survives_save_and_restores_a_fresh_event(CuTest *tc)
+{
+  struct char_data source;
+  struct char_data restored;
+  struct mud_event_data *event;
+  char *first;
+  char *second;
+  long long now;
+  long long first_deadline;
+  long long second_deadline;
+  long remaining;
+  bool restored_ok;
+  enum pet_lifetime_kind source_kind;
+
+  begin_lifetime_pet(&source);
+  begin_lifetime_pet(&restored);
+  attach_mud_event(new_mud_event(ePURGEMOB, &source, NULL), 90 * PASSES_PER_SEC);
+  now = (long long)time(NULL);
+
+  first = serialize_pet_runtime_state_for_test(&source);
+  second = serialize_pet_runtime_state_for_test(&source);
+  if (first == NULL || second == NULL)
+  {
+    free(first);
+    free(second);
+    end_lifetime_pet(&source);
+    CuFail(tc, "could not serialize the timed follower");
+    return;
+  }
+  first_deadline = saved_deadline(first);
+  second_deadline = saved_deadline(second);
+  source_kind = pet_lifetime_kind(&source);
+
+  restored_ok = restore_pet_runtime_state_for_test(&restored, first);
+  event = char_has_mud_event(&restored, ePURGEMOB);
+  remaining = mud_event_is_live(event) ? mud_event_remaining(event) : -1;
+
+  free(first);
+  free(second);
+  end_lifetime_pet(&source);
+  end_lifetime_pet(&restored);
+
+  CuAssertIntEquals(tc, PET_LIFETIME_DEADLINE, source_kind);
+  /* The saved deadline is absolute real time, so repeated saves agree. */
+  CuAssertTrue(tc, first_deadline >= now + 89 && first_deadline <= now + 92);
+  CuAssertTrue(tc, second_deadline >= first_deadline && second_deadline <= first_deadline + 1);
+  CuAssertTrue(tc, restored_ok);
+  CuAssertTrue(tc, remaining >= 87L * PASSES_PER_SEC && remaining <= 92L * PASSES_PER_SEC);
+}
+
+void Test_pet_lifetime_rejects_expired_and_malformed_records(CuTest *tc)
+{
+  struct char_data source;
+  struct char_data restored;
+  char *durable;
+  char *record;
+  char expired_line[64];
+  const char *malformed[] = {"T 2 5", "T 0 5", "T 1 0", "T 1 -5", "T 1 x", "T 1", "T 0 0 7"};
+  bool expired_rejected;
+  bool malformed_rejected;
+  bool missing_rejected;
+  bool legacy_line_rejected;
+  bool legacy_durable;
+  bool no_event_after_rejection;
+  size_t i;
+
+  begin_lifetime_pet(&source);
+  begin_lifetime_pet(&restored);
+  durable = serialize_pet_runtime_state_for_test(&source);
+  if (durable == NULL || strstr(durable, "\nT 0 0\n") == NULL)
+  {
+    free(durable);
+    end_lifetime_pet(&source);
+    CuFail(tc, "durable follower did not serialize a durable lifetime record");
+    return;
+  }
+
+  snprintf(expired_line, sizeof(expired_line), "T 1 %lld", (long long)time(NULL) - 5);
+  record = with_lifetime_line(durable, expired_line);
+  expired_rejected = record != NULL && !restore_pet_runtime_state_for_test(&restored, record);
+  no_event_after_rejection = char_has_mud_event(&restored, ePURGEMOB) == NULL;
+  free(record);
+
+  malformed_rejected = true;
+  for (i = 0; i < sizeof(malformed) / sizeof(malformed[0]); i++)
+  {
+    record = with_lifetime_line(durable, malformed[i]);
+    malformed_rejected = malformed_rejected && record != NULL &&
+                         !restore_pet_runtime_state_for_test(&restored, record);
+    free(record);
+  }
+
+  /* A version 4 record must carry its lifetime line. */
+  record = with_lifetime_line(durable, NULL);
+  missing_rejected = record != NULL && !restore_pet_runtime_state_for_test(&restored, record);
+  /* Older versions never carried one; a stray line is malformed there. */
+  if (record != NULL)
+    record[2] = '3';
+  legacy_durable = record != NULL && restore_pet_runtime_state_for_test(&restored, record) &&
+                   char_has_mud_event(&restored, ePURGEMOB) == NULL &&
+                   pet_lifetime_kind(&restored) == PET_LIFETIME_DURABLE;
+  free(record);
+  durable[2] = '3';
+  legacy_line_rejected = !restore_pet_runtime_state_for_test(&restored, durable);
+
+  free(durable);
+  end_lifetime_pet(&source);
+  end_lifetime_pet(&restored);
+
+  CuAssertTrue(tc, expired_rejected);
+  CuAssertTrue(tc, no_event_after_rejection);
+  CuAssertTrue(tc, malformed_rejected);
+  CuAssertTrue(tc, missing_rejected);
+  CuAssertTrue(tc, legacy_durable);
+  CuAssertTrue(tc, legacy_line_rejected);
+}
+
+void Test_pet_lifetime_decoys_never_persist_without_a_deadline(CuTest *tc)
+{
+  struct char_data decoy;
+  struct char_data restored;
+  char *record;
+  char *legacy;
+  long long now;
+  long long deadline;
+  enum pet_lifetime_kind decoy_kind;
+  bool spent_rejected;
+  bool legacy_rejected;
+
+  begin_lifetime_pet(&decoy);
+  begin_lifetime_pet(&restored);
+  decoy.pet_source_spell = SPELL_MISLEAD;
+  restored.pet_source_spell = SPELL_MISLEAD;
+  now = (long long)time(NULL);
+  record = serialize_pet_runtime_state_for_test(&decoy);
+  if (record == NULL)
+  {
+    end_lifetime_pet(&decoy);
+    CuFail(tc, "could not serialize the decoy");
+    return;
+  }
+  deadline = saved_deadline(record);
+  decoy_kind = pet_lifetime_kind(&decoy);
+  spent_rejected = !restore_pet_runtime_state_for_test(&restored, record);
+  /* A pre-lifetime record for a decoy is expired, not promoted to durable. */
+  legacy = with_lifetime_line(record, NULL);
+  if (legacy != NULL)
+    legacy[2] = '3';
+  legacy_rejected = legacy != NULL && !restore_pet_runtime_state_for_test(&restored, legacy) &&
+                    char_has_mud_event(&restored, ePURGEMOB) == NULL;
+  free(legacy);
+  free(record);
+  end_lifetime_pet(&decoy);
+  end_lifetime_pet(&restored);
+
+  CuAssertIntEquals(tc, PET_LIFETIME_DEADLINE, decoy_kind);
+  /* A decoy with no live event is saved already spent, never as durable. */
+  CuAssertTrue(tc, deadline >= now && deadline <= now + 1);
+  CuAssertTrue(tc, spent_rejected);
+  CuAssertTrue(tc, legacy_rejected);
+}
+
+void Test_pet_lifetime_status_reports_each_policy(CuTest *tc)
+{
+  struct char_data pet;
+  struct affected_type control;
+  char status[64];
+  bool durable;
+  bool timed_control;
+  bool deadline;
+
+  begin_lifetime_pet(&pet);
+  pet_lifetime_status(&pet, status, sizeof(status));
+  durable = pet_lifetime_kind(&pet) == PET_LIFETIME_DURABLE && !strcmp(status, "durable");
+
+  new_affect(&control);
+  control.spell = SPELL_CHARM_MONSTER;
+  control.duration = 9;
+  SET_BIT_AR(control.bitvector, AFF_CHARM);
+  affect_to_char(&pet, &control);
+  pet_lifetime_status(&pet, status, sizeof(status));
+  timed_control =
+      pet_lifetime_kind(&pet) == PET_LIFETIME_CONTROL && strstr(status, "timed control") != NULL;
+
+  attach_mud_event(new_mud_event(ePURGEMOB, &pet, NULL), 125 * PASSES_PER_SEC);
+  pet_lifetime_status(&pet, status, sizeof(status));
+  deadline = pet_lifetime_kind(&pet) == PET_LIFETIME_DEADLINE &&
+             strstr(status, "expires in 2m") != NULL && strstr(status, "real time") != NULL;
+
+  end_lifetime_pet(&pet);
+
+  CuAssertTrue(tc, durable);
+  CuAssertTrue(tc, timed_control);
+  CuAssertTrue(tc, deadline);
+}
+
+/* Ordinary spell summons outside the kept families last only for the session:
+ * they are not saved, the keeper refuses them, and a saved record of one is
+ * rejected on restore. */
+void Test_pet_lifetime_session_summons_are_never_saved(CuTest *tc)
+{
+  struct char_data summon;
+  struct char_data restored;
+  struct affected_type control;
+  char status[64];
+  char *record;
+  bool session;
+  bool kept_family;
+  bool timed_control_kept;
+  bool deadline_not_boarded;
+  bool record_rejected;
+  bool legacy_rejected;
+
+  begin_lifetime_pet(&summon);
+  begin_lifetime_pet(&restored);
+  summon.pet_source_spell = SPELL_SUMMON_CREATURE_1;
+  pet_lifetime_status(&summon, status, sizeof(status));
+  session = pet_lifetime_kind(&summon) == PET_LIFETIME_SESSION && !pet_lifetime_persists(&summon) &&
+            !pet_keeper_accepts(&summon) && strstr(status, "not saved") != NULL;
+
+  record = serialize_pet_runtime_state_for_test(&summon);
+  if (record == NULL)
+  {
+    end_lifetime_pet(&summon);
+    end_lifetime_pet(&restored);
+    CuFail(tc, "could not serialize the session summon");
+    return;
+  }
+  record_rejected = !restore_pet_runtime_state_for_test(&restored, record);
+  record[2] = '3';
+  legacy_rejected = !restore_pet_runtime_state_for_test(&restored, record);
+  free(record);
+
+  /* Permanent creations keep even though a spell made them. */
+  SET_BIT_AR(MOB_FLAGS(&summon), MOB_ANIMATED_DEAD);
+  kept_family = pet_lifetime_kind(&summon) == PET_LIFETIME_DURABLE &&
+                pet_lifetime_persists(&summon) && pet_keeper_accepts(&summon);
+  REMOVE_BIT_AR(MOB_FLAGS(&summon), MOB_ANIMATED_DEAD);
+
+  new_affect(&control);
+  control.spell = SPELL_CHARM_MONSTER;
+  control.duration = 9;
+  SET_BIT_AR(control.bitvector, AFF_CHARM);
+  affect_to_char(&summon, &control);
+  timed_control_kept =
+      pet_lifetime_kind(&summon) == PET_LIFETIME_CONTROL && pet_keeper_accepts(&summon);
+
+  attach_mud_event(new_mud_event(ePURGEMOB, &summon, NULL), 60 * PASSES_PER_SEC);
+  deadline_not_boarded = pet_lifetime_kind(&summon) == PET_LIFETIME_DEADLINE &&
+                         pet_lifetime_persists(&summon) && !pet_keeper_accepts(&summon);
+
+  end_lifetime_pet(&summon);
+  end_lifetime_pet(&restored);
+
+  CuAssertTrue(tc, session);
+  CuAssertTrue(tc, record_rejected);
+  CuAssertTrue(tc, legacy_rejected);
+  CuAssertTrue(tc, kept_family);
+  CuAssertTrue(tc, timed_control_kept);
+  CuAssertTrue(tc, deadline_not_boarded);
+}


### PR DESCRIPTION
Fixes #119

## Problem

`save_char_pets()` / `load_char_pets()` preserved substantial runtime state but not the remaining `ePURGEMOB` lifetime. A temporary follower such as an illusory decoy could reload without its expiration event and live forever. Every charmed NPC was also implicitly persistent, so ordinary spell summons reloaded across logouts.

## Policy

Follower persistence is now explicit (`pet_lifetime_kind()` in `src/utils.c`):

- **Durable** (companions, familiars, mounts, dragon mounts, eidolons, golems, mercenaries, animated dead, lycanthropes, totem spirits, purchased or charmed followers with no spell source): persist until dismissed, killed, or stored.
- **Timed control** (a charm affect with a duration): the remaining affect duration is saved as before and pauses while the owner is offline.
- **Deadline** (a live `ePURGEMOB` event, plus illusory decoys, which never persist without one): an absolute real-time deadline that keeps elapsing offline, across reboots and copyovers.
- **Session** (any other spell summon: summoned creatures, allies, genies, shamblers, planar allies, and so on): lasts while the owner plays and is never saved. A saved record of one is rejected on restore.

The pet keeper boards only durable and timed-control followers. Reclaiming a stored row whose lifetime has ended (for example a decoy stabled before this policy existed) deletes the row and its objects inside the reclaim transaction and tells the player the keeper released it, so the stable slot is not held forever.

## Changes

- Runtime-state record version 4 adds a validated `T <kind> <epoch>` line bound to the existing pet row identity. The scheduler handle is never persisted. The existing versioned parser and the atomic snapshot contract are unchanged.
- Restore rejects an expired record, a decoy record without a deadline, and a session-summon record; the roomless copy is discarded and logged. Active rows are dropped by the next snapshot; stored rows are deleted on reclaim. Live deadline records get a fresh native `ePURGEMOB` for the remaining time, and the restore fails closed if that event cannot be scheduled.
- `save_char_pets()` skips session followers; `pet_store_pet()` and the keeper's `stable store` refuse session and deadline followers with a player-facing message.
- `pets` shows each pet's persistence policy and remaining real time, with a footer explaining offline behavior.
- Help updated in `lib/text/help/help.hlp` and `sql/components/help_pet_entries.sql` (PETS and STABLE). `docs/systems/SAVE_SYSTEMS_BREAKDOWN.md` updated.

## Tests

`unittests/CuTest/test_pet_lifetime.c` covers the record format: deadline round trip with a fresh event, repeated saves agreeing on the absolute deadline, expired restoration rejected with no event, malformed records, missing or stray lifetime lines by version, legacy v3 records restoring as durable, decoys saved as spent without a live event, session summons classified and rejected, keeper acceptance per kind, and status output for every policy.

`Test_pet_lifetime_survives_snapshot_restore_and_keeper_release` in `unittests/CuTest/test_database_persistence.c` drives the production path against MariaDB (`LUMINARI_TEST_MYSQL_ENABLE=1`) with real prototypes and a room: `save_char_pets()` skips the session summon and stores the absolute deadline; `load_char_pets()` republishes the deadline follower with a fresh event and the control follower with its affect; an expired active row is refused on reload while the roster still counts as fully restored and the next `save_char_pets()` drops it; `pet_store_pet()` refuses deadline and session followers; `pet_retrieve_stored()` deletes a spent legacy stored decoy and reports the release, and still reclaims a live durable stored follower into the room. Disconnect, reboot, and copyover all reach persistence through these same functions.

https://claude.ai/code/session_01Adu1bF5vNR7Drp3a9oKR97
