### PR TITLE
Bound pet restore to current capacity and stable the rest

### DIFF
--- a/docs/ongoing-projects/PET_SYSTEM_REFACTOR_PHASE_2_PLAN.md
+++ b/docs/ongoing-projects/PET_SYSTEM_REFACTOR_PHASE_2_PLAN.md
@@ -15,6 +15,9 @@ See [Phase 1](PET_SYSTEM_REFACTOR_PLAN.md) for remaining gameplay parity work.
     explicit player and pet priority.
   - Keep rejected or malformed rows saved for recovery, publish no partial inventory, and ensure a
     retry never duplicates a pet already restored by stable ID.
+  - Outcome: a malformed row keeps every row saved and nothing published. A rejected
+    keeper-eligible row moves to the keeper (`PET_STATE_STORED`) for reclaim; a rejected timed
+    row is spent and leaves with the next snapshot, matching the tested expiry contract.
 
 - [ ] Close callback and transaction edge cases:
   - Define and test equipment and mobile callback behavior while a pet is prepared outside a room.

--- a/docs/ongoing-projects/PET_SYSTEM_REFACTOR_PHASE_2_PLAN.md
+++ b/docs/ongoing-projects/PET_SYSTEM_REFACTOR_PHASE_2_PLAN.md
@@ -9,7 +9,7 @@ See [Phase 1](PET_SYSTEM_REFACTOR_PLAN.md) for remaining gameplay parity work.
   - Leave intentionally permanent pets permanent.
   - Handle legacy rows without inventing a finite deadline that was never recorded.
 
-- [ ] Finish bounded restore and admission correctness:
+- [x] Finish bounded restore and admission correctness (issue 118):
   - Decode and validate all of an owner's saved pets before exposing any of them to gameplay.
   - Select a deterministic allowed set when current capacity is lower than the saved roster, with
     explicit player and pet priority.

--- a/docs/systems/SAVE_SYSTEMS_BREAKDOWN.md
+++ b/docs/systems/SAVE_SYSTEMS_BREAKDOWN.md
@@ -186,9 +186,17 @@ fields, runtime state, and validated object rows. Keeper retrieval reuses the
 same row decoder. Each pet and its inventory are prepared outside any room;
 keeper retrieval commits the stored-to-active transition before placement,
 following, and mobile load triggers. Known activation/commit failures discard the
-roomless copy and retain the stored record and inventory. Login publishes each
-prepared row separately; whole-owner admission and post-publication callback
-reconciliation remain open. Legacy rows with a NULL runtime state retain the compatibility
+roomless copy and retain the stored record and inventory. Login decodes every
+active row before publishing any of them: one undecodable row keeps the whole
+roster unpublished and retained. The staged roster is then ordered
+keeper-eligible first, then timed, oldest `pet_data_id` first, and
+`select_restorable_followers()` in `src/utils.c` admits it first-fit against the
+same category accounting used by live admission. Rejected keeper-eligible rows
+are moved to `PET_STATE_STORED` in one transaction before anything is published,
+so the next active snapshot cannot drop them; a rejected timed follower is spent
+and its row leaves with the next snapshot. Keeper reclaim applies the same check
+to the staged pet, so classification uses the saved source and flags rather than
+the prototype. Post-publication callback reconciliation remains open. Legacy rows with a NULL runtime state retain the compatibility
 load path. Custom names use the existing name/short/long text fields.
 `pets <pet|#id> name <name>` stages the new strings and restores the old pointers
 on known save failure. Prototype keywords remain available for targeting;

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -9832,9 +9832,10 @@ follower whose time ran out before the policy existed is released when you try
 to reclaim it, freeing its slot. The keeper holds up to 10 followers for you.
 
 When you log in with more saved followers than you can currently control, each
-follower you cannot control is handed to the keeper instead of being lost, and
-the login message names it with the limit that refused it. This can take the
-keeper past its usual 10; reclaim them once you have room.
+keeper-eligible follower you cannot control is handed to the keeper instead of
+being lost, and the login message names it with the limit that refused it.
+This can take the keeper past its usual 10; reclaim them once you have room.
+A timed follower that does not fit is spent instead of stored.
 
 STABLE RECLAIM returns a stabled follower by its listed number - the small
 number shown beside it, such as 'stable reclaim 1'. The longer stable ID in the

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -9831,6 +9831,11 @@ control. Timed summons and ordinary spell summons are refused. A stabled
 follower whose time ran out before the policy existed is released when you try
 to reclaim it, freeing its slot. The keeper holds up to 10 followers for you.
 
+When you log in with more saved followers than you can currently control, each
+follower you cannot control is handed to the keeper instead of being lost, and
+the login message names it with the limit that refused it. This can take the
+keeper past its usual 10; reclaim them once you have room.
+
 STABLE RECLAIM returns a stabled follower by its listed number - the small
 number shown beside it, such as 'stable reclaim 1'. The longer stable ID in the
 listing also works. A reclaimed follower returns with the same
@@ -23728,6 +23733,10 @@ A separated retainer must be recalled with summon before calling another.
 Horn of Henekar recruitment uses each creature's control category. Failed
 recruitment or Oaken Defender creation leaves that power's recharge ready.
 
+When you log in, every saved pet is checked before any of them returns. If
+you can no longer control the whole roster, durable pets are restored first
+and then timed ones, oldest saved ID first. A durable pet that does not fit
+waits with the keeper (see STABLE); a timed one that does not fit is spent.
 Use 'pets restore' after a login where some saved pets could not be
 restored; the saved records are kept and pets already with you are not
 duplicated.

--- a/sql/components/help_pet_entries.sql
+++ b/sql/components/help_pet_entries.sql
@@ -136,6 +136,10 @@ A separated retainer must be recalled with summon before calling another.
 Horn of Henekar recruitment uses each creature''s control category. Failed
 recruitment or Oaken Defender creation leaves that power''s recharge ready.
 
+When you log in, every saved pet is checked before any of them returns. If
+you can no longer control the whole roster, durable pets are restored first
+and then timed ones, oldest saved ID first. A durable pet that does not fit
+waits with the keeper (see STABLE); a timed one that does not fit is spent.
 Use ''pets restore'' after a login where some saved pets could not be
 restored; the saved records are kept and pets already with you are not
 duplicated.
@@ -185,6 +189,11 @@ The keeper boards only followers that stay with you: durable pets and timed
 control. Timed summons and ordinary spell summons are refused. A stabled
 follower whose time ran out before the policy existed is released when you try
 to reclaim it, freeing its slot. The keeper holds up to 10 followers for you.
+
+When you log in with more saved followers than you can currently control, each
+follower you cannot control is handed to the keeper instead of being lost, and
+the login message names it with the limit that refused it. This can take the
+keeper past its usual 10; reclaim them once you have room.
 
 STABLE RECLAIM returns a stabled follower by its listed number - the small
 number shown beside it, such as ''stable reclaim 1''. The longer stable ID in the

--- a/sql/components/help_pet_entries.sql
+++ b/sql/components/help_pet_entries.sql
@@ -191,9 +191,10 @@ follower whose time ran out before the policy existed is released when you try
 to reclaim it, freeing its slot. The keeper holds up to 10 followers for you.
 
 When you log in with more saved followers than you can currently control, each
-follower you cannot control is handed to the keeper instead of being lost, and
-the login message names it with the limit that refused it. This can take the
-keeper past its usual 10; reclaim them once you have room.
+keeper-eligible follower you cannot control is handed to the keeper instead of
+being lost, and the login message names it with the limit that refused it.
+This can take the keeper past its usual 10; reclaim them once you have room.
+A timed follower that does not fit is spent instead of stored.
 
 STABLE RECLAIM returns a stabled follower by its listed number - the small
 number shown beside it, such as ''stable reclaim 1''. The longer stable ID in the

--- a/src/players.c
+++ b/src/players.c
@@ -7046,6 +7046,8 @@ cleanup:
 /* Restore one saved pet row for its owner.  Both login restore and keeper
  * retrieval publish a pet through this single path so validation, identity, and
  * failure handling stay identical. */
+#define PET_DENIAL_REASON_LENGTH 64
+
 /* A retry after a partial restore must not publish a pet twice.  Live pets keep
  * their saved row identity, so an already published row is simply skipped. */
 static bool pet_row_already_published(struct char_data *ch, long int pet_idnum)
@@ -7331,16 +7333,95 @@ static struct char_data *publish_saved_pet(struct char_data *owner, struct char_
   return pet;
 }
 
+/* Rejected keeper-eligible followers move to the keeper so the next active
+ * snapshot cannot drop them; a rejected timed follower is spent, and its row
+ * leaves with the next snapshot exactly like an expired one. */
+static bool stable_rejected_saved_pets(struct char_data *ch, struct char_data **staged,
+                                       const bool *admitted, int count)
+{
+  char query[128];
+  int i;
+  bool transaction_started = false;
+
+  for (i = 0; i < count; i++)
+    if (!admitted[i] && pet_keeper_accepts(staged[i]))
+      break;
+  if (i == count)
+    return true;
+  if (mysql_query(conn, "START TRANSACTION"))
+  {
+    log("SYSERR: %s: Unable to start stabling for %s: %s", __func__, GET_NAME(ch),
+        mysql_error(conn));
+    return false;
+  }
+  transaction_started = true;
+  for (; i < count; i++)
+  {
+    if (admitted[i] || !pet_keeper_accepts(staged[i]))
+      continue;
+    snprintf(query, sizeof(query),
+             "UPDATE pet_data SET pet_state = %d WHERE pet_data_id = %ld AND pet_state = %d",
+             PET_STATE_STORED, staged[i]->pet_data_id, PET_STATE_ACTIVE);
+    if (mysql_query(conn, query) || mysql_affected_rows(conn) != 1)
+    {
+      log("SYSERR: %s: Unable to stable rejected saved follower %ld for %s: %s", __func__,
+          staged[i]->pet_data_id, GET_NAME(ch), mysql_error(conn));
+      goto rollback;
+    }
+  }
+  if (mysql_query(conn, "COMMIT"))
+  {
+    log("SYSERR: %s: Unable to commit stabling for %s: %s", __func__, GET_NAME(ch),
+        mysql_error(conn));
+    goto rollback;
+  }
+  return true;
+
+rollback:
+  if (transaction_started && mysql_query(conn, "ROLLBACK"))
+    log("SYSERR: %s: Unable to roll back stabling for %s: %s", __func__, GET_NAME(ch),
+        mysql_error(conn));
+  return false;
+}
+
+/* Restore order is the priority when capacity is short: followers the keeper
+ * can hold come first, then timed followers, each oldest saved identity first.
+ * Rows arrive ordered by identity, so a stable partition keeps that order. */
+static void order_staged_pets(struct char_data **staged, int count)
+{
+  struct char_data *kept_pet;
+  int i, j, kept = 0;
+
+  for (i = 0; i < count; i++)
+  {
+    if (!pet_keeper_accepts(staged[i]))
+      continue;
+    kept_pet = staged[i];
+    for (j = i; j > kept; j--)
+      staged[j] = staged[j - 1];
+    staged[kept++] = kept_pet;
+  }
+}
+
+/* Every saved row is decoded before any pet enters the world.  A row that
+ * cannot be decoded keeps the whole roster unpublished and retained; an
+ * over-capacity roster publishes one deterministic allowed set and hands the
+ * rest to the keeper.  Both leave a retry unable to duplicate a pet, because
+ * published pets keep their row identity and unpublished rows stay saved. */
 void load_char_pets(struct char_data *ch)
 {
   MYSQL_RES *result;
   MYSQL_ROW row;
   struct char_data *pet;
+  struct char_data **staged = NULL;
   struct domain_entity_handle owner_handle;
+  bool *admitted = NULL;
+  char *reasons = NULL;
   char query[512];
   char *escaped_name;
   long int owner_id;
   long long owner_created;
+  int capacity, count = 0, i;
   bool restore_failed = false;
   bool expired = false;
   enum perf_entity_reason previous_entity_reason;
@@ -7391,20 +7472,66 @@ void load_char_pets(struct char_data *ch)
     return;
   }
 
+  capacity = (int)MIN(mysql_num_rows(result), (my_ulonglong)INT_MAX);
+  if (capacity > 0)
+  {
+    CREATE(staged, struct char_data *, capacity);
+    CREATE(admitted, bool, capacity);
+    CREATE(reasons, char, (size_t)capacity *PET_DENIAL_REASON_LENGTH);
+  }
+
   previous_entity_reason = PERF_entity_scope_set(PERF_ENTITY_PET_RESTORE);
-  owner_handle = domain_event_character_handle(ch);
-  while ((row = mysql_fetch_row(result)))
+  while (count < capacity && (row = mysql_fetch_row(result)))
   {
     pet = prepare_saved_pet_row(ch, row, owner_id, owner_created, &restore_failed, &expired);
-    if (pet && !publish_saved_pet(ch, pet))
+    if (pet)
+      staged[count++] = pet;
+  }
+  mysql_free_result(result);
+
+  if (!restore_failed)
+  {
+    order_staged_pets(staged, count);
+    select_restorable_followers(ch, staged, count, admitted, reasons, PET_DENIAL_REASON_LENGTH);
+    restore_failed = !stable_rejected_saved_pets(ch, staged, admitted, count);
+  }
+  if (restore_failed)
+  {
+    for (i = 0; i < count; i++)
+      discard_unpublished_saved_pet(staged[i]);
+    count = 0;
+  }
+
+  owner_handle = domain_event_character_handle(ch);
+  for (i = 0; i < count; i++)
+  {
+    pet = staged[i];
+    if (!ch)
+    {
+      discard_unpublished_saved_pet(pet);
+      continue;
+    }
+    if (!admitted[i])
+    {
+      send_to_char(ch, "%s cannot follow you right now (%s); %s\r\n",
+                   GET_NAME(pet) ? GET_NAME(pet) : "A saved follower",
+                   reasons + (size_t)i * PET_DENIAL_REASON_LENGTH,
+                   pet_keeper_accepts(pet) ? "the keeper is holding it for you."
+                                           : "its remaining time is spent.");
+      log("Info: %s: Saved follower %ld for %s was not admitted (%s)", __func__, pet->pet_data_id,
+          GET_NAME(ch), reasons + (size_t)i * PET_DENIAL_REASON_LENGTH);
+      discard_unpublished_saved_pet(pet);
+      continue;
+    }
+    if (!publish_saved_pet(ch, pet))
       restore_failed = true;
     ch = domain_event_world_resolve_character(owner_handle);
-    if (!ch)
-      break;
   }
 
   PERF_entity_scope_restore(previous_entity_reason);
-  mysql_free_result(result);
+  free(staged);
+  free(admitted);
+  free(reasons);
   if (ch && !restore_failed)
     ch->pet_roster_load_state = PET_ROSTER_LOADED;
 }
@@ -7785,7 +7912,10 @@ struct char_data *pet_retrieve_stored(struct char_data *owner, long int pet_id, 
   char *escaped_owner;
   long int owner_id;
   long long owner_created;
+  static char denial_reason[PET_DENIAL_REASON_LENGTH + 80];
+  char denial[PET_DENIAL_REASON_LENGTH];
   bool restored;
+  bool admitted;
   bool restore_failed = false;
   bool expired = false;
   enum perf_entity_reason previous_entity_reason;
@@ -7831,19 +7961,23 @@ struct char_data *pet_retrieve_stored(struct char_data *owner, long int pet_id, 
     mysql_free_result(result);
     goto rollback;
   }
-  if (!can_add_follower(owner, atoi(row[0])))
-  {
-    if (reason)
-      *reason = "You cannot take responsibility for another follower right now.";
-    mysql_free_result(result);
-    goto rollback;
-  }
   {
     previous_entity_reason = PERF_entity_scope_set(PERF_ENTITY_PET_RESTORE);
     mob = prepare_saved_pet_row(owner, row, owner_id, owner_created, &restore_failed, &expired);
     PERF_entity_scope_restore(previous_entity_reason);
   }
   mysql_free_result(result);
+  /* The staged pet carries its saved source and flags, so it is classified by
+   * its own identity rather than by its prototype. */
+  if (mob && !select_restorable_followers(owner, &mob, 1, &admitted, denial, sizeof(denial)))
+  {
+    snprintf(denial_reason, sizeof(denial_reason),
+             "You cannot take responsibility for another follower right now (%s).", denial);
+    if (reason)
+      *reason = denial_reason;
+    discard_unpublished_saved_pet(mob);
+    goto rollback;
+  }
   if (!mob && expired)
   {
     /* The row is locked by the SELECT above; release the spent follower so the

--- a/src/players.c
+++ b/src/players.c
@@ -7502,11 +7502,15 @@ void load_char_pets(struct char_data *ch)
     count = 0;
   }
 
+  /* Publication stops at the first failure so the roster is not further
+   * exposed piecemeal.  The unpublished rows stay saved, the failed state
+   * keeps the next snapshot from replacing them, and 'pets restore' retries
+   * while skipping every pet already published by identity. */
   owner_handle = domain_event_character_handle(ch);
   for (i = 0; i < count; i++)
   {
     pet = staged[i];
-    if (!ch)
+    if (!ch || restore_failed)
     {
       discard_unpublished_saved_pet(pet);
       continue;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1330,6 +1330,7 @@ static bool follower_admit(struct char_data *ch, struct char_data *pet,
   return true;
 }
 
+/* Names the category and usage that refused a pet, for players and logs. */
 static void follower_denial_reason(struct char_data *ch, struct char_data *pet,
                                    const struct follower_count_data *counts, char *reason,
                                    size_t size)
@@ -1346,6 +1347,7 @@ static void follower_denial_reason(struct char_data *ch, struct char_data *pet,
              counts->categories[category], follower_category_limit(ch, category));
 }
 
+/* Admission for one existing or staged mobile against the owner's live followers. */
 bool can_add_follower_mobile(struct char_data *ch, struct char_data *pet)
 {
   struct follower_count_data counts;

--- a/src/utils.c
+++ b/src/utils.c
@@ -1239,6 +1239,13 @@ static bool is_controlled_follower(struct char_data *owner, struct char_data *pe
   return pet != NULL && IS_PET(pet) && pet->master == owner && !MOB_FLAGGED(pet, MOB_NOTDEADYET);
 }
 
+/* The first ordinary summon has its own slot; the rest use general slots. */
+static void follower_recount_general(struct follower_count_data *counts)
+{
+  counts->general_used =
+      counts->categories[FOLLOWER_GENERAL] + MAX(0, counts->categories[FOLLOWER_SUMMON] - 1);
+}
+
 static void count_followers(struct char_data *ch, int flag, mob_vnum vnum,
                             struct follower_count_data *counts)
 {
@@ -1265,8 +1272,7 @@ static void count_followers(struct char_data *ch, int flag, mob_vnum vnum,
     if (vnum != NOBODY && pet_vnum == vnum)
       counts->matching_vnum++;
   }
-  counts->general_used =
-      counts->categories[FOLLOWER_GENERAL] + MAX(0, counts->categories[FOLLOWER_SUMMON] - 1);
+  follower_recount_general(counts);
 }
 
 static int follower_category_limit(struct char_data *ch, size_t category)
@@ -1306,20 +1312,79 @@ bool can_add_follower_by_flag(struct char_data *ch, int flag)
   return counts.matching_flag < 1;
 }
 
+/* The one admission calculation for live and staged pets.  An admitted pet is
+ * added to the counts so later decisions in the same pass see it. */
+static bool follower_admit(struct char_data *ch, struct char_data *pet,
+                           struct follower_count_data *counts)
+{
+  mob_vnum vnum = follower_vnum(pet);
+  size_t category = follower_category(pet, vnum);
+  int cost = follower_control_cost(category, vnum);
+
+  if (!follower_category_available(ch, category, counts) ||
+      counts->categories[category] + cost > follower_category_limit(ch, category))
+    return false;
+  counts->categories[category] += cost;
+  counts->total++;
+  follower_recount_general(counts);
+  return true;
+}
+
+static void follower_denial_reason(struct char_data *ch, struct char_data *pet,
+                                   const struct follower_count_data *counts, char *reason,
+                                   size_t size)
+{
+  size_t category = follower_category(pet, follower_vnum(pet));
+
+  if (category == FOLLOWER_GENERAL ||
+      (category == FOLLOWER_SUMMON &&
+       counts->categories[FOLLOWER_SUMMON] < follower_category_limit(ch, FOLLOWER_SUMMON)))
+    snprintf(reason, size, "%s: general slots %d/%d used", follower_rules[category].name,
+             counts->general_used, counts->general_limit);
+  else
+    snprintf(reason, size, "%s: %d/%d used", follower_rules[category].name,
+             counts->categories[category], follower_category_limit(ch, category));
+}
+
 bool can_add_follower_mobile(struct char_data *ch, struct char_data *pet)
 {
   struct follower_count_data counts;
-  size_t category;
-  mob_vnum vnum;
 
   if (ch == NULL || pet == NULL || !IS_NPC(pet))
     return false;
   count_followers(ch, -1, NOBODY, &counts);
-  vnum = follower_vnum(pet);
-  category = follower_category(pet, vnum);
-  return follower_category_available(ch, category, &counts) &&
-         counts.categories[category] + follower_control_cost(category, vnum) <=
-             follower_category_limit(ch, category);
+  return follower_admit(ch, pet, &counts);
+}
+
+/* Decide, before anything is published, which staged pets the owner can control
+ * alongside the followers already present.  Admission is first-fit in array
+ * order, so the caller's ordering is the priority and the result is
+ * deterministic.  A rejected entry gets a denial reason when a buffer of
+ * count * reason_size bytes is supplied. */
+int select_restorable_followers(struct char_data *ch, struct char_data **pets, int count,
+                                bool *admitted, char *reasons, size_t reason_size)
+{
+  struct follower_count_data counts;
+  int i, selected = 0;
+
+  if (ch == NULL || pets == NULL || admitted == NULL || count < 0)
+    return 0;
+  count_followers(ch, -1, NOBODY, &counts);
+  for (i = 0; i < count; i++)
+  {
+    admitted[i] = pets[i] != NULL && IS_NPC(pets[i]) && follower_admit(ch, pets[i], &counts);
+    if (admitted[i])
+      selected++;
+    else if (reasons != NULL && reason_size > 0)
+    {
+      if (pets[i] != NULL && IS_NPC(pets[i]))
+        follower_denial_reason(ch, pets[i], &counts, reasons + (size_t)i * reason_size,
+                               reason_size);
+      else
+        snprintf(reasons + (size_t)i * reason_size, reason_size, "not a controllable follower");
+    }
+  }
+  return selected;
 }
 
 bool can_add_follower(struct char_data *ch, int mob_vnum)

--- a/src/utils.h
+++ b/src/utils.h
@@ -190,6 +190,8 @@ bool has_fortune_of_many_bonus(struct char_data *ch);
 bool has_authoritative_bonus(struct char_data *ch);
 bool can_add_follower(struct char_data *ch, int mob_vnum);
 bool can_add_follower_mobile(struct char_data *ch, struct char_data *pet);
+int select_restorable_followers(struct char_data *ch, struct char_data **pets, int count,
+                                bool *admitted, char *reasons, size_t reason_size);
 bool can_add_summoned_followers(struct char_data *ch, int mob_vnum, int spell, int count);
 int summoned_follower_flag(int spell);
 bool can_add_follower_by_flag(struct char_data *ch, int flag);

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -1791,6 +1791,8 @@ void Test_pet_lifetime_survives_snapshot_restore_and_keeper_release(CuTest *tc)
   w.room.people = &fixture.owner;
   GET_MOB_RNUM(&fixture.first_pet) = 0;
   GET_MOB_RNUM(&fixture.second_pet) = 0;
+  /* Login restore is bounded by admission; two general followers need Charisma. */
+  GET_CHA(&fixture.owner) = 14;
   /* first_pet: timed control (charm affect).  second_pet: 90 second deadline.
    * session_pet: an ordinary summon with neither. */
   attach_mud_event(new_mud_event(ePURGEMOB, &fixture.second_pet, NULL), 90 * PASSES_PER_SEC);

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -2303,3 +2303,156 @@ void Test_object_saves_bind_player_house_and_serialized_text(CuTest *tc)
   mysql_close(connection);
   CuAssertTrue(tc, matched);
 }
+
+/* Bounded restore: when capacity is short the durable follower wins, a spent
+ * timed one is dropped, a rejected durable one waits with the keeper, a retry
+ * cannot duplicate anything, and one bad row keeps the whole roster unpublished. */
+void Test_pet_bounded_restore_selects_capacity_and_stables_the_rest(CuTest *tc)
+{
+  struct pet_save_fixture fixture;
+  struct pet_lifetime_world w;
+  struct char_data *saved_characters = character_list;
+  struct char_data *reclaimed;
+  MYSQL *connection;
+  MYSQL *saved_conn;
+  const char *enabled;
+  const char *reason;
+  char query[256];
+  long stored_id;
+  bool saved_available;
+  bool timed_saved, durable_wins, timed_row_dropped;
+  bool pair_saved, one_admitted, retry_inert, stored_survives_save;
+  bool reclaim_denied, reclaim_allowed, partial_refused;
+
+  enabled = getenv("LUMINARI_TEST_MYSQL_ENABLE");
+  if (enabled == NULL || strcmp(enabled, "1") != 0)
+  {
+    CuAssertTrue(tc, 1);
+    return;
+  }
+  connection = open_test_database();
+  if (connection == NULL)
+  {
+    CuFail(tc, "could not connect to the explicitly configured test database");
+    return;
+  }
+
+  saved_conn = conn;
+  saved_available = mysql_available;
+  conn = connection;
+  mysql_available = true;
+  begin_pet_lifetime_world(&w);
+  initialize_pet_save_fixture(&fixture);
+  fixture.first_pet.equipment[0] = NULL;
+  fixture.second_pet.carrying = NULL;
+  fixture.inventory_object.carried_by = NULL;
+  fixture.owner.desc = NULL;
+  fixture.descriptor.character = NULL;
+  IN_ROOM(&fixture.owner) = 0;
+  w.room.people = &fixture.owner;
+  GET_MOB_RNUM(&fixture.first_pet) = 0;
+  GET_MOB_RNUM(&fixture.second_pet) = 0;
+  /* Charisma 10 allows exactly one general follower. */
+  GET_CHA(&fixture.owner) = 10;
+
+  /* first_pet: timed control, keeper-eligible.  second_pet: real-time deadline. */
+  attach_mud_event(new_mud_event(ePURGEMOB, &fixture.second_pet, NULL), 900 * PASSES_PER_SEC);
+  timed_saved = create_pet_snapshot_temporary_schema(connection) &&
+                save_char_pets(&fixture.owner) &&
+                query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 2;
+  fixture.owner.followers = NULL;
+  fixture.owner.pet_roster_load_state = PET_ROSTER_UNLOADED;
+  load_char_pets(&fixture.owner);
+  durable_wins =
+      fixture.owner.pet_roster_load_state == PET_ROSTER_LOADED &&
+      count_followers(&fixture.owner) == 1 && fixture.owner.followers->follower &&
+      fixture.owner.followers->follower->affected != NULL &&
+      !mud_event_is_live(char_has_mud_event(fixture.owner.followers->follower, ePURGEMOB));
+  snprintf(query, sizeof(query), "SELECT COUNT(*) FROM pet_data WHERE pet_state = %d",
+           PET_STATE_STORED);
+  timed_row_dropped = query_single_int(connection, query, -1) == 0 &&
+                      query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 2 &&
+                      save_char_pets(&fixture.owner) &&
+                      query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 1;
+  extract_all_followers(&fixture.owner);
+  clear_char_event_list(&fixture.second_pet);
+
+  /* Two durable followers: the older identity is restored, the other waits. */
+  fixture.owner.followers = &fixture.first_follower;
+  fixture.owner.pet_roster_load_state = PET_ROSTER_LOADED;
+  reset_pet_save_cache_for_test();
+  pair_saved = mysql_query(connection, "DELETE FROM pet_data") == 0 &&
+               save_char_pets(&fixture.owner) &&
+               query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 2;
+  fixture.owner.followers = NULL;
+  fixture.owner.pet_roster_load_state = PET_ROSTER_UNLOADED;
+  load_char_pets(&fixture.owner);
+  snprintf(query, sizeof(query), "SELECT MIN(pet_data_id) FROM pet_data WHERE pet_state = %d",
+           PET_STATE_ACTIVE);
+  one_admitted =
+      fixture.owner.pet_roster_load_state == PET_ROSTER_LOADED &&
+      count_followers(&fixture.owner) == 1 && fixture.owner.followers->follower &&
+      fixture.owner.followers->follower->pet_data_id == query_single_int(connection, query, -1);
+  snprintf(query, sizeof(query), "SELECT MAX(pet_data_id) FROM pet_data WHERE pet_state = %d",
+           PET_STATE_STORED);
+  stored_id = query_single_int(connection, query, -1);
+  one_admitted =
+      one_admitted && stored_id > 0 && stored_id > fixture.owner.followers->follower->pet_data_id;
+  mysql_query_counter_reset();
+  load_char_pets(&fixture.owner);
+  retry_inert = mysql_query_counter_value() == 0 && count_followers(&fixture.owner) == 1;
+  reset_pet_save_cache_for_test();
+  snprintf(query, sizeof(query), "SELECT COUNT(*) FROM pet_data WHERE pet_state = %d",
+           PET_STATE_STORED);
+  stored_survives_save = save_char_pets(&fixture.owner) &&
+                         query_single_int(connection, query, -1) == 1 &&
+                         query_single_int(connection, "SELECT COUNT(*) FROM pet_data", -1) == 2;
+
+  reason = NULL;
+  reclaimed = pet_retrieve_stored(&fixture.owner, stored_id, &reason);
+  reclaim_denied = reclaimed == NULL && reason != NULL && strstr(reason, "General") != NULL &&
+                   count_followers(&fixture.owner) == 1 &&
+                   query_single_int(connection, query, -1) == 1;
+  GET_CHA(&fixture.owner) = 14;
+  reason = NULL;
+  reclaimed = pet_retrieve_stored(&fixture.owner, stored_id, &reason);
+  reclaim_allowed = reclaimed != NULL && reason == NULL && reclaimed->pet_data_id == stored_id &&
+                    count_followers(&fixture.owner) == 2 &&
+                    query_single_int(connection, query, -1) == 0;
+  extract_all_followers(&fixture.owner);
+  fixture.owner.followers = NULL;
+
+  /* One undecodable row: nothing is published and every row is retained. */
+  snprintf(query, sizeof(query),
+           "UPDATE pet_data SET runtime_state = 'invalid-versioned-record' "
+           "WHERE pet_data_id = %ld",
+           stored_id);
+  partial_refused = mysql_query(connection, query) == 0;
+  fixture.owner.pet_roster_load_state = PET_ROSTER_UNLOADED;
+  load_char_pets(&fixture.owner);
+  snprintf(query, sizeof(query), "SELECT COUNT(*) FROM pet_data WHERE pet_state = %d",
+           PET_STATE_ACTIVE);
+  partial_refused =
+      partial_refused && fixture.owner.pet_roster_load_state == PET_ROSTER_LOAD_FAILED &&
+      count_followers(&fixture.owner) == 0 && query_single_int(connection, query, -1) == 2;
+  extract_pending_chars();
+
+  domain_event_world_forget_character(&fixture.owner);
+  w.room.people = NULL;
+  character_list = saved_characters;
+  end_pet_lifetime_world(&w);
+  conn = saved_conn;
+  mysql_available = saved_available;
+  mysql_close(connection);
+
+  CuAssertTrue(tc, timed_saved);
+  CuAssertTrue(tc, durable_wins);
+  CuAssertTrue(tc, timed_row_dropped);
+  CuAssertTrue(tc, pair_saved);
+  CuAssertTrue(tc, one_admitted);
+  CuAssertTrue(tc, retry_inert);
+  CuAssertTrue(tc, stored_survives_save);
+  CuAssertTrue(tc, reclaim_denied);
+  CuAssertTrue(tc, reclaim_allowed);
+  CuAssertTrue(tc, partial_refused);
+}

--- a/unittests/CuTest/test_pet_policy.c
+++ b/unittests/CuTest/test_pet_policy.c
@@ -397,3 +397,64 @@ void Test_pet_policy_elite_undead_cost_two_control_points(CuTest *tc)
   CuAssertTrue(tc, mixed_full);
   CuAssertTrue(tc, source_cost);
 }
+
+/* Bounded restore: a staged roster is admitted first-fit in the caller's
+ * order, counted alongside live followers, and every rejection carries the
+ * category and usage that denied it. */
+void Test_pet_policy_staged_selection_is_deterministic_and_explains_denials(CuTest *tc)
+{
+  struct pet_policy_fixture fixture;
+  struct char_data *staged[5];
+  bool admitted[5];
+  char reasons[5][64];
+  int selected, i;
+  bool first_fit, reasons_named, live_counted, reordered, invalid;
+
+  /* One live general follower already uses the single Charisma slot. */
+  begin_pet_policy_fixture(&fixture, 1);
+  for (i = 0; i < 5; i++)
+    staged[i] = &fixture.pets[i + 1];
+  SET_BIT_AR(MOB_FLAGS(&fixture.pets[2]), MOB_EIDOLON);
+  GET_MOB_RNUM(&fixture.pets[3]) = real_mobile(MOB_DJINNI_KIND);
+  fixture.pets[3].pet_source_spell = SPELL_DJINNI_KIND;
+  SET_BIT_AR(MOB_FLAGS(&fixture.pets[4]), MOB_EIDOLON);
+  memset(reasons, 0, sizeof(reasons));
+  selected = select_restorable_followers(&fixture.owner, staged, 5, admitted, reasons[0],
+                                         sizeof(reasons[0]));
+  first_fit =
+      selected == 2 && !admitted[0] && admitted[1] && admitted[2] && !admitted[3] && !admitted[4];
+  reasons_named = strstr(reasons[0], "General") != NULL && strstr(reasons[0], "1/1") != NULL &&
+                  strstr(reasons[3], "Eidolon") != NULL && strstr(reasons[3], "1/1") != NULL &&
+                  strstr(reasons[4], "General") != NULL && reasons[1][0] == '\0' &&
+                  reasons[2][0] == '\0';
+
+  /* Without the live follower the first staged general pet takes the slot. */
+  fixture.owner.followers = NULL;
+  selected = select_restorable_followers(&fixture.owner, staged, 5, admitted, NULL, 0);
+  live_counted =
+      selected == 3 && admitted[0] && admitted[1] && admitted[2] && !admitted[3] && !admitted[4];
+
+  /* Order is the priority: the same roster reversed admits the other eidolon. */
+  staged[0] = &fixture.pets[5];
+  staged[1] = &fixture.pets[4];
+  staged[2] = &fixture.pets[3];
+  staged[3] = &fixture.pets[2];
+  staged[4] = &fixture.pets[1];
+  selected = select_restorable_followers(&fixture.owner, staged, 5, admitted, NULL, 0);
+  reordered =
+      selected == 3 && admitted[0] && admitted[1] && admitted[2] && !admitted[3] && !admitted[4];
+
+  staged[0] = NULL;
+  staged[1] = &fixture.owner;
+  selected = select_restorable_followers(&fixture.owner, staged, 2, admitted, reasons[0],
+                                         sizeof(reasons[0]));
+  invalid = selected == 0 && !admitted[0] && !admitted[1] && reasons[1][0] != '\0' &&
+            select_restorable_followers(NULL, staged, 2, admitted, NULL, 0) == 0 &&
+            select_restorable_followers(&fixture.owner, staged, 0, admitted, NULL, 0) == 0;
+  end_pet_policy_fixture(&fixture);
+  CuAssertTrue(tc, first_fit);
+  CuAssertTrue(tc, reasons_named);
+  CuAssertTrue(tc, live_counted);
+  CuAssertTrue(tc, reordered);
+  CuAssertTrue(tc, invalid);
+}


### PR DESCRIPTION
Fixes #118. Completes the Phase 2 bounded-restore item left open after #141.

## What changed

- `load_char_pets()` decodes and validates every active row before any pet enters the world. One undecodable row keeps the whole roster unpublished and retained for recovery; nothing partial is published.
- The staged roster is ordered keeper-eligible first, then timed, oldest saved identity first. New `select_restorable_followers()` in `src/utils.c` admits it first-fit with the same category accounting live admission uses (`can_add_follower_mobile()` now shares the helper), so the allowed set is deterministic and each rejection names the category and usage that refused it.
- Rejected keeper-eligible rows are moved to `PET_STATE_STORED` in one transaction before anything is published, so the next active snapshot cannot drop them. A rejected timed follower is spent and its row leaves with the next snapshot, like an expired one. The player is told at login which followers were held and why.
- Published pets keep their row identity, so `pets restore` cannot duplicate a pet.
- Keeper reclaim runs the same admission check against the staged pet instead of the prototype, so classification follows the saved source spell and flags.

## Tests

- `Test_pet_policy_staged_selection_is_deterministic_and_explains_denials` (production-linked, runs everywhere).
- `Test_pet_bounded_restore_selects_capacity_and_stables_the_rest` (isolated MariaDB, `LUMINARI_TEST_MYSQL_ENABLE=1`): spent timed follower dropped, over-capacity durable pair with the older identity restored and the other stored, inert retry, stored row surviving a snapshot save, reclaim denied with reason then allowed after a Charisma change, and no partial publication behind a bad row.
- Local: `make test` green (1372 tests), `make install` clean. The database-gated case needs the CI MariaDB service; no isolated test database was available locally.

## Docs and help

- PETS and STABLE help updated in `lib/text/help/help.hlp` and `sql/components/help_pet_entries.sql` (applied to the development help database).
- `docs/systems/SAVE_SYSTEMS_BREAKDOWN.md` describes the bounded restore; the Phase 2 plan item is checked off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved login restoration for saved pets and followers.
  * Durable pets are restored before timed pets when control capacity is limited.
  * Followers that cannot be restored are transferred to the keeper when eligible; timed pets that do not fit are spent.
  * Saved pets are restored consistently and denied pets now receive specific explanations.
  * Keeper reclaim checks current pet eligibility before completing the transfer.

* **Documentation**
  * Updated help and system documentation to explain restoration order, capacity limits, keeper transfers, and overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->