### PR TITLE
Free replaced eidolon descriptions and bound mission name formatting

### DIFF
--- a/src/character/evolutions.c
+++ b/src/character/evolutions.c
@@ -1470,6 +1470,7 @@ ACMD(do_eidolon)
 
     if (!strcmp(arg2, "reset"))
     {
+      free(GET_EIDOLON_SHORT_DESCRIPTION(ch));
       GET_EIDOLON_SHORT_DESCRIPTION(ch) = NULL;
       send_to_char(ch, "You've reset your eidolon short description.  This will be reflected next "
                        "time you summon your eidolon.\r\n");
@@ -1484,9 +1485,10 @@ ACMD(do_eidolon)
 
     strip_cr(arg2);
 
-    desc = strdup(arg2);
-    GET_EIDOLON_SHORT_DESCRIPTION(ch) = desc;
-    GET_SHORT(eidolon) = desc;
+    /* The owner and the eidolon each own their own copy of the text. */
+    free(GET_EIDOLON_SHORT_DESCRIPTION(ch));
+    GET_EIDOLON_SHORT_DESCRIPTION(ch) = strdup(arg2);
+    GET_SHORT(eidolon) = strdup(arg2);
     desc = strdup(arg2);
     (eidolon)->player.name = desc;
     send_to_char(ch, "You change your eidilon's short description to: %s\r\n", desc);
@@ -1510,6 +1512,7 @@ ACMD(do_eidolon)
     }
     if (!strcmp(arg2, "reset"))
     {
+      free(GET_EIDOLON_LONG_DESCRIPTION(ch));
       GET_EIDOLON_LONG_DESCRIPTION(ch) = NULL;
       send_to_char(ch, "You've reset your eidolon long description.  This will be reflected next "
                        "time you summon your eidolon.\r\n");
@@ -1529,8 +1532,9 @@ ACMD(do_eidolon)
 
     desc = strdup(buf);
 
+    free(GET_EIDOLON_LONG_DESCRIPTION(ch));
     GET_EIDOLON_LONG_DESCRIPTION(ch) = desc;
-    eidolon->player.long_descr = desc;
+    eidolon->player.long_descr = strdup(buf);
     snprintf(buf, sizeof(buf), "%s\n", GET_EIDOLON_LONG_DESCRIPTION(ch));
     eidolon->player.description = strdup(buf);
     send_to_char(ch, "You change your eidilon's long description to: %s\r\n", arg2);

--- a/src/character/evolutions.c
+++ b/src/character/evolutions.c
@@ -1349,12 +1349,36 @@ struct char_data *get_eidolon_in_room(struct char_data *ch)
   return NULL;
 }
 
+/* The prototype a live eidolon was loaded from, or NULL when it has none. */
+static struct char_data *eidolon_prototype(struct char_data *eidolon)
+{
+  mob_rnum rnum = GET_MOB_RNUM(eidolon);
+
+  if (mob_proto == NULL || rnum == NOBODY || rnum > top_of_mobt)
+    return NULL;
+  return &mob_proto[rnum];
+}
+
+/* Replace one of a live eidolon's description strings with a copy of text.
+ * The previous string is released unless it is still the prototype's, which
+ * mirrors the ownership rule free_char() applies to prototyped NPCs. */
+static void replace_eidolon_text(char **destination, const char *prototype_text, const char *text)
+{
+  char *copy = strdup(text);
+
+  if (copy == NULL)
+    return;
+  if (*destination != NULL && *destination != prototype_text)
+    free(*destination);
+  *destination = copy;
+}
+
 ACMD(do_eidolon)
 {
   char arg[MAX_INPUT_LENGTH] = {'\0'}, arg2[MAX_INPUT_LENGTH] = {'\0'},
        buf[MAX_INPUT_LENGTH] = {'\0'};
   struct char_data *eidolon = NULL;
-  char *desc = NULL;
+  struct char_data *prototype = NULL;
   int i = 0, count = 0;
 
   half_chop_c(argument, arg, sizeof(arg), arg2, sizeof(arg2));
@@ -1488,10 +1512,11 @@ ACMD(do_eidolon)
     /* The owner and the eidolon each own their own copy of the text. */
     free(GET_EIDOLON_SHORT_DESCRIPTION(ch));
     GET_EIDOLON_SHORT_DESCRIPTION(ch) = strdup(arg2);
-    GET_SHORT(eidolon) = strdup(arg2);
-    desc = strdup(arg2);
-    (eidolon)->player.name = desc;
-    send_to_char(ch, "You change your eidilon's short description to: %s\r\n", desc);
+    prototype = eidolon_prototype(eidolon);
+    replace_eidolon_text(&eidolon->player.short_descr,
+                         prototype ? prototype->player.short_descr : NULL, arg2);
+    replace_eidolon_text(&eidolon->player.name, prototype ? prototype->player.name : NULL, arg2);
+    send_to_char(ch, "You change your eidilon's short description to: %s\r\n", arg2);
     return;
   }
   else if (is_abbrev(arg, "longdesc"))
@@ -1530,13 +1555,14 @@ ACMD(do_eidolon)
     strlcpy(buf, arg2, sizeof(buf));
     strlcat(buf, "\r\n", sizeof(buf));
 
-    desc = strdup(buf);
-
     free(GET_EIDOLON_LONG_DESCRIPTION(ch));
-    GET_EIDOLON_LONG_DESCRIPTION(ch) = desc;
-    eidolon->player.long_descr = strdup(buf);
-    snprintf(buf, sizeof(buf), "%s\n", GET_EIDOLON_LONG_DESCRIPTION(ch));
-    eidolon->player.description = strdup(buf);
+    GET_EIDOLON_LONG_DESCRIPTION(ch) = strdup(buf);
+    prototype = eidolon_prototype(eidolon);
+    replace_eidolon_text(&eidolon->player.long_descr,
+                         prototype ? prototype->player.long_descr : NULL, buf);
+    strlcat(buf, "\n", sizeof(buf));
+    replace_eidolon_text(&eidolon->player.description,
+                         prototype ? prototype->player.description : NULL, buf);
     send_to_char(ch, "You change your eidilon's long description to: %s\r\n", arg2);
     return;
   }

--- a/src/players.c
+++ b/src/players.c
@@ -8133,6 +8133,7 @@ void set_eidolon_descs(struct char_data *ch)
   if (mysql_query(conn, query))
   {
     log("SYSERR: 1 Unable to SELECT from player_eidolons: %s", mysql_error(conn));
+    return;
   }
 
   if (!(result = mysql_store_result(conn)))
@@ -8143,8 +8144,11 @@ void set_eidolon_descs(struct char_data *ch)
 
   if ((row = mysql_fetch_row(result)))
   {
-    GET_EIDOLON_SHORT_DESCRIPTION(ch) = strdup(row[2]);
-    GET_EIDOLON_LONG_DESCRIPTION(ch) = strdup(row[3]);
+    /* The owner keeps its own copies; release the previous ones before replacing them. */
+    free(GET_EIDOLON_SHORT_DESCRIPTION(ch));
+    free(GET_EIDOLON_LONG_DESCRIPTION(ch));
+    GET_EIDOLON_SHORT_DESCRIPTION(ch) = row[2] ? strdup(row[2]) : NULL;
+    GET_EIDOLON_LONG_DESCRIPTION(ch) = row[3] ? strdup(row[3]) : NULL;
   }
 
   mysql_free_result(result);

--- a/src/quest/missions.c
+++ b/src/quest/missions.c
@@ -513,24 +513,24 @@ void create_mission_mobs(char_data *ch)
 
     mob->mission_owner = GET_IDNUM(ch);
 
-    sprintf(buf, "%s %s %s %ld -%s",
-            AN(mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))]),
-            mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))],
-            (i > 0) ? " guard" : random_npc_names[randName], (i == 0) ? GET_IDNUM(ch) : 0,
-            GET_NAME(ch));
+    snprintf(buf, sizeof(buf), "%s %s %s %ld -%s",
+             AN(mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))]),
+             mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))],
+             (i > 0) ? " guard" : random_npc_names[randName], (i == 0) ? GET_IDNUM(ch) : 0,
+             GET_NAME(ch));
     mob->player.name = strdup(buf);
 
-    sprintf(buf, "%s %s%s%s",
-            AN(mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))]),
-            mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))],
-            (i > 0) ? "" : " named ", (i > 0) ? " guard" : random_npc_names[randName]);
+    snprintf(buf, sizeof(buf), "%s %s%s%s",
+             AN(mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))]),
+             mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))],
+             (i > 0) ? "" : " named ", (i > 0) ? " guard" : random_npc_names[randName]);
     mob->player.short_descr = strdup(buf);
 
-    sprintf(buf, "%s %s%s%s (%s) is here.\r\n",
-            AN(mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))]),
-            mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))],
-            (i > 0) ? "" : " named ", (i > 0) ? " guard" : random_npc_names[randName],
-            GET_NAME(ch));
+    snprintf(buf, sizeof(buf), "%s %s%s%s (%s) is here.\r\n",
+             AN(mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))]),
+             mission_targets[mission_details_to_faction(GET_MISSION_FACTION(ch))],
+             (i > 0) ? "" : " named ", (i > 0) ? " guard" : random_npc_names[randName],
+             GET_NAME(ch));
     mob->player.long_descr = strdup(buf);
 
     if (real_room(to_room) != NOWHERE)
@@ -545,7 +545,7 @@ void create_mission_mobs(char_data *ch)
 
       if (i > 0)
       {
-        sprintf(buf, "%ld", GET_IDNUM(ch));
+        snprintf(buf, sizeof(buf), "%ld", GET_IDNUM(ch));
         do_follow(mob, strdup(buf), 0, 0);
       }
     }

--- a/unittests/CuTest/test_gameplay_e2e.c
+++ b/unittests/CuTest/test_gameplay_e2e.c
@@ -8458,6 +8458,11 @@ static void verify_named_pet_keeper_round_trip(CuTest *tc, bool eidolon)
   mysql_available = saved_available;
   mysql_close(connection);
   ProtocolDestroy(descriptor.pProtocol);
+  if (descriptor.large_outbuf != NULL)
+  {
+    free(descriptor.large_outbuf->text);
+    free(descriptor.large_outbuf);
+  }
   free(GET_EIDOLON_SHORT_DESCRIPTION((&owner)));
   free(GET_EIDOLON_LONG_DESCRIPTION((&owner)));
 


### PR DESCRIPTION
## Summary

Fixes #148 and resolves code-scanning alerts 870 and 871.

- `set_eidolon_descs()` in `src/players.c` replaced the owner's eidolon short/long description strings on every `call eidolon` and stored-pet restore without freeing the previous copies. This is the source of the LeakSanitizer report through `pet_retrieve_stored()`. It now frees the old strings before loading, returns on a failed query instead of falling through, and tolerates NULL columns.
- The `eidolon shortdesc` / `eidolon longdesc` commands in `src/character/evolutions.c` stored one heap string in both the owner and the live eidolon. With the owner now freeing its copy, that aliasing would have dangled the eidolon's pointer, so each side gets its own copy and the owner's previous text is freed on change or reset.
- `verify_named_pet_keeper_round_trip` now frees the descriptor's large output buffer, which was the remaining `vwrite_to_output` leak in the report.
- The four `sprintf()` calls in `create_mission_mobs()` (`src/quest/missions.c`) are bounded with `snprintf()` (alerts 870, 871).

## Verification

Built `cutest` with `-fsanitize=address,undefined` and ran it against a disposable MariaDB with `LUMINARI_TEST_MYSQL_ENABLE=1` and `ASAN_OPTIONS=detect_leaks=1`.

- 1371 of 1372 tests pass; no eidolon description or output buffer leaks remain.
- The single failure is `Test_syntax_check_encounter_world_boots_and_cleans_up_once`, which is environmental: the boot child connects to MariaDB on the default port while the local fixture listened on 13307. The only LeakSanitizer entry left is CuTest's own failure-message string from that test.
- Normal Autotools build and `make install` are clean with no warnings.

https://claude.ai/code/session_01C2SYmhyLPqsNNmyDqVoXkq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when loading eidolon descriptions, including cases with missing description fields or database errors.
  - Prevented outdated eidolon and summoner descriptions from being retained after updates.
  - Improved reliability when generating mission creature names and descriptions by preventing oversized text output.
  - Resolved a resource cleanup issue affecting named pet keeper gameplay checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->