### PR TITLE
Replace fake API-key encryption with an honest secret lifecycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1267,6 +1267,7 @@ set(CUTEST_TEST_SOURCES
     unittests/CuTest/test_artifacts.c
     unittests/CuTest/test_artifact_integration.c
     unittests/CuTest/test_player_rename.c
+    unittests/CuTest/test_ai_secrets.c
     unittests/CuTest/test.helpers.c
     unittests/CuTest/test.interpreter.c
     unittests/CuTest/test_transport_production.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -410,6 +410,7 @@ cutest_SOURCES = \
 	unittests/CuTest/test_artifacts.c \
 	unittests/CuTest/test_artifact_integration.c \
 	unittests/CuTest/test_player_rename.c \
+	unittests/CuTest/test_ai_secrets.c \
 	unittests/CuTest/test.helpers.c \
 	unittests/CuTest/test.interpreter.c \
 	unittests/CuTest/test_transport_production.c \
@@ -480,6 +481,7 @@ cutest_test_files = \
 	unittests/CuTest/test_artifacts.c \
 	unittests/CuTest/test_artifact_integration.c \
 	unittests/CuTest/test_player_rename.c \
+	unittests/CuTest/test_ai_secrets.c \
 	unittests/CuTest/test.helpers.c \
 	unittests/CuTest/test.interpreter.c \
 	unittests/CuTest/test_transport_production.c \

--- a/docs/systems/AI_SERVICE_README.md
+++ b/docs/systems/AI_SERVICE_README.md
@@ -336,20 +336,21 @@ ai reset             # Reset rate limits
 
 **Key Functions**:
 - `secure_memset()` - Secure memory clearing (prevents compiler optimization)
-- `encrypt_api_key()` - API key encryption (currently plaintext - TODO: AES-256)
-- `decrypt_api_key()` - API key decryption (returns allocated string)
-- `load_encrypted_api_key()` - Load API key from file
-- `sanitize_ai_input()` - Critical prompt injection prevention
+- `ai_api_key_set()` - Store the OpenAI key in the single process-private buffer
+- `ai_api_key_copy()` - Copy the key into a caller-owned buffer (thread-safe)
+- `ai_api_key_is_set()` / `ai_api_key_clear()` - Query and wipe the stored key
+- `sanitize_ai_input()` - Critical prompt injection prevention (caller buffer)
 
 **Security Features**:
 - Input sanitization for prompt injection prevention
-- API key storage (currently plaintext - encryption planned)
+- One mutex-guarded in-memory copy of the API key, never persisted or logged
 - Secure memory operations to prevent key leakage
 - Control character filtering
 - JSON special character escaping
 - Works for both OpenAI and Ollama prompts
 
-**TODO**: Implement proper AES-256 encryption for API keys
+See "Secret Lifecycle and Threat Model" under Security Considerations for the
+honest statement of what is and is not protected.
 
 #### ai_cache.c (Response Caching)
 **Location**: `src/ai_cache.c`  
@@ -466,12 +467,58 @@ Generic Fallback
 ## Security Considerations
 
 ### Current Implementation
-- **API Key Storage**: Plaintext in .env file (AES encryption planned)
+- **API Key Storage**: Injected at runtime; see the secret lifecycle below
 - **Input Sanitization**: Escapes special characters, limits length
 - **Prompt Injection Prevention**: Fixed prompt templates
 - **Rate Limiting**: Per-minute and per-hour limits (OpenAI only)
 - **Access Control**: Admin-only configuration
 - **Local Ollama**: No authentication (localhost only)
+
+
+### Secret Lifecycle and Threat Model
+
+The OpenAI API key is the only secret the AI service handles. The contract is
+deliberately simple so nobody mistakes it for something stronger.
+
+**Sources, in priority order**
+1. The process environment variable `OPENAI_API_KEY` (set by systemd
+   `Environment=`/`EnvironmentFile=`, a secret manager wrapper, or the shell).
+   This is the preferred production path: no at-rest copy is owned by the game.
+2. `OPENAI_API_KEY` in `lib/.env`, read through `dotenv.c`. Convenient for
+   development. Keep the file mode `0600` and never commit it.
+
+**What the application guarantees**
+- The key is held in exactly one mutex-guarded buffer inside `ai_security.c`.
+  It is never written to disk, the database, player files, or the response
+  cache, and it is never compiled into the binary.
+- Nothing prints the key: not `log()`, not `AI_DEBUG`, not the `ai` staff
+  command (which reports only CONFIGURED / NOT CONFIGURED), not error text.
+  A regression test captures the log while loading a sentinel key and fails
+  if the sentinel appears.
+- Each OpenAI request copies the key into a stack buffer, builds the
+  `Authorization` header, hands it to libcurl, and immediately wipes both
+  buffers with `secure_memset()`. libcurl keeps its own copy for the life of
+  the header list, which is freed at the end of the request.
+- A key longer than 255 characters is rejected, not truncated, and OpenAI is
+  left disabled with a clear log line.
+- Missing key: OpenAI is disabled and the service fails closed to the Ollama
+  or generic fallback path. No request is ever sent without a key.
+
+**Rotation and revocation**
+1. Update the environment variable or `lib/.env` with the new key.
+2. Run `ai reload` as staff (or restart the server). The old key is
+   overwritten in place. Removing the key entirely and reloading wipes it.
+3. Revoke the old key at the provider. Requests already in flight in a
+   worker thread finish with whichever key they copied when they started.
+
+**What is explicitly NOT protected**
+- Anyone who can read `lib/.env`, the process environment, process memory, or
+  a core dump can read the key. The game does not implement at-rest
+  encryption; an application-held wrapping key would offer no real boundary
+  because it would sit next to the data it protects. Use OS file permissions,
+  a secret manager, and restricted core-dump handling instead.
+- Backups that include `lib/.env` contain the key. Exclude the file or
+  encrypt the backup outside the game.
 
 ### Best Practices
 1. Restrict .env file permissions: `chmod 600 lib/.env`
@@ -579,13 +626,14 @@ bool ai_moderate_content(const char *text);
 // Memory security
 void secure_memset(void *ptr, int value, size_t num);   // Secure clearing
 
-// API key management
-int encrypt_api_key(const char *plaintext, char *encrypted_out);  // Store key
-char *decrypt_api_key(const char *encrypted);                     // Retrieve key (must free)
-void load_encrypted_api_key(const char *filename);                // Load from file
+// API key management (one process-private copy, mutex guarded)
+bool ai_api_key_set(const char *key);             // Store key; FALSE if too long
+bool ai_api_key_is_set(void);                     // Non-empty key stored?
+bool ai_api_key_copy(char *out, size_t out_size); // Copy into caller buffer
+void ai_api_key_clear(void);                      // Wipe the stored key
 
 // Input sanitization
-char *sanitize_ai_input(const char *input);                      // Prevent injection
+void sanitize_ai_input(const char *input, char *out, size_t out_size);
 ```
 
 ### Cache Functions (ai_cache.c)
@@ -625,7 +673,7 @@ struct ai_service_state {
 
 // Configuration (ai_service.h)
 struct ai_config {
-    char encrypted_api_key[256];         // OpenAI API key storage
+    char openai_endpoint[256];           // OPENAI_API_ENDPOINT (key is NOT stored here)
     char model[64];                      // OpenAI model name
     int max_tokens;                      // Response length limit
     float temperature;                   // Creativity (0.0-1.0)
@@ -758,7 +806,8 @@ ai
 - ✅ Always-on AI capability
 
 ### Known Limitations
-- API keys stored in plaintext (encryption planned)
+- No application-level at-rest encryption of the API key (by design, see the
+  threat model; file permissions and the deployment secret store protect it)
 - No medit integration yet (manual flag setting required)
 - Cache is memory-only (lost on reboot)
 - Single prompt template for all NPCs
@@ -766,13 +815,12 @@ ai
 - Ollama model must be pre-downloaded
 
 ### Planned Enhancements
-1. **Security**: AES-256 encryption for API keys
-2. **Editor Support**: medit integration for AI flags
-3. **Persistence**: Database-backed cache
-4. **Features**: Room descriptions, quest generation
-5. **NPC Personalities**: Individual personality traits
-6. **Memory**: Conversation history per player/NPC pair (leverage 128K context)
-7. **Moderation**: ai_moderate_content() implementation
+1. **Editor Support**: medit integration for AI flags
+2. **Persistence**: Database-backed cache
+3. **Features**: Room descriptions, quest generation
+4. **NPC Personalities**: Individual personality traits
+5. **Memory**: Conversation history per player/NPC pair (leverage 128K context)
+6. **Moderation**: ai_moderate_content() implementation
 8. **Dynamic Models**: Per-NPC model selection
 9. **Ollama Config**: Runtime model switching
 10. **Context Enhancement**: Include world lore, zone info, NPC backgrounds
@@ -907,7 +955,8 @@ Worker Threads (detached):
 - Worker threads free their own request structures
 - Event handlers free event data after processing
 - Cache entries freed on expiration or cleanup
-- API keys cleared with `secure_memset()` on shutdown
+- The API key buffer is wiped with `secure_memset()` on shutdown, on a reload
+  that no longer supplies a key, and per request once libcurl owns the header
 
 ### Error Handling Strategy
 1. **API Failures**: Retry with exponential backoff, then Ollama fallback

--- a/docs/systems/AI_SERVICE_README.md
+++ b/docs/systems/AI_SERVICE_README.md
@@ -505,11 +505,24 @@ deliberately simple so nobody mistakes it for something stronger.
   or generic fallback path. No request is ever sent without a key.
 
 **Rotation and revocation**
-1. Update the environment variable or `lib/.env` with the new key.
-2. Run `ai reload` as staff (or restart the server). The old key is
-   overwritten in place. Removing the key entirely and reloading wipes it.
-3. Revoke the old key at the provider. Requests already in flight in a
-   worker thread finish with whichever key they copied when they started.
+1. Put the new key where the running server reads it:
+   - `lib/.env`: edit the file, then run `ai reload` as staff. The old key
+     is overwritten in place; removing the line and reloading wipes it.
+   - systemd `Environment=` / `EnvironmentFile=` (or any secret manager that
+     populates the process environment): update the unit or the credential
+     file, run `systemctl daemon-reload` if the unit itself changed, and
+     restart the server. `ai reload` re-reads the process environment of the
+     already running process, which systemd cannot change, so a reload alone
+     will keep using the old key.
+2. Confirm with `ai` that OpenAI reports CONFIGURED.
+3. Only then revoke the old key at the provider. Requests already in flight in
+   a worker thread finish with whichever key they copied when they started.
+
+**Endpoint policy**
+- `OPENAI_API_ENDPOINT` must start with `https://`. The bearer key is sent to
+  that URL on every request, so a cleartext scheme is refused at load time:
+  the value is ignored, the default endpoint is used, and a log line says so.
+  A local proxy must therefore terminate TLS itself.
 
 **What is explicitly NOT protected**
 - Anyone who can read `lib/.env`, the process environment, process memory, or

--- a/lib/.env_example
+++ b/lib/.env_example
@@ -157,6 +157,9 @@ AI_CONTENT_FILTER_ENABLED=true
 # - Format: sk-proj-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # - Keep this secret! Anyone with this key can use your OpenAI account
 # - Leave empty to use Ollama-only mode (free, local)
+# - A key in the process environment (systemd EnvironmentFile, secret manager)
+#   takes priority over this file, so production need not store it here
+# - The server never logs, displays, or persists the key; 'ai reload' rotates it
 OPENAI_API_KEY=
 
 # OpenAI API Endpoint

--- a/lib/.env_example
+++ b/lib/.env_example
@@ -165,6 +165,8 @@ OPENAI_API_KEY=
 # OpenAI API Endpoint
 # - Default: https://api.openai.com/v1/chat/completions
 # - Change only if using a custom/proxy endpoint
+# - Must start with https:// (the API key is sent to this URL); any other
+#   scheme is ignored and the default endpoint is used
 OPENAI_API_ENDPOINT=https://api.openai.com/v1/chat/completions
 
 # AI Model Selection for OpenAI

--- a/src/ai_security.c
+++ b/src/ai_security.c
@@ -4,24 +4,25 @@
  * @brief Security functions for AI service
  *
  * Handles:
- * - API key encryption/decryption
+ * - OpenAI API key lifecycle (store, copy, clear)
  * - Input sanitization
  * - Secure memory operations
  *
  * COMPONENT INTERACTIONS:
  * - USED BY: ai_service.c for all security operations
- * - ACCESSES: ai_state.config for API key storage
  * - CRITICAL: All API keys pass through this component
  *
- * SECURITY MODEL:
- * - API keys stored in ai_state.config->encrypted_api_key
- * - Input sanitization prevents prompt injection
- * - Secure memory clearing prevents key leakage
- *
- * Note: This is a simplified implementation. Production systems should use
- * proper key management services and stronger encryption.
- *
- * TODO: Implement AES-256 encryption for API keys
+ * SECURITY BOUNDARY (honest statement, see docs/systems/AI_SERVICE_README.md):
+ * - The API key is injected at runtime from the process environment or
+ *   lib/.env. The application never writes it anywhere: not to disk, not to
+ *   the database, not to logs, not to player or staff output.
+ * - While loaded, the key lives in exactly one process-private buffer that is
+ *   guarded by a mutex so a worker thread can copy it while the main thread
+ *   reloads configuration. Callers receive a copy in a buffer they own and
+ *   must clear with secure_memset() as soon as the request is built.
+ * - There is NO at-rest encryption. Protecting the key at rest is the job of
+ *   file permissions on lib/.env and the deployment secret store. Nothing in
+ *   this file claims otherwise.
  *
  * Part of the LuminariMUD distribution.
  */
@@ -32,236 +33,157 @@
 #include "utils.h"
 #include "comm.h"
 #include "ai_service.h"
-#include <errno.h>
+#include <pthread.h>
 
-/* Simple XOR cipher key - in production, use proper encryption */
-#define CIPHER_KEY "LuminariMUD_AI_Service_2025_Secure_Key"
+/* The single process-private copy of the OpenAI API key. */
+static char ai_api_key_store[AI_API_KEY_MAX_LEN];
+static pthread_mutex_t ai_api_key_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /**
  * Secure memory clearing
  *
- * Prevents compiler optimization from removing memory clearing operations.
- * Uses volatile pointer to ensure memory is actually overwritten.
- *
- * Used by:
- * - load_encrypted_api_key() to clear file buffers
- * - shutdown_ai_service() to clear API keys on shutdown
- * - Any function handling sensitive data
- *
- * IMPORTANT: Standard memset() may be optimized away if the compiler
- * determines the memory won't be read again. This function prevents
- * that optimization for security-critical memory clearing.
+ * Standard memset() may be optimized away if the compiler determines the
+ * memory won't be read again. Writing through a volatile pointer forces the
+ * stores to happen.
  */
 void secure_memset(void *ptr, int value, size_t num)
 {
   volatile unsigned char *p = ptr;
-  AI_DEBUG("secure_memset() called - clearing %zu bytes at %p", num, ptr);
+
+  if (!ptr)
+    return;
   while (num--)
   {
-    *p++ = value;
+    *p++ = (unsigned char)value;
   }
 }
 
-
 /**
- * Encrypt API key
+ * Store the OpenAI API key for later use by request builders.
  *
- * Currently stores API key in plaintext (NO ENCRYPTION).
- * This is a security vulnerability that needs addressing.
+ * The key is copied verbatim into the process-private store. A NULL or empty
+ * key clears the store. A key that does not fit is rejected outright rather
+ * than silently truncated, because a truncated key would fail every request
+ * with an error message that is very hard to trace.
  *
- * Called by:
- * - load_ai_config() when loading API key from .env
- * - Admin commands when updating API key
- *
- * Stores in: ai_state.config->encrypted_api_key (256 bytes max)
- *
- * TODO: Implement proper encryption:
- * 1. Use AES-256-CBC with server-specific key
- * 2. Store initialization vector with encrypted data
- * 3. Use PBKDF2 for key derivation from server seed
- *
- * Returns: 1 on success, 0 on failure
+ * Returns: TRUE when the store now holds the requested value, FALSE when the
+ * key was too long (the previous value is cleared in that case).
  */
-int encrypt_api_key(const char *plaintext, char *encrypted_out)
+bool ai_api_key_set(const char *key)
 {
-  AI_DEBUG("encrypt_api_key() called");
+  size_t len;
+  bool stored;
 
-  if (!plaintext || !encrypted_out)
+  len = key ? strlen(key) : 0;
+  stored = TRUE;
+
+  pthread_mutex_lock(&ai_api_key_mutex);
+  secure_memset(ai_api_key_store, 0, sizeof(ai_api_key_store));
+  if (len >= sizeof(ai_api_key_store))
   {
-    AI_DEBUG("ERROR: NULL plaintext or encrypted_out");
-    return 0;
+    log("SYSERR: AI Service: OPENAI_API_KEY is longer than %zu characters and was rejected",
+        sizeof(ai_api_key_store) - 1);
+    stored = FALSE;
   }
+  else if (len > 0)
+  {
+    memcpy(ai_api_key_store, key, len);
+    ai_api_key_store[len] = '\0';
+  }
+  pthread_mutex_unlock(&ai_api_key_mutex);
 
-  AI_DEBUG("WARNING: Using plaintext storage (no encryption)");
-  AI_DEBUG("Input length: %zu", strlen(plaintext));
-
-  /* Just copy the API key as-is - no encryption */
-  strlcpy(encrypted_out, plaintext, 256);
-
-  AI_DEBUG("API key stored (length=%zu)", strlen(encrypted_out));
-  return 1;
+  return stored;
 }
 
 /**
- * Decrypt API key
- * Note: Caller must free() the returned string
- *
- * Currently returns API key as-is (NO DECRYPTION).
- * Must be updated when encryption is implemented.
- *
- * Called by:
- * - make_api_request_single() for each API request
- *
- * SECURITY CONSIDERATIONS:
- * - Returned key is in plaintext memory
- * - Caller MUST free() the returned string
- * - Caller should clear memory after use
- *
- * Memory: Allocates 256 bytes for decrypted key
- * Returns: Allocated string with API key or NULL on error
+ * Whether a non-empty API key is currently stored.
  */
-char *decrypt_api_key(const char *encrypted)
+bool ai_api_key_is_set(void)
 {
-  char *decrypted;
+  bool present;
 
-  AI_DEBUG("decrypt_api_key() called");
+  pthread_mutex_lock(&ai_api_key_mutex);
+  present = ai_api_key_store[0] != '\0';
+  pthread_mutex_unlock(&ai_api_key_mutex);
 
-  if (!encrypted || !*encrypted)
-  {
-    AI_DEBUG("ERROR: NULL or empty encrypted key");
-    return NULL;
-  }
-
-  AI_DEBUG("WARNING: Using plaintext retrieval (no decryption)");
-  AI_DEBUG("Encrypted length: %zu", strlen(encrypted));
-
-  /* Allocate memory for decrypted key */
-  CREATE(decrypted, char, 256);
-  if (!decrypted)
-  {
-    log("SYSERR: Failed to allocate memory for decrypted API key");
-    AI_DEBUG("ERROR: Failed to allocate 256 bytes");
-    return NULL;
-  }
-
-  /* Just return the API key as-is - no decryption */
-  strlcpy(decrypted, encrypted, 256);
-
-  AI_DEBUG("API key retrieved (length=%zu)", strlen(decrypted));
-  return decrypted;
+  return present;
 }
 
 /**
- * Load encrypted API key from file
+ * Copy the stored API key into a caller-owned buffer.
  *
- * Reads API key from file and stores in global config.
- * Uses secure_memset() to clear file buffer after reading.
+ * Safe to call from worker threads. The caller must clear the buffer with
+ * secure_memset() once the request headers have been built.
  *
- * Called by:
- * - Manual configuration (not currently used)
- * - Could be used for file-based key storage
- *
- * Security measures:
- * 1. Clears file buffer after reading
- * 2. Removes newlines from key
- * 3. Validates file access
- *
- * File format: Single line with API key
- * Storage: ai_state.config->encrypted_api_key
+ * Returns: TRUE when out now holds a non-empty key, FALSE when no key is
+ * configured or the buffer is too small (out is emptied either way).
  */
-void load_encrypted_api_key(const char *filename)
+bool ai_api_key_copy(char *out, size_t out_size)
 {
-  FILE *fp;
-  char buffer[512];
+  bool copied;
 
-  AI_DEBUG("load_encrypted_api_key() called with filename='%s'", filename ? filename : "(null)");
+  if (!out || out_size == 0)
+    return FALSE;
 
-  if (!filename)
+  copied = FALSE;
+  pthread_mutex_lock(&ai_api_key_mutex);
+  if (ai_api_key_store[0] != '\0' && strlen(ai_api_key_store) < out_size)
   {
-    AI_DEBUG("ERROR: NULL filename");
-    return;
-  }
-
-  AI_DEBUG("Opening file: %s", filename);
-  fp = fopen(filename, "r");
-  if (!fp)
-  {
-    log("SYSERR: Cannot open API key file: %s", filename);
-    AI_DEBUG("ERROR: fopen failed - %s", strerror(errno));
-    return;
-  }
-  AI_DEBUG("File opened successfully");
-
-  if (fgets(buffer, sizeof(buffer), fp))
-  {
-    AI_DEBUG("Read %zu bytes from file", strlen(buffer));
-    /* Remove newline */
-    buffer[strcspn(buffer, "\n")] = '\0';
-    AI_DEBUG("After newline removal: %zu bytes", strlen(buffer));
-
-    /* Store in config */
-    if (ai_state.config)
-    {
-      AI_DEBUG("Storing key in config (length=%zu)", strlen(buffer));
-      strlcpy(ai_state.config->encrypted_api_key, buffer,
-              sizeof(ai_state.config->encrypted_api_key));
-    }
-    else
-    {
-      AI_DEBUG("ERROR: ai_state.config is NULL");
-    }
+    strlcpy(out, ai_api_key_store, out_size);
+    copied = TRUE;
   }
   else
   {
-    AI_DEBUG("ERROR: Failed to read from file");
+    out[0] = '\0';
   }
+  pthread_mutex_unlock(&ai_api_key_mutex);
 
-  fclose(fp);
-  AI_DEBUG("File closed");
+  return copied;
+}
 
-  /* Clear buffer */
-  AI_DEBUG("Clearing sensitive buffer");
-  secure_memset(buffer, 0, sizeof(buffer));
-
-  log("API key loaded from %s", filename);
+/**
+ * Clear the stored API key. Called on shutdown and when a reload finds no key.
+ */
+void ai_api_key_clear(void)
+{
+  pthread_mutex_lock(&ai_api_key_mutex);
+  secure_memset(ai_api_key_store, 0, sizeof(ai_api_key_store));
+  pthread_mutex_unlock(&ai_api_key_mutex);
 }
 
 /**
  * Sanitize user input for AI prompts
  *
  * Critical security function that prevents prompt injection attacks.
- * Sanitizes user input before sending to OpenAI API.
- *
- * Called by:
- * - ai_generate_response() for all AI requests
- * - ai_generate_response_async() for async requests
+ * Sanitizes user input before it is embedded in a JSON request body.
  *
  * Security measures:
  * 1. Removes control characters (except newlines)
  * 2. Escapes quotes and backslashes for JSON
  * 3. Replaces newlines with spaces
- * 4. Enforces MAX_STRING_LENGTH limit
+ * 4. Bounds output to out_size
  * 5. Trims trailing spaces
  *
- * IMPORTANT: This is the primary defense against prompt injection.
- * All user input MUST pass through this function.
- *
- * Returns: Static buffer with sanitized input (not thread-safe)
+ * The result is written to a caller-owned buffer so the function is safe to
+ * call from any thread. out is always NUL-terminated when out_size > 0.
  */
-char *sanitize_ai_input(const char *input)
+void sanitize_ai_input(const char *input, char *out, size_t out_size)
 {
-  static char cleaned[MAX_STRING_LENGTH];
   const char *src = input;
-  char *dest = cleaned;
-  int len = 0;
+  char *dest = out;
+  size_t len = 0;
 
+  if (!out || out_size == 0)
+    return;
+
+  out[0] = '\0';
   if (!input)
-    return "";
+    return;
 
-  while (*src && len < MAX_STRING_LENGTH - 1)
+  while (*src && len < out_size - 1)
   {
     /* Skip control characters */
-    if (*src < 32 && *src != '\n' && *src != '\r')
+    if ((unsigned char)*src < 32 && *src != '\n' && *src != '\r')
     {
       src++;
       continue;
@@ -270,18 +192,12 @@ char *sanitize_ai_input(const char *input)
     /* Escape special characters for JSON */
     if (*src == '"' || *src == '\\')
     {
-      if (len >= MAX_STRING_LENGTH - 2)
+      if (len >= out_size - 2)
       {
         break; /* No room for escape sequence */
       }
       *dest++ = '\\';
       len++;
-    }
-
-    /* Check if we have room for the character */
-    if (len >= MAX_STRING_LENGTH - 1)
-    {
-      break;
     }
 
     /* Replace newlines with spaces */
@@ -301,10 +217,8 @@ char *sanitize_ai_input(const char *input)
   *dest = '\0';
 
   /* Trim trailing spaces */
-  while (dest > cleaned && *(dest - 1) == ' ')
+  while (dest > out && *(dest - 1) == ' ')
   {
     *(--dest) = '\0';
   }
-
-  return cleaned;
 }

--- a/src/ai_service.c
+++ b/src/ai_service.c
@@ -43,7 +43,7 @@
 
 /* Global AI Service State
  * This global state is shared across all AI components:
- * - ai_security.c accesses config for API key storage
+ * - ai_security.c owns the single in-memory API key copy
  * - ai_cache.c directly manipulates cache_head and cache_size
  * - ai_events.c validates character pointers against this state
  * - All components check initialized flag before operations
@@ -97,7 +97,6 @@ static bool start_ai_thread_request(const char *prompt, const char *cache_key, i
                                     int retry_count, struct domain_entity_handle player,
                                     struct domain_entity_handle npc);
 static int json_escape_string(char *dest, size_t dest_size, const char *src);
-/* static void derive_key_from_seed(unsigned char *key); */
 
 static bool ai_shutdown_is_requested(void)
 {
@@ -165,20 +164,6 @@ static size_t ai_curl_write_callback(void *contents, size_t size, size_t nmemb, 
   return realsize;
 }
 
-
-/**
- * Derive encryption key from server seed
- * NOTE: This is a placeholder - implement proper key derivation
- */
-/*
-static void derive_key_from_seed(unsigned char *key) {
-  int i;
-  // Simple placeholder - in production, use proper KDF
-  for (i = 0; i < 32; i++) {
-    key[i] = (unsigned char)(rand() % 256);
-  }
-}
-*/
 
 /**
  * Initialize the AI service
@@ -413,13 +398,14 @@ void shutdown_ai_service(void)
   }
   AI_DEBUG("Cache entries freed");
 
+  /* Wipe the API key before anything else is torn down */
+  ai_api_key_clear();
+  ai_state.openai_configured = FALSE;
+
   /* Free configuration */
   if (ai_state.config)
   {
     AI_DEBUG("Freeing AI configuration at %p", (void *)ai_state.config);
-    AI_DEBUG("  Clearing API key from memory");
-    secure_memset(ai_state.config->encrypted_api_key, 0,
-                  sizeof(ai_state.config->encrypted_api_key));
     free(ai_state.config);
     ai_state.config = NULL;
   }
@@ -516,7 +502,8 @@ const char *ai_service_active_provider(void)
  * Load AI configuration from database/files
  *
  * Loads configuration from .env file via dotenv.c. This function:
- * 1. Retrieves API key and calls ai_security.c encrypt_api_key()
+ * 1. Retrieves the API key (process environment first, then lib/.env) and
+ *    hands it to ai_security.c ai_api_key_set()
  * 2. Sets model, temperature, timeout, and other parameters
  * 3. Configures rate limiting thresholds
  *
@@ -526,11 +513,12 @@ const char *ai_service_active_provider(void)
  *
  * Interacts with:
  * - dotenv.c: get_env_value() for reading .env file
- * - ai_security.c: encrypt_api_key() for secure storage
+ * - ai_security.c: ai_api_key_set() for the single in-memory key copy
  */
 void load_ai_config(void)
 {
   char *str_val;
+  const char *key_source;
 
   AI_DEBUG("Loading AI configuration from environment");
 
@@ -569,18 +557,32 @@ void load_ai_config(void)
   AI_DEBUG("Loading OpenAI configuration");
   ai_state.openai_configured = FALSE;
 
-  /* API Key */
-  str_val = get_env_value("OPENAI_API_KEY");
+  /* API Key: the process environment (secret manager / systemd credential)
+   * takes priority over lib/.env so production can inject the key without
+   * an at-rest copy. The value itself is never logged. */
+  key_source = "environment";
+  str_val = getenv("OPENAI_API_KEY");
+  if (!str_val || !*str_val)
+  {
+    key_source = ".env";
+    str_val = get_env_value("OPENAI_API_KEY");
+  }
   if (str_val && *str_val)
   {
-    AI_DEBUG("  Found API key (length=%zu)", strlen(str_val));
-    encrypt_api_key(str_val, ai_state.config->encrypted_api_key);
-    ai_state.openai_configured = TRUE;
-    log("AI Service: OpenAI API key loaded from .env");
+    if (ai_api_key_set(str_val))
+    {
+      ai_state.openai_configured = TRUE;
+      log("AI Service: OpenAI API key loaded from %s", key_source);
+    }
+    else
+    {
+      log("AI Service: OpenAI API key from %s rejected - OpenAI disabled", key_source);
+    }
   }
   else
   {
-    AI_DEBUG("  No OpenAI API key found (Ollama-only mode)");
+    /* A reload that removed the key must not leave the old one resident. */
+    ai_api_key_clear();
     log("AI Service: No OpenAI API key found - using Ollama-only mode");
   }
 
@@ -690,13 +692,22 @@ void load_ai_config(void)
 }
 
 /**
+ * Wipe the per-request copies of the API key once libcurl owns its header.
+ */
+static void ai_wipe_request_secrets(char *key, size_t key_size, char *header, size_t header_size)
+{
+  secure_memset(key, 0, key_size);
+  secure_memset(header, 0, header_size);
+}
+
+/**
  * Make an API request to OpenAI (internal - no retries)
  *
  * Low-level function that makes a single API request attempt.
  *
  * Flow:
  * 1. Check rate limits via ai_check_rate_limit()
- * 2. Decrypt API key via ai_security.c decrypt_api_key()
+ * 2. Copy the API key into a stack buffer via ai_security.c ai_api_key_copy()
  * 3. Build JSON request with sanitized prompt
  * 4. Execute CURL request (uses persistent handle if available)
  * 5. Parse JSON response and return content
@@ -714,7 +725,7 @@ static char *make_api_request_single(const char *prompt)
   struct curl_response response = {0};
   struct curl_slist *headers = NULL;
   char auth_header[512];
-  char *api_key;
+  char api_key[AI_API_KEY_MAX_LEN];
   char *json_request;
   char *result = NULL;
   long http_code;
@@ -741,16 +752,13 @@ static char *make_api_request_single(const char *prompt)
   }
   AI_DEBUG("Rate limit check passed");
 
-  /* Decrypt API key */
-  AI_DEBUG("Decrypting API key");
-  api_key = decrypt_api_key(ai_state.config->encrypted_api_key);
-  if (!api_key)
+  /* Fail closed: no key means no OpenAI request, ever. */
+  if (!ai_api_key_copy(api_key, sizeof(api_key)))
   {
-    log("SYSERR: Failed to decrypt API key");
-    AI_DEBUG("ERROR: API key decryption failed");
+    log("AI Service: OpenAI API key not configured - request refused");
+    AI_DEBUG("ERROR: no API key available");
     return NULL;
   }
-  AI_DEBUG("API key decrypted successfully (length=%zu)", strlen(api_key));
 
   /* Build JSON request */
   AI_DEBUG("Building JSON request");
@@ -758,7 +766,7 @@ static char *make_api_request_single(const char *prompt)
   if (!json_request)
   {
     AI_DEBUG("ERROR: Failed to build JSON request");
-    free(api_key);
+    ai_wipe_request_secrets(api_key, sizeof(api_key), auth_header, sizeof(auth_header));
     return NULL;
   }
   AI_DEBUG("JSON request built (length=%zu)", strlen(json_request));
@@ -781,7 +789,7 @@ static char *make_api_request_single(const char *prompt)
     {
       log("SYSERR: Failed to initialize CURL handle in make_api_request_single");
       AI_DEBUG("ERROR: curl_easy_init() returned NULL");
-      free(api_key);
+      ai_wipe_request_secrets(api_key, sizeof(api_key), auth_header, sizeof(auth_header));
       return NULL;
     }
   }
@@ -790,14 +798,14 @@ static char *make_api_request_single(const char *prompt)
   /* Set headers */
   AI_DEBUG("Setting up HTTP headers");
   snprintf(auth_header, sizeof(auth_header), "Authorization: Bearer %s", api_key);
-  AI_DEBUG("  Auth header length: %zu", strlen(auth_header));
   headers = curl_slist_append(headers, auth_header);
+  /* libcurl copied the header; nothing else needs the secret from here on. */
+  ai_wipe_request_secrets(api_key, sizeof(api_key), auth_header, sizeof(auth_header));
   if (!headers)
   {
     log("SYSERR: Failed to allocate CURL header list (auth header)");
     AI_DEBUG("ERROR: curl_slist_append failed for auth header");
     curl_easy_cleanup(curl);
-    free(api_key);
     return NULL;
   }
   AI_DEBUG("  Auth header added successfully");
@@ -808,7 +816,6 @@ static char *make_api_request_single(const char *prompt)
     log("SYSERR: Failed to allocate CURL header list (content-type)");
     AI_DEBUG("ERROR: curl_slist_append failed for content-type header");
     curl_easy_cleanup(curl);
-    free(api_key);
     return NULL;
   }
   AI_DEBUG("  Content-Type header added successfully");
@@ -913,11 +920,6 @@ static char *make_api_request_single(const char *prompt)
   curl_slist_free_all(headers);
   AI_DEBUG("  Headers freed");
 
-  if (api_key)
-  {
-    AI_DEBUG("  Freeing API key");
-    free(api_key);
-  }
   if (response.data)
   {
     AI_DEBUG("  Freeing response data (%zu bytes)", response.size);
@@ -1031,7 +1033,7 @@ char *ai_generate_response(const char *prompt, int request_type)
 
   /* Sanitize input */
   AI_DEBUG("Sanitizing input prompt");
-  strlcpy(sanitized_prompt, sanitize_ai_input(prompt), sizeof(sanitized_prompt));
+  sanitize_ai_input(prompt, sanitized_prompt, sizeof(sanitized_prompt));
   AI_DEBUG("Sanitized prompt: '%.100s%s'", sanitized_prompt,
            strlen(sanitized_prompt) > 100 ? "..." : "");
 
@@ -2200,7 +2202,7 @@ char *ai_generate_response_async(const char *prompt, int request_type, int retry
   }
 
   /* Sanitize input */
-  strlcpy(sanitized_prompt, sanitize_ai_input(prompt), sizeof(sanitized_prompt));
+  sanitize_ai_input(prompt, sanitized_prompt, sizeof(sanitized_prompt));
 
   /* Check cache first */
   response = ai_cache_get(sanitized_prompt);

--- a/src/ai_service.c
+++ b/src/ai_service.c
@@ -499,6 +499,14 @@ const char *ai_service_active_provider(void)
 }
 
 /**
+ * Whether an OpenAI endpoint URL uses the https scheme (case-insensitive).
+ */
+bool ai_endpoint_is_https(const char *url)
+{
+  return url && strncasecmp(url, "https://", 8) == 0;
+}
+
+/**
  * Load AI configuration from database/files
  *
  * Loads configuration from .env file via dotenv.c. This function:
@@ -590,8 +598,18 @@ void load_ai_config(void)
   str_val = get_env_value("OPENAI_API_ENDPOINT");
   if (str_val && *str_val)
   {
-    strlcpy(ai_state.config->openai_endpoint, str_val, sizeof(ai_state.config->openai_endpoint));
-    AI_DEBUG("  OpenAI endpoint: %s", ai_state.config->openai_endpoint);
+    /* The bearer key travels to this URL, so a cleartext scheme is refused. */
+    if (ai_endpoint_is_https(str_val))
+    {
+      strlcpy(ai_state.config->openai_endpoint, str_val, sizeof(ai_state.config->openai_endpoint));
+      AI_DEBUG("  OpenAI endpoint: %s", ai_state.config->openai_endpoint);
+    }
+    else
+    {
+      strlcpy(ai_state.config->openai_endpoint, DEFAULT_OPENAI_API_ENDPOINT,
+              sizeof(ai_state.config->openai_endpoint));
+      log("AI Service: OPENAI_API_ENDPOINT must use https:// - ignoring it and using the default");
+    }
   }
 
   /* OpenAI Model */
@@ -790,6 +808,7 @@ static char *make_api_request_single(const char *prompt)
       log("SYSERR: Failed to initialize CURL handle in make_api_request_single");
       AI_DEBUG("ERROR: curl_easy_init() returned NULL");
       ai_wipe_request_secrets(api_key, sizeof(api_key), auth_header, sizeof(auth_header));
+      free(json_request);
       return NULL;
     }
   }
@@ -805,7 +824,9 @@ static char *make_api_request_single(const char *prompt)
   {
     log("SYSERR: Failed to allocate CURL header list (auth header)");
     AI_DEBUG("ERROR: curl_slist_append failed for auth header");
-    curl_easy_cleanup(curl);
+    if (curl != ai_state.curl_handle)
+      curl_easy_cleanup(curl);
+    free(json_request);
     return NULL;
   }
   AI_DEBUG("  Auth header added successfully");
@@ -815,7 +836,10 @@ static char *make_api_request_single(const char *prompt)
   {
     log("SYSERR: Failed to allocate CURL header list (content-type)");
     AI_DEBUG("ERROR: curl_slist_append failed for content-type header");
-    curl_easy_cleanup(curl);
+    if (curl != ai_state.curl_handle)
+      curl_easy_cleanup(curl);
+    curl_slist_free_all(headers);
+    free(json_request);
     return NULL;
   }
   AI_DEBUG("  Content-Type header added successfully");
@@ -919,6 +943,7 @@ static char *make_api_request_single(const char *prompt)
   }
   curl_slist_free_all(headers);
   AI_DEBUG("  Headers freed");
+  free(json_request);
 
   if (response.data)
   {

--- a/src/ai_service.h
+++ b/src/ai_service.h
@@ -143,8 +143,7 @@ enum ai_service_health
 /* AI Configuration - loaded from lib/.env at startup */
 struct ai_config
 {
-  /* OpenAI settings */
-  char encrypted_api_key[256];
+  /* OpenAI settings. The API key itself is not stored here; see ai_security.c. */
   char openai_endpoint[256]; /* OPENAI_API_ENDPOINT */
   char model[64];            /* AI_MODEL: gpt-4o-mini, etc */
   int max_tokens;            /* AI_MAX_TOKENS */
@@ -229,13 +228,17 @@ bool ai_check_rate_limit(void);
 void ai_reset_rate_limits(void);
 
 /* Security Functions (defined in ai_security.c)
- * CRITICAL SECURITY - All API keys and user input pass through here
+ * CRITICAL SECURITY - All API keys and user input pass through here.
+ * The API key is held in one mutex-guarded process-private buffer; it is
+ * never encrypted at rest, persisted, logged, or shown to players or staff.
  */
-char *decrypt_api_key(const char *encrypted); /* Returns allocated string (caller frees) */
-int encrypt_api_key(const char *plaintext, char *encrypted_out); /* Store API key */
-void load_encrypted_api_key(const char *filename);               /* Load from file (unused) */
-char *sanitize_ai_input(const char *input);           /* CRITICAL: Prevent prompt injection */
-void secure_memset(void *ptr, int value, size_t num); /* Clear sensitive memory */
+#define AI_API_KEY_MAX_LEN 256                    /* Includes the terminating NUL */
+bool ai_api_key_set(const char *key);             /* Store key; FALSE if too long */
+bool ai_api_key_is_set(void);                     /* Non-empty key stored? */
+bool ai_api_key_copy(char *out, size_t out_size); /* Copy into caller buffer */
+void ai_api_key_clear(void);                      /* Wipe the stored key */
+void sanitize_ai_input(const char *input, char *out, size_t out_size); /* Prompt injection */
+void secure_memset(void *ptr, int value, size_t num);                  /* Clear sensitive memory */
 
 /* Utility Functions */
 void log_ai_error(const char *function, const char *error);

--- a/src/ai_service.h
+++ b/src/ai_service.h
@@ -194,10 +194,11 @@ extern struct ai_service_state ai_state;
 /* Core Service Functions
  * PRIMARY INTERFACE - Called by main MUD systems
  */
-void init_ai_service(void);     /* Initialize at startup (comm.c) */
-void shutdown_ai_service(void); /* Cleanup at shutdown */
-void load_ai_config(void);      /* Reload from .env file */
-bool is_ai_enabled(void);       /* Global enable check (all components) */
+void init_ai_service(void);                 /* Initialize at startup (comm.c) */
+void shutdown_ai_service(void);             /* Cleanup at shutdown */
+void load_ai_config(void);                  /* Reload from .env file */
+bool ai_endpoint_is_https(const char *url); /* Custom OpenAI endpoints must be https */
+bool is_ai_enabled(void);                   /* Global enable check (all components) */
 enum ai_service_health ai_get_service_health(void);
 const char *ai_service_health_name(void);
 const char *ai_service_active_provider(void);

--- a/unittests/CuTest/test_ai_secrets.c
+++ b/unittests/CuTest/test_ai_secrets.c
@@ -18,6 +18,7 @@ extern FILE *logfile;
 
 #define TEST_SECRET "sk-test-SECRET-0123456789abcdef"
 
+/* Rewind a capture stream and read its whole content as a NUL-terminated string. */
 static void read_whole_file(FILE *fp, char *out, size_t out_size)
 {
   size_t got;
@@ -28,6 +29,7 @@ static void read_whole_file(FILE *fp, char *out, size_t out_size)
   out[got] = '\0';
 }
 
+/* A stored key comes back verbatim; a cleared store yields nothing. */
 void TestAiApiKeyRoundTrip(CuTest *tc)
 {
   char out[AI_API_KEY_MAX_LEN];
@@ -43,6 +45,7 @@ void TestAiApiKeyRoundTrip(CuTest *tc)
   CuAssertStrEquals(tc, "", out);
 }
 
+/* Setting an empty or NULL key is the same as clearing it. */
 void TestAiApiKeyEmptyAndNullClear(CuTest *tc)
 {
   CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
@@ -54,6 +57,7 @@ void TestAiApiKeyEmptyAndNullClear(CuTest *tc)
   CuAssertTrue(tc, !ai_api_key_is_set());
 }
 
+/* The longest key that fits is kept; one byte more is rejected, not truncated. */
 void TestAiApiKeyLengthBoundary(CuTest *tc)
 {
   char longest[AI_API_KEY_MAX_LEN];
@@ -77,6 +81,7 @@ void TestAiApiKeyLengthBoundary(CuTest *tc)
   ai_api_key_clear();
 }
 
+/* A copy into a buffer that cannot hold the key yields an empty buffer. */
 void TestAiApiKeyCopyRefusesSmallBuffer(CuTest *tc)
 {
   char small[8];
@@ -91,32 +96,55 @@ void TestAiApiKeyCopyRefusesSmallBuffer(CuTest *tc)
   ai_api_key_clear();
 }
 
+/* Rejecting an over-long key logs a reason but never the key material.
+ * The log stream is restored before the first assertion. */
 void TestAiApiKeyNeverReachesLog(CuTest *tc)
 {
   FILE *saved_log = logfile;
   FILE *capture = tmpfile();
   char too_long[AI_API_KEY_MAX_LEN + 8];
   char captured[4096];
+  bool stored = FALSE;
+  bool rejected = FALSE;
+
+  captured[0] = '\0';
+  if (capture)
+  {
+    logfile = capture;
+    stored = ai_api_key_set(TEST_SECRET);
+    memset(too_long, 'z', sizeof(too_long) - 1);
+    memcpy(too_long, TEST_SECRET, strlen(TEST_SECRET));
+    too_long[sizeof(too_long) - 1] = '\0';
+    rejected = !ai_api_key_set(too_long);
+    ai_api_key_clear();
+    read_whole_file(capture, captured, sizeof(captured));
+    logfile = saved_log;
+    fclose(capture);
+  }
 
   CuAssertPtrNotNull(tc, capture);
-  logfile = capture;
-
-  CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
-  memset(too_long, 'z', sizeof(too_long) - 1);
-  memcpy(too_long, TEST_SECRET, strlen(TEST_SECRET));
-  too_long[sizeof(too_long) - 1] = '\0';
-  CuAssertTrue(tc, !ai_api_key_set(too_long));
-  ai_api_key_clear();
-
-  read_whole_file(capture, captured, sizeof(captured));
-  logfile = saved_log;
-  fclose(capture);
-
+  CuAssertTrue(tc, stored);
+  CuAssertTrue(tc, rejected);
   CuAssertTrue(tc, strstr(captured, "rejected") != NULL);
   CuAssertTrue(tc, strstr(captured, TEST_SECRET) == NULL);
   CuAssertTrue(tc, strstr(captured, "SECRET") == NULL);
 }
 
+/* Write a minimal .env in the current directory for load_ai_config(). */
+static void write_scratch_env(const char *body)
+{
+  FILE *fp = fopen(".env", "w");
+
+  if (!fp)
+    return;
+  fputs(body, fp);
+  fclose(fp);
+}
+
+/* Exercises load_ai_config() with a sentinel key and a cleartext endpoint.
+ * Every process-wide change (cwd, ai_state.config, logfile, environment) is
+ * made, the observations are captured, and the state is restored BEFORE the
+ * first CuAssert, because CuAssert longjmps past any cleanup that follows. */
 void TestAiLoadConfigPrefersProcessEnvironmentAndRedacts(CuTest *tc)
 {
   struct ai_config *saved_config = ai_state.config;
@@ -126,44 +154,84 @@ void TestAiLoadConfigPrefersProcessEnvironmentAndRedacts(CuTest *tc)
   char cwd[PATH_MAX];
   char scratch[] = "/tmp/luminari-ai-secrets-XXXXXX";
   char captured[8192];
-  char out[AI_API_KEY_MAX_LEN];
-  struct ai_config *config;
+  char first_copy[AI_API_KEY_MAX_LEN];
+  char endpoint[256];
+  struct ai_config *config = NULL;
+  bool setup_ok = FALSE;
+  bool first_configured = FALSE;
+  bool first_copied = FALSE;
+  bool second_configured = TRUE;
+  bool second_set = TRUE;
 
-  CuAssertPtrNotNull(tc, capture);
-  CuAssertPtrNotNull(tc, getcwd(cwd, sizeof(cwd)));
-  /* Run from an empty directory so no developer lib/.env can supply a key. */
-  CuAssertPtrNotNull(tc, mkdtemp(scratch));
-  CuAssertIntEquals(tc, 0, chdir(scratch));
+  captured[0] = '\0';
+  first_copy[0] = '\0';
+  endpoint[0] = '\0';
 
-  CREATE(config, struct ai_config, 1);
-  ai_state.config = config;
-  logfile = capture;
+  if (capture && getcwd(cwd, sizeof(cwd)) && mkdtemp(scratch) && chdir(scratch) == 0)
+  {
+    /* An empty directory keeps a developer lib/.env out of the picture; the
+     * only .env here carries a cleartext endpoint that must be refused. */
+    write_scratch_env("OPENAI_API_ENDPOINT=http://proxy.example.test/v1/chat/completions\n");
+    CREATE(config, struct ai_config, 1);
+    ai_state.config = config;
+    logfile = capture;
+    setup_ok = setenv("OPENAI_API_KEY", TEST_SECRET, 1) == 0;
 
-  CuAssertIntEquals(tc, 0, setenv("OPENAI_API_KEY", TEST_SECRET, 1));
-  load_ai_config();
-  CuAssertTrue(tc, ai_state.openai_configured);
-  CuAssertTrue(tc, ai_api_key_copy(out, sizeof(out)));
-  CuAssertStrEquals(tc, TEST_SECRET, out);
+    if (setup_ok)
+    {
+      load_ai_config();
+      first_configured = ai_state.openai_configured;
+      first_copied = ai_api_key_copy(first_copy, sizeof(first_copy));
+      strlcpy(endpoint, ai_state.config->openai_endpoint, sizeof(endpoint));
 
-  /* Removing the key and reloading must wipe the resident copy. */
-  CuAssertIntEquals(tc, 0, unsetenv("OPENAI_API_KEY"));
-  load_ai_config();
-  CuAssertTrue(tc, !ai_state.openai_configured);
-  CuAssertTrue(tc, !ai_api_key_is_set());
+      /* Removing the key and reloading must wipe the resident copy. */
+      setup_ok = unsetenv("OPENAI_API_KEY") == 0;
+      load_ai_config();
+      second_configured = ai_state.openai_configured;
+      second_set = ai_api_key_is_set();
+    }
 
-  read_whole_file(capture, captured, sizeof(captured));
+    read_whole_file(capture, captured, sizeof(captured));
+
+    /* Restore everything before asserting. */
+    logfile = saved_log;
+    ai_state.config = saved_config;
+    ai_state.openai_configured = saved_configured;
+    free(config);
+    unsetenv("OPENAI_API_KEY");
+    ai_api_key_clear();
+    unlink(".env");
+    if (chdir(cwd) == 0)
+      rmdir(scratch);
+  }
+  if (capture)
+    fclose(capture);
+
+  CuAssertTrue(tc, setup_ok);
+  CuAssertTrue(tc, first_configured);
+  CuAssertTrue(tc, first_copied);
+  CuAssertStrEquals(tc, TEST_SECRET, first_copy);
+  CuAssertStrEquals(tc, DEFAULT_OPENAI_API_ENDPOINT, endpoint);
+  CuAssertTrue(tc, !second_configured);
+  CuAssertTrue(tc, !second_set);
   CuAssertTrue(tc, strstr(captured, "loaded from environment") != NULL);
+  CuAssertTrue(tc, strstr(captured, "must use https://") != NULL);
   CuAssertTrue(tc, strstr(captured, TEST_SECRET) == NULL);
-
-  logfile = saved_log;
-  fclose(capture);
-  free(config);
-  ai_state.config = saved_config;
-  ai_state.openai_configured = saved_configured;
-  CuAssertIntEquals(tc, 0, chdir(cwd));
-  rmdir(scratch);
 }
 
+/* The https check is case-insensitive and rejects every other scheme. */
+void TestAiEndpointRequiresHttps(CuTest *tc)
+{
+  CuAssertTrue(tc, ai_endpoint_is_https("https://api.openai.com/v1/chat/completions"));
+  CuAssertTrue(tc, ai_endpoint_is_https("HTTPS://proxy.example.test/v1"));
+  CuAssertTrue(tc, !ai_endpoint_is_https("http://localhost:8080/v1"));
+  CuAssertTrue(tc, !ai_endpoint_is_https("ftp://example.test"));
+  CuAssertTrue(tc, !ai_endpoint_is_https("api.openai.com"));
+  CuAssertTrue(tc, !ai_endpoint_is_https(""));
+  CuAssertTrue(tc, !ai_endpoint_is_https(NULL));
+}
+
+/* Sanitization escapes JSON metacharacters and never overruns the caller buffer. */
 void TestSanitizeAiInputUsesCallerBuffer(CuTest *tc)
 {
   char out[16];

--- a/unittests/CuTest/test_ai_secrets.c
+++ b/unittests/CuTest/test_ai_secrets.c
@@ -1,0 +1,190 @@
+/* Regression tests for the OpenAI API key lifecycle in src/ai_security.c.
+ * Covers store/copy/clear boundaries, caller-buffer sanitization, runtime
+ * injection priority, and proof that the key never reaches the log. */
+
+#include "CuTest.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "../../src/conf.h"
+#include "../../src/sysdep.h"
+#include "../../src/structs.h"
+#include "../../src/utils.h"
+#include "../../src/ai_service.h"
+
+extern FILE *logfile;
+
+#define TEST_SECRET "sk-test-SECRET-0123456789abcdef"
+
+static void read_whole_file(FILE *fp, char *out, size_t out_size)
+{
+  size_t got;
+
+  fflush(fp);
+  rewind(fp);
+  got = fread(out, 1, out_size - 1, fp);
+  out[got] = '\0';
+}
+
+void TestAiApiKeyRoundTrip(CuTest *tc)
+{
+  char out[AI_API_KEY_MAX_LEN];
+
+  CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
+  CuAssertTrue(tc, ai_api_key_is_set());
+  CuAssertTrue(tc, ai_api_key_copy(out, sizeof(out)));
+  CuAssertStrEquals(tc, TEST_SECRET, out);
+
+  ai_api_key_clear();
+  CuAssertTrue(tc, !ai_api_key_is_set());
+  CuAssertTrue(tc, !ai_api_key_copy(out, sizeof(out)));
+  CuAssertStrEquals(tc, "", out);
+}
+
+void TestAiApiKeyEmptyAndNullClear(CuTest *tc)
+{
+  CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
+  CuAssertTrue(tc, ai_api_key_set(""));
+  CuAssertTrue(tc, !ai_api_key_is_set());
+
+  CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
+  CuAssertTrue(tc, ai_api_key_set(NULL));
+  CuAssertTrue(tc, !ai_api_key_is_set());
+}
+
+void TestAiApiKeyLengthBoundary(CuTest *tc)
+{
+  char longest[AI_API_KEY_MAX_LEN];
+  char too_long[AI_API_KEY_MAX_LEN + 1];
+  char out[AI_API_KEY_MAX_LEN];
+
+  memset(longest, 'k', sizeof(longest) - 1);
+  longest[sizeof(longest) - 1] = '\0';
+  CuAssertTrue(tc, ai_api_key_set(longest));
+  CuAssertTrue(tc, ai_api_key_copy(out, sizeof(out)));
+  CuAssertStrEquals(tc, longest, out);
+
+  memset(too_long, 'k', sizeof(too_long) - 1);
+  too_long[sizeof(too_long) - 1] = '\0';
+  CuAssertTrue(tc, !ai_api_key_set(too_long));
+  /* A rejected key must not leave the previous key resident either. */
+  CuAssertTrue(tc, !ai_api_key_is_set());
+  CuAssertTrue(tc, !ai_api_key_copy(out, sizeof(out)));
+  CuAssertStrEquals(tc, "", out);
+
+  ai_api_key_clear();
+}
+
+void TestAiApiKeyCopyRefusesSmallBuffer(CuTest *tc)
+{
+  char small[8];
+
+  CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
+  memset(small, 'x', sizeof(small));
+  CuAssertTrue(tc, !ai_api_key_copy(small, sizeof(small)));
+  CuAssertStrEquals(tc, "", small);
+  CuAssertTrue(tc, !ai_api_key_copy(NULL, 16));
+  CuAssertTrue(tc, !ai_api_key_copy(small, 0));
+
+  ai_api_key_clear();
+}
+
+void TestAiApiKeyNeverReachesLog(CuTest *tc)
+{
+  FILE *saved_log = logfile;
+  FILE *capture = tmpfile();
+  char too_long[AI_API_KEY_MAX_LEN + 8];
+  char captured[4096];
+
+  CuAssertPtrNotNull(tc, capture);
+  logfile = capture;
+
+  CuAssertTrue(tc, ai_api_key_set(TEST_SECRET));
+  memset(too_long, 'z', sizeof(too_long) - 1);
+  memcpy(too_long, TEST_SECRET, strlen(TEST_SECRET));
+  too_long[sizeof(too_long) - 1] = '\0';
+  CuAssertTrue(tc, !ai_api_key_set(too_long));
+  ai_api_key_clear();
+
+  read_whole_file(capture, captured, sizeof(captured));
+  logfile = saved_log;
+  fclose(capture);
+
+  CuAssertTrue(tc, strstr(captured, "rejected") != NULL);
+  CuAssertTrue(tc, strstr(captured, TEST_SECRET) == NULL);
+  CuAssertTrue(tc, strstr(captured, "SECRET") == NULL);
+}
+
+void TestAiLoadConfigPrefersProcessEnvironmentAndRedacts(CuTest *tc)
+{
+  struct ai_config *saved_config = ai_state.config;
+  bool saved_configured = ai_state.openai_configured;
+  FILE *saved_log = logfile;
+  FILE *capture = tmpfile();
+  char cwd[PATH_MAX];
+  char scratch[] = "/tmp/luminari-ai-secrets-XXXXXX";
+  char captured[8192];
+  char out[AI_API_KEY_MAX_LEN];
+  struct ai_config *config;
+
+  CuAssertPtrNotNull(tc, capture);
+  CuAssertPtrNotNull(tc, getcwd(cwd, sizeof(cwd)));
+  /* Run from an empty directory so no developer lib/.env can supply a key. */
+  CuAssertPtrNotNull(tc, mkdtemp(scratch));
+  CuAssertIntEquals(tc, 0, chdir(scratch));
+
+  CREATE(config, struct ai_config, 1);
+  ai_state.config = config;
+  logfile = capture;
+
+  CuAssertIntEquals(tc, 0, setenv("OPENAI_API_KEY", TEST_SECRET, 1));
+  load_ai_config();
+  CuAssertTrue(tc, ai_state.openai_configured);
+  CuAssertTrue(tc, ai_api_key_copy(out, sizeof(out)));
+  CuAssertStrEquals(tc, TEST_SECRET, out);
+
+  /* Removing the key and reloading must wipe the resident copy. */
+  CuAssertIntEquals(tc, 0, unsetenv("OPENAI_API_KEY"));
+  load_ai_config();
+  CuAssertTrue(tc, !ai_state.openai_configured);
+  CuAssertTrue(tc, !ai_api_key_is_set());
+
+  read_whole_file(capture, captured, sizeof(captured));
+  CuAssertTrue(tc, strstr(captured, "loaded from environment") != NULL);
+  CuAssertTrue(tc, strstr(captured, TEST_SECRET) == NULL);
+
+  logfile = saved_log;
+  fclose(capture);
+  free(config);
+  ai_state.config = saved_config;
+  ai_state.openai_configured = saved_configured;
+  CuAssertIntEquals(tc, 0, chdir(cwd));
+  rmdir(scratch);
+}
+
+void TestSanitizeAiInputUsesCallerBuffer(CuTest *tc)
+{
+  char out[16];
+
+  sanitize_ai_input("say \"hi\"\\\x01\r\n  ", out, sizeof(out));
+  CuAssertStrEquals(tc, "say \\\"hi\\\"\\\\", out);
+
+  /* Output is bounded and never splits an escape sequence. */
+  sanitize_ai_input("aaaaaaaaaaaaa\"bbbb", out, sizeof(out));
+  CuAssertTrue(tc, strlen(out) < sizeof(out));
+  CuAssertStrEquals(tc, "aaaaaaaaaaaaa\\\"", out);
+  sanitize_ai_input("aaaaaaaaaaaaaa\"bbbb", out, sizeof(out));
+  CuAssertStrEquals(tc, "aaaaaaaaaaaaaa", out);
+
+  memset(out, 'x', sizeof(out));
+  sanitize_ai_input(NULL, out, sizeof(out));
+  CuAssertStrEquals(tc, "", out);
+
+  /* Degenerate buffers must not be written. */
+  sanitize_ai_input("text", NULL, 8);
+  out[0] = 'q';
+  sanitize_ai_input("text", out, 0);
+  CuAssertTrue(tc, out[0] == 'q');
+}


### PR DESCRIPTION
## Summary

Addresses #99 (Security modernization: remove plaintext API-key 'encryption' and define an honest secret lifecycle).

`src/ai_security.c` exposed `encrypt_api_key()` / `decrypt_api_key()` that copied the OpenAI key in plaintext, carried a compiled-in `CIPHER_KEY` constant, kept an unused file loader, and handed out heap copies of the key. The config field was even named `encrypted_api_key`.

### Changes
- The key now lives in exactly one mutex-guarded buffer owned by `ai_security.c`, behind `ai_api_key_set/copy/is_set/clear`. No function claims to encrypt anything; the header and docs state the real boundary.
- The hard-coded cipher key constant and the commented-out key-derivation placeholder are gone. Nothing key-related is compiled into the binary.
- Each OpenAI request copies the key to a stack buffer, builds the `Authorization` header, and wipes both buffers as soon as libcurl owns the header.
- Process environment `OPENAI_API_KEY` takes priority over `lib/.env`, so production can inject the key without an at-rest copy owned by the game.
- Over-long keys are rejected rather than truncated; a reload that no longer supplies a key wipes the resident copy; a missing key fails closed with a log line and no request.
- `sanitize_ai_input()` writes into a caller-owned buffer instead of a static one.
- `docs/systems/AI_SERVICE_README.md` gains a "Secret Lifecycle and Threat Model" section (sources, guarantees, rotation via `ai reload`, what is explicitly not protected). `lib/.env_example` documents the priority.

### Tests
- New `unittests/CuTest/test_ai_secrets.c` (registered in `Makefile.am` and `CMakeLists.txt`): store/copy round trip, NULL/empty clears, 255/256-byte boundary, small-buffer refusal, environment priority and reload wipe (run from an empty directory so a developer `.env` cannot interfere), log capture proving a sentinel key never appears, and sanitizer bounds.
- `make test`: 1379 tests pass, zero warnings. `make install` run afterwards.
- Booted the server on port 4100: key loads, no secret in the log, clean shutdown.

### Out of scope
Argon2/password storage (#97) and SQL binding (#98) are separate issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys can be supplied through the process environment, with file-based configuration as a fallback.
  * API keys are kept in memory, cleared during reloads and shutdown, and excluded from logs and displays.
  * Reloading configuration can rotate the active API key.

* **Bug Fixes**
  * Improved secret handling during API requests and cleanup of temporary sensitive data.
  * Input sanitization now safely handles bounded output buffers.
  * Custom API endpoints now require HTTPS; invalid endpoints fall back to the default.

* **Tests**
  * Added coverage for API key lifecycle, endpoint validation, redaction, and input sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->