### PR TITLE
Own a real optimized and hardened production build profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,14 @@ jobs:
           cp src/mud_options.example.h src/mud_options.h
           cp src/vnums.example.h src/vnums.h
 
-      - name: Build with autotools
+      - name: Build the production profile with autotools
         run: |
           autoreconf -fvi
-          ./configure
+          ./configure --enable-production
           make -j"$(nproc)"
+
+      - name: Verify the hardened release binary
+        run: scripts/deployment/verify_hardened_binary.sh ./luminari
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - 'unittests/**'
       - 'scripts/world/**'
       - 'scripts/ci/**'
+      - 'scripts/deployment/**'
       - 'scripts/operations/**'
       - 'scripts/development/generate-web-guides.sh'
       - 'scripts/events/**'
@@ -38,6 +39,7 @@ on:
       - 'unittests/**'
       - 'scripts/world/**'
       - 'scripts/ci/**'
+      - 'scripts/deployment/**'
       - 'scripts/operations/**'
       - 'scripts/development/generate-web-guides.sh'
       - 'scripts/events/**'
@@ -411,6 +413,101 @@ jobs:
 
       - name: Run the authoritative test entry point
         run: make test-all
+
+  production-profile:
+    name: Production profile (${{ matrix.build }}, ${{ matrix.cc }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [autotools, cmake]
+        cc: [gcc, clang]
+        include:
+          # GCC 14 is the newest GCC on the runner image; it proves the explicit
+          # hardening set on a compiler generation CI would otherwise never see.
+          - build: autotools
+            cc: gcc-14
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: test_root_password
+          MARIADB_DATABASE: luminari_test
+          MARIADB_USER: luminari_test
+          MARIADB_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      CC: ${{ matrix.cc }}
+      LUMINARI_TEST_MYSQL_ENABLE: '1'
+      LUMINARI_TEST_MYSQL_HOST: 127.0.0.1
+      LUMINARI_TEST_MYSQL_USER: luminari_test
+      LUMINARI_TEST_MYSQL_PASSWORD: test_password
+      LUMINARI_TEST_MYSQL_DATABASE: luminari_test
+      LUMINARI_TEST_MYSQL_PORT: '3306'
+      LUMINARI_TEST_DATA_DIR: ${{ github.workspace }}/.ci-runtime/lib
+      LUMINARI_TEST_CONFIG_FILE: .ci-runtime/lib/etc/config
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf automake build-essential clang cmake gcc-14 libcurl4-openssl-dev \
+            libevent-dev libgd-dev libjson-c-dev libmariadb-dev libssl-dev libtool \
+            mariadb-client pandoc ripgrep zlib1g-dev
+
+      - name: Copy config headers
+        run: |
+          cp src/campaign.example.h src/campaign.h
+          cp src/mud_options.example.h src/mud_options.h
+          cp src/vnums.example.h src/vnums.h
+
+      - name: Prepare isolated test runtime
+        run: scripts/ci/prepare_test_runtime.sh "$LUMINARI_TEST_DATA_DIR"
+
+      - name: Build, verify, and test the hardened artifact (autotools)
+        if: matrix.build == 'autotools'
+        run: |
+          autoreconf -fvi
+          # The retired no-op profile option must be rejected, not warned about.
+          if ./configure --enable-optimizations >configure-unknown.log 2>&1; then
+            cat configure-unknown.log
+            echo "configure accepted an unknown option" >&2
+            exit 1
+          fi
+          grep -q 'unrecognized options: --enable-optimizations' configure-unknown.log
+          # The profile must be the last word over a caller's CFLAGS/LDFLAGS.
+          ./configure --enable-production CFLAGS='-O1 -D_FORTIFY_SOURCE=2' LDFLAGS='-Wl,-z,lazy' \
+            >configure-override.log 2>&1
+          grep -Eq '^CFLAGS = -O1 -D_FORTIFY_SOURCE=2 .*-D_FORTIFY_SOURCE=3' Makefile
+          grep -Eq '^LDFLAGS = -Wl,-z,lazy .*-Wl,-z,now' Makefile
+          ./configure --enable-production
+          make -j"$(nproc)"
+          scripts/deployment/verify_hardened_binary.sh ./luminari
+          make test
+          make install
+          scripts/deployment/verify_hardened_binary.sh bin/luminari
+          test -L bin/luminari
+          test ! -e luminari
+
+      - name: Build, verify, and test the hardened artifact (cmake)
+        if: matrix.build == 'cmake'
+        run: |
+          cmake -S . -B build -DLUMINARI_PRODUCTION=ON -DBUILD_TESTS=ON
+          cmake --build build -j"$(nproc)"
+          scripts/deployment/verify_hardened_binary.sh build/bin/luminari
+          scripts/deployment/verify_hardened_binary.sh build/cutest
+          ctest --test-dir build --output-on-failure
+          cmake --install build
+          scripts/deployment/verify_hardened_binary.sh bin/luminari
 
   sanitizers:
     name: ASan, UBSan, and protocol fuzzing

--- a/.gitignore
+++ b/.gitignore
@@ -466,6 +466,7 @@ unittests/CuTest/vessel_tests
 unittests/CuTest/vessel_stress_test
 unittests/CuTest/protocol_parser_tests
 unittests/CuTest/protocol_parser_fuzz
+unittests/CuTest/protocol_parser_bench
 ascii_map.txt
 FRMUD-HEX-Aunauroch.jpg
 plan.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,67 @@ foreach(HEADER
     check_include_file("${HEADER}" HAVE_${_upper_name})
 endforeach()
 
+# ========== Production build profile ==========
+# scripts/deployment/production_profile.sh is the single source of truth shared
+# with configure.ac.  It feature-detects the optimization and hardening flags
+# against the same GNU C23 dialect flag the build uses and reports anything the
+# toolchain rejects.  LTO and PGO are explicit, measured profiles and never
+# default.
+option(LUMINARI_PRODUCTION
+       "Build the optimized and hardened production profile (-O2 -g plus feature-detected hardening)"
+       OFF)
+option(LUMINARI_LTO "Add link-time optimization to the build (explicit, measured profile)" OFF)
+set(LUMINARI_PGO_GENERATE "" CACHE PATH
+    "Instrument the build to write profile data into this directory")
+set(LUMINARI_PGO_USE "" CACHE PATH
+    "Optimize using previously collected profile data at this path")
+
+set(PRODUCTION_PROFILE_ARGS)
+if (LUMINARI_PRODUCTION)
+    if (CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE STREQUAL "None")
+        message(FATAL_ERROR
+            "LUMINARI_PRODUCTION owns the optimization and debug-symbol policy; "
+            "leave CMAKE_BUILD_TYPE unset instead of '${CMAKE_BUILD_TYPE}'")
+    endif()
+    list(APPEND PRODUCTION_PROFILE_ARGS --production)
+endif()
+if (LUMINARI_LTO)
+    list(APPEND PRODUCTION_PROFILE_ARGS --lto)
+endif()
+if (LUMINARI_PGO_GENERATE)
+    list(APPEND PRODUCTION_PROFILE_ARGS --pgo-generate ${LUMINARI_PGO_GENERATE})
+endif()
+if (LUMINARI_PGO_USE)
+    list(APPEND PRODUCTION_PROFILE_ARGS --pgo-use ${LUMINARI_PGO_USE})
+endif()
+
+set(PRODUCTION_SUPPORTED "")
+if (PRODUCTION_PROFILE_ARGS)
+    execute_process(
+        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/scripts/deployment/production_profile.sh
+                --cc ${CMAKE_C_COMPILER}
+                --cflags "${CMAKE_C23_EXTENSION_COMPILE_OPTION}"
+                ${PRODUCTION_PROFILE_ARGS}
+        OUTPUT_VARIABLE PRODUCTION_PROFILE_OUTPUT
+        ERROR_VARIABLE PRODUCTION_PROFILE_ERROR
+        RESULT_VARIABLE PRODUCTION_PROFILE_RESULT)
+    if (NOT PRODUCTION_PROFILE_RESULT EQUAL 0)
+        message(FATAL_ERROR "Production build profile failed: ${PRODUCTION_PROFILE_ERROR}")
+    endif()
+    foreach (key CFLAGS LDFLAGS SUPPORTED UNSUPPORTED)
+        string(REGEX MATCH "PRODUCTION_${key}=([^\n]*)" _ "${PRODUCTION_PROFILE_OUTPUT}")
+        set(PRODUCTION_${key} "${CMAKE_MATCH_1}")
+    endforeach()
+    string(APPEND CMAKE_C_FLAGS " ${PRODUCTION_CFLAGS}")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " ${PRODUCTION_LDFLAGS}")
+    message(STATUS "Production profile flags: ${PRODUCTION_CFLAGS} ${PRODUCTION_LDFLAGS}")
+    if (PRODUCTION_UNSUPPORTED)
+        message(WARNING
+            "Hardening features not supported by ${CMAKE_C_COMPILER} and left out: "
+            "${PRODUCTION_UNSUPPORTED}")
+    endif()
+endif()
+
 if (HAVE_STDLIB_H AND HAVE_STDIO_H AND HAVE_STRING_H)
     set(STDC_HEADERS 1)
 endif()
@@ -1101,6 +1162,12 @@ if (BUILD_TESTS)
         native-event-architecture
         event-pubsub-retirement
         PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    # These scripts preprocess game sources; point them at the generated conf.h.
+    set_tests_properties(
+        demand-driven-event-architecture
+        native-event-architecture
+        PROPERTIES ENVIRONMENT
+            "CC=${CMAKE_C_COMPILER};CPPFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}")
 
     add_test(NAME world-tools
         COMMAND Python3::Interpreter -m unittest discover
@@ -1120,10 +1187,13 @@ if (BUILD_TESTS)
         world-tool-wrapper
         PROPERTIES
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    # The world tests preprocess game sources; point them at the generated conf.h.
+    set(WORLD_TOOLS_TEST_ENV "CPPFLAGS=-I${CMAKE_CURRENT_BINARY_DIR}")
     if (TARGET rol_mob_calculator)
-        set_tests_properties(world-tools PROPERTIES
-            ENVIRONMENT "ROL_MOB_CALCULATOR=$<TARGET_FILE:rol_mob_calculator>")
+        list(APPEND WORLD_TOOLS_TEST_ENV
+            "ROL_MOB_CALCULATOR=$<TARGET_FILE:rol_mob_calculator>")
     endif()
+    set_tests_properties(world-tools PROPERTIES ENVIRONMENT "${WORLD_TOOLS_TEST_ENV}")
 
     add_test(NAME autorun-supervision
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/autorun/test_autorun_supervision.sh)
@@ -1138,6 +1208,11 @@ if (BUILD_TESTS)
         COMMAND bash
             ${CMAKE_CURRENT_SOURCE_DIR}/scripts/deployment/test_binary_name_static.sh)
     set_tests_properties(binary-name-static PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    add_test(NAME production-profile
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/deployment/test_production_profile.sh)
+    set_tests_properties(production-profile PROPERTIES
+        ENVIRONMENT "CC=${CMAKE_C_COMPILER}"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_test(NAME healthcheck
@@ -1242,6 +1317,8 @@ message(STATUS "  C Standard: GNU C23")
 message(STATUS "  C Compiler: ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
 message(STATUS "  MySQL Client: ${LUMINARI_MYSQL_TARGET}")
 message(STATUS "  Build Type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "  Production Profile: ${LUMINARI_PRODUCTION} (${PRODUCTION_SUPPORTED})")
+message(STATUS "  LTO: ${LUMINARI_LTO}")
 message(STATUS "  Build Utilities: ${BUILD_UTILS}")
 message(STATUS "  Build Tests: ${BUILD_TESTS}")
 message(STATUS "  Developer Mode: ${DEVELOPER_MODE}")

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,8 @@ SUBDIRS = util
 
 # Additional compiler flags
 # Revert to project defaults: do NOT force global feature defines here.
+# The production profile lives in CFLAGS/LDFLAGS (configure appends it after
+# the user's flags) rather than here, where user CFLAGS would override it.
 AM_CFLAGS = @CSTD_CFLAGS@ @MYFLAGS@ @LIBEVENT_CFLAGS@
 
 
@@ -824,6 +826,7 @@ EXTRA_DIST = \
 	unittests/README_unittests.md \
 	unittests/CuTest/Makefile \
 	unittests/CuTest/README.txt \
+	unittests/CuTest/bench_protocol_parser.c \
 	unittests/CuTest/fuzz_protocol_parser.c \
 	unittests/CuTest/fuzz_corpus/plain_command.txt \
 	unittests/CuTest/fuzz_corpus/gmcp_like.txt \
@@ -857,8 +860,11 @@ EXTRA_DIST = \
 	scripts/deployment/generate_build_identity.sh \
 	scripts/deployment/install_versioned_binary.sh \
 	scripts/deployment/move_bin.sh \
+	scripts/deployment/production_profile.sh \
 	scripts/deployment/setup.sh \
+	scripts/deployment/test_production_profile.sh \
 	scripts/deployment/test_versioned_binary_install.sh \
+	scripts/deployment/verify_hardened_binary.sh \
 	scripts/development/check_local_port_allocations.sh \
 	scripts/development/dev_create_test_character.sh \
 	scripts/development/dev_kohdee_login_smoke.sh \
@@ -1024,7 +1030,7 @@ distcheck-archive:
 
 # Run unit tests
 test: check check-build-parity test-help-sync test-autorun-supervision test-versioned-binary-install \
-	test-binary-name-static test-healthcheck test-sql-interpolation \
+	test-binary-name-static test-healthcheck test-sql-interpolation test-production-profile \
 	test-background-help-entries test-demand-driven-architecture test-event-admission \
 	test-event-core-performance-gate test-native-event-architecture test-pubsub-retirement \
 	test-vessel-tooling
@@ -1036,7 +1042,7 @@ test: check check-build-parity test-help-sync test-autorun-supervision test-vers
 	test-help-sync-integration test-protocol test-protocol-fuzz test-character-rename-static \
 	test-character-rename-schema test-background-help-entries test-autorun-supervision \
 	test-versioned-binary-install test-binary-name-static test-healthcheck \
-	test-sql-interpolation \
+	test-sql-interpolation test-production-profile \
 	test-demand-driven-architecture test-event-admission test-native-event-architecture \
 	test-event-core-performance-gate test-pubsub-retirement \
 	test-vessel-tooling
@@ -1100,6 +1106,9 @@ test-versioned-binary-install:
 
 test-binary-name-static:
 	$(SHELL) ./scripts/deployment/test_binary_name_static.sh
+
+test-production-profile:
+	CC="$(CC)" ./scripts/deployment/test_production_profile.sh
 
 test-healthcheck:
 	./scripts/operations/test_healthcheck.sh

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,12 @@ AC_SUBST(CRYPTLIB)
 AC_SUBST(CSTD_CFLAGS)
 
 AC_CONFIG_HEADERS([src/conf.h:conf.h.in])
+
+dnl Unknown configure options are fatal by default.  The production profile was
+dnl once requested through an option configure.ac never defined, and the build
+dnl silently used the default flags; a caller may still pass
+dnl --enable-option-checking=no or =warn to override this deliberately.
+m4_divert_text([DEFAULTS], [enable_option_checking=fatal])
 AC_DEFINE([CIRCLE_UNIX], [1], [Define for Unix-based systems])
 
 dnl Find the 'more' program
@@ -94,6 +100,69 @@ else
   dnl We aren't using gcc so we can't assume any special flags.
   MYFLAGS=""
 
+fi
+
+dnl Production build profile.  scripts/deployment/production_profile.sh is the
+dnl single source of truth shared with CMake: it feature-detects the
+dnl optimization and hardening flags and reports anything the toolchain
+dnl rejects.  LTO and PGO are explicit, measured profiles and never default.
+AC_ARG_ENABLE([production],
+  [AS_HELP_STRING([--enable-production],
+    [build the optimized and hardened production profile (-O2 -g plus feature-detected hardening)])],
+  [], [enable_production=no])
+AC_ARG_ENABLE([lto],
+  [AS_HELP_STRING([--enable-lto],
+    [add link-time optimization to the build (explicit, measured profile)])],
+  [], [enable_lto=no])
+AC_ARG_WITH([pgo-generate],
+  [AS_HELP_STRING([--with-pgo-generate=DIR],
+    [instrument the build to write profile data into DIR])],
+  [], [with_pgo_generate=no])
+AC_ARG_WITH([pgo-use],
+  [AS_HELP_STRING([--with-pgo-use=PATH],
+    [optimize using previously collected profile data at PATH])],
+  [], [with_pgo_use=no])
+
+PRODUCTION_CFLAGS=""
+PRODUCTION_LDFLAGS=""
+production_profile_args=""
+AS_IF([test "x$enable_production" != xno],
+  [production_profile_args="$production_profile_args --production"])
+AS_IF([test "x$enable_lto" != xno],
+  [production_profile_args="$production_profile_args --lto"])
+AS_IF([test "x$with_pgo_generate" != xno],
+  [production_profile_args="$production_profile_args --pgo-generate $with_pgo_generate"])
+AS_IF([test "x$with_pgo_use" != xno],
+  [production_profile_args="$production_profile_args --pgo-use $with_pgo_use"])
+
+if test "x$production_profile_args" != x; then
+  AC_MSG_CHECKING([the production build profile for $CC])
+  production_profile_output=`$SHELL "$srcdir/scripts/deployment/production_profile.sh" \
+    --cc "$CC" --cflags "$CSTD_CFLAGS" $production_profile_args 2>conftest.profile.err`
+  production_profile_status=$?
+  if test $production_profile_status -ne 0; then
+    AC_MSG_RESULT([failed])
+    cat conftest.profile.err >&AS_MESSAGE_LOG_FD
+    production_profile_error=`cat conftest.profile.err`
+    rm -f conftest.profile.err
+    AC_MSG_ERROR([$production_profile_error])
+  fi
+  rm -f conftest.profile.err
+  PRODUCTION_CFLAGS=`printf '%s\n' "$production_profile_output" | sed -n 's/^PRODUCTION_CFLAGS=//p'`
+  PRODUCTION_LDFLAGS=`printf '%s\n' "$production_profile_output" | sed -n 's/^PRODUCTION_LDFLAGS=//p'`
+  production_supported=`printf '%s\n' "$production_profile_output" | sed -n 's/^PRODUCTION_SUPPORTED=//p'`
+  production_unsupported=`printf '%s\n' "$production_profile_output" | sed -n 's/^PRODUCTION_UNSUPPORTED=//p'`
+  AC_MSG_RESULT([$PRODUCTION_CFLAGS $PRODUCTION_LDFLAGS])
+  AC_MSG_NOTICE([production hardening enabled: ${production_supported:-none}])
+  for production_feature in $production_unsupported; do
+    AC_MSG_WARN([hardening feature not supported by $CC and left out: $production_feature])
+  done
+  dnl Automake compiles with $(AM_CFLAGS) $(CFLAGS), so anything carried in
+  dnl AM_CFLAGS loses to a user CFLAGS such as -D_FORTIFY_SOURCE=2.  Append the
+  dnl profile to CFLAGS/LDFLAGS themselves, after the user's values, so the
+  dnl repository policy is the last word exactly as it is under CMake.
+  CFLAGS="$CFLAGS $PRODUCTION_CFLAGS"
+  LDFLAGS="$LDFLAGS $PRODUCTION_LDFLAGS"
 fi
 
 dnl Checks for libraries.  We check for the library only if the function is

--- a/docs/deployment/DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/DEPLOYMENT_GUIDE.md
@@ -48,7 +48,7 @@ Verified options from `./scripts/deployment/deploy.sh --help`:
 |--------|----------|
 | `--auto` | Use defaults without prompts |
 | `--dev` | Development build with debugging tools |
-| `--prod` | Optimized production build |
+| `--prod` | Production profile: optimized, hardened, and verified build |
 | `--skip-deps` | Skip dependency installation |
 | `--skip-db` | Skip database setup; the server still requires a configured database |
 | `--init-world` | Initialize minimal world data; enabled by default |
@@ -82,6 +82,146 @@ make install
 
 The [setup and build guide](../guides/SETUP_AND_BUILD_GUIDE.md) documents fresh
 manual configuration and the CMake path.
+
+## Production Build Profile
+
+`deploy.sh --prod` configures the production profile. Both build systems apply
+the same contract, produced by `scripts/deployment/production_profile.sh`,
+which feature-detects every flag against the selected compiler and reports
+anything the toolchain rejects instead of dropping it silently:
+
+```bash
+./configure --enable-production
+cmake -S . -B build -DLUMINARI_PRODUCTION=ON
+```
+
+`configure.ac` makes unknown configure options fatal, so a misspelled or
+removed profile can never fall back to the default flags; pass
+`--enable-option-checking=warn` only to override that deliberately. With CMake
+the profile owns the optimization policy, so leave `CMAKE_BUILD_TYPE` unset;
+configuring both is an error.
+
+| Policy | Setting |
+|--------|---------|
+| Optimization | `-O2` |
+| Debug symbols | `-g`; `make install` splits them into `bin/releases/<build-id>/luminari.debug` |
+| Assertions | Enabled (no `NDEBUG`); a core file beats running on corrupt state |
+| Build ID | Required by the versioned installer and the crash workflow |
+| LTO and PGO | Never default; explicit options below |
+
+Hardening set (each flag is requested explicitly and accepted only after a
+compile-and-link probe; GCC 14's `-fhardened` bundle is not used because
+distributions that already define `_FORTIFY_SOURCE` in the compiler spec make
+it reject the very flags it bundles):
+
+- `_FORTIFY_SOURCE=3` with optimization
+- PIE (`-fPIE -pie`)
+- full RELRO with immediate binding (`-z relro -z now`)
+- strong stack protector
+- stack-clash protection
+- control-flow protection (`-fcf-protection=full`, x86 toolchains)
+- non-executable stack (`-z noexecstack`)
+
+Supported GCC and Clang toolchains produce equivalent binaries; configure
+prints the enabled set and warns for each unsupported item. On architectures
+without `-fcf-protection` that item is reported as unsupported and left out.
+
+The profile also defines `LUMINARI_PRODUCTION_PROFILE`, which makes
+`src/constants.c` embed a marker in a `.luminari.profile` ELF section. That
+marker is what lets the verifier below distinguish the repository profile from
+a distribution whose compiler defaults happen to include the same hardening.
+
+### Verifying the artifact
+
+Every production build must pass the ELF check, which only needs `readelf`:
+
+```bash
+./scripts/deployment/verify_hardened_binary.sh bin/luminari
+```
+
+It requires the profile marker section, PIE, a non-executable stack, RELRO
+with BIND_NOW, stack-protector and fortified libc references, a build ID,
+control-flow protection notes on x86-64, and the absence of RPATH/RUNPATH and
+text relocations. A binary built with the compiler's default flags fails on the
+missing marker even on Ubuntu, whose defaults already supply the other
+properties; `test-production-profile` asserts exactly that. `deploy.sh --prod`
+runs the check after installation and fails the deployment on any missing
+property. The `production-profile` CI matrix (Autotools with GCC, GCC 14, and
+Clang; CMake with GCC and Clang) builds the profile, verifies the linked server
+and the test binary, runs the full production-linked suite against that exact
+hardened artifact, and verifies the installed `bin/luminari`. The Autotools
+cells also assert that the retired `--enable-optimizations` option is rejected.
+The release workflow builds the same profile and verifies it before publishing.
+
+### Crash symbolization
+
+The installed release keeps full symbols next to the executable. Load them
+explicitly when the build ID directory is not in gdb's search path:
+
+```bash
+gdb -ex "symbol-file bin/releases/<build-id>/luminari.debug" \
+    bin/releases/<build-id>/luminari core
+```
+
+`bin/luminari --build-info` and `readelf -n` print the build ID that names the
+release directory for any core file or autorun crash archive.
+
+### Explicit LTO and PGO profiles
+
+Link-time optimization and profile-guided optimization are opt-in, and their
+effect must be measured against the benchmarks below before they are ever
+made default:
+
+```bash
+./configure --enable-production --enable-lto
+./configure --enable-production --with-pgo-generate=/path/to/profiles
+./configure --enable-production --with-pgo-use=/path/to/profiles
+cmake -S . -B build -DLUMINARI_PRODUCTION=ON -DLUMINARI_LTO=ON
+cmake -S . -B build -DLUMINARI_PRODUCTION=ON -DLUMINARI_PGO_GENERATE=/path/to/profiles
+```
+
+GCC uses `-flto=auto`; Clang uses ThinLTO. With Clang, merge the generated
+`.profraw` files with `llvm-profdata merge` and pass the resulting
+`.profdata` file to `--with-pgo-use` or `LUMINARI_PGO_USE`. A requested LTO or
+PGO profile the compiler cannot honor is a configuration error, not a warning.
+
+### Benchmarks
+
+Two stable benchmarks record the cost of a flag change:
+
+- The hot-parser microbenchmark isolates the protocol layer from world,
+  database, and scheduler effects. Build it with the flags under test and
+  compare the median:
+
+  ```bash
+  make -C unittests/CuTest protocol-bench \
+      PROTOCOL_BENCH_CFLAGS="-Wall -Wextra -std=gnu23 <profile CFLAGS>" \
+      PROTOCOL_BENCH_LDFLAGS="-lm -ljson-c <profile LDFLAGS>"
+  ```
+
+- The live game-loop benchmark is the
+  [event-core performance gate](EVENT_DRIVEN_CORE_RELEASE_GATE.md), which
+  measures scheduler lateness and command round-trip latency on the installed
+  artifact. It needs a dedicated database snapshot and an idle host, so CI
+  does not run it; it has not yet been recorded under the production profile,
+  and that measurement is a precondition for making LTO or PGO default.
+
+Baseline recorded 2026-09-11 on an idle WSL2 host (Ubuntu 24.04, GCC 13.3,
+glibc 2.39, x86-64) with `PROTOCOL_BENCH_ITERATIONS=2000`, median of five
+rounds over the three corpus inputs:
+
+| Profile | Median per iteration |
+|---------|----------------------|
+| Default `-O2 -g` | 34.2 us |
+| Production (hardened) | 34.6 us |
+| Production + LTO | 33.9 us |
+
+Round-to-round spread was about 1 us, so the hardening cost and the LTO gain
+are both inside measurement noise on this parser workload. Removing any single
+hardening flag did not move the median. This is parser-only evidence: LTO
+stays opt-in until the live gate above shows a benefit on the hardened server.
+Numbers taken while other builds are running are not comparable; the same
+machine measured a 2x slowdown under load.
 
 ## Configuration Boundaries
 
@@ -138,11 +278,11 @@ Use direct startup for local development. For a supervised local process:
 | Workflow | Trigger | Contract |
 |----------|---------|----------|
 | Code Quality | Push or pull request affecting C sources/config | Formatting, targeted static analysis, warning build |
-| Build & Test | Relevant pushes and pull requests | World tools, production tests, sanitizers, Valgrind, coverage, and related gates |
+| Build & Test | Relevant pushes and pull requests | World tools, production tests, hardened production-profile matrix, sanitizers, Valgrind, coverage, and related gates |
 | Security | Relevant pushes/PRs, manual, twice monthly | Gitleaks, CodeQL, and PR-only dependency review |
 | Integration | Relevant pull requests or manual dispatch | MariaDB schema checks, isolated world/runtime validation, network and health smoke tests |
 | GitHub Pages | Documentation push to `master` or manual dispatch | Publishes the `docs/` tree |
-| Release | Tag matching `v*.*.*` | Builds and creates GitHub release notes |
+| Release | Tag matching `v*.*.*` | Builds and verifies the hardened production profile, then creates GitHub release notes |
 
 The release workflow creates GitHub release metadata; it does not update a
 running host. Production deployment remains an explicit operator action.
@@ -252,4 +392,4 @@ the crash archive and its matching immutable executable before rebuilding.
 - [Testing guide](../guides/TESTING_GUIDE.md)
 - [Incident response](../runbooks/incident-response.md)
 
-Last updated: 2026-09-06
+Last updated: 2026-09-11

--- a/docs/guides/SETUP_AND_BUILD_GUIDE.md
+++ b/docs/guides/SETUP_AND_BUILD_GUIDE.md
@@ -77,6 +77,26 @@ Edit local configuration without committing it. Never overwrite an existing
 World and text data must exist under `lib/`. Use the deployment script for a
 fresh minimal world rather than assembling the required indexes manually.
 
+## Production Profile
+
+The default configuration is the development build. Production deployments
+use the optimized and hardened profile, which both build systems derive from
+`scripts/deployment/production_profile.sh`:
+
+```bash
+./configure --enable-production
+make -j"$(nproc)"
+./scripts/deployment/verify_hardened_binary.sh ./luminari
+make test
+make install
+```
+
+Unknown configure options are fatal, so a misspelled profile cannot fall back
+to the default flags. `--enable-lto`, `--with-pgo-generate=DIR`, and
+`--with-pgo-use=PATH` are explicit, measured additions. The
+[deployment guide](../deployment/DEPLOYMENT_GUIDE.md#production-build-profile)
+records the flag policy, verification, and crash-symbolization workflow.
+
 ## CMake
 
 CMake is the supported secondary build. Use the checked-in presets, which
@@ -101,6 +121,15 @@ run by `make test`, CTest, and CI) fails when `Makefile.am` and
 installs an untouched `git archive HEAD` through both systems; CI runs it as
 a blocking job, and it is not part of `make test` because it rebuilds the
 tree twice.
+
+The production profile replaces `CMAKE_BUILD_TYPE`:
+
+```bash
+cmake -S . -B build -DLUMINARI_PRODUCTION=ON
+```
+
+`LUMINARI_LTO`, `LUMINARI_PGO_GENERATE`, and `LUMINARI_PGO_USE` mirror the
+Autotools options.
 
 ## Run and Verify
 

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -385,6 +385,28 @@ The harness exercises the production protocol parser without booting the MUD
 or opening a live network socket. See
 `docs/testing/PROTOCOL_PARSER_HARNESS.md` for its fixture and case matrix.
 
+Time the same parser paths with the flags under evaluation:
+
+```sh
+make -C unittests/CuTest protocol-bench
+```
+
+`PROTOCOL_BENCH_CFLAGS` and `PROTOCOL_BENCH_LDFLAGS` select the profile;
+`PROTOCOL_BENCH_ITERATIONS` bounds the run. The target prints the median,
+minimum, and maximum nanoseconds per iteration over five rounds. Measure on an
+idle host; the result is not comparable while other builds are running.
+
+## Production Profile Contract
+
+`make test` includes `test-production-profile`, which checks that
+`scripts/deployment/production_profile.sh` emits its four output keys with the
+`-O2 -g` policy, that a program built with those flags passes
+`scripts/deployment/verify_hardened_binary.sh`, that the same program built
+with the compiler's default flags fails it (the profile marker section is
+missing, whatever hardening the distribution applies on its own), and that the
+verifier names every property a deliberately degraded build lacks. Set `CC` to
+run it against another compiler. The CMake test is named `production-profile`.
+
 Run every maintained test path from the repository root with:
 
 ```sh
@@ -662,6 +684,11 @@ must not be added to the enforced suite.
   `ci-gcc` and `ci-clang` presets (`-Wall -Wextra -Werror`);
 - the supported Luminari behavioral suite;
 - root `make test-all`;
+- the hardened production profile on Autotools (GCC, GCC 14, Clang) and CMake
+  (GCC, Clang), rejecting the retired `--enable-optimizations` option,
+  verifying the linked server and test binaries, running the full
+  production-linked suite against that artifact, and verifying the installed
+  server;
 - ASan, UBSan, and bounded protocol fuzzing;
 - Valgrind on the production-linked suite;
 - MariaDB-backed fixed gcovr floors and coverage-artifact upload;

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -10,7 +10,7 @@
 #   -h, --help        Show help message
 #   --auto            Automated setup with defaults (no prompts)
 #   -d, --dev         Development mode (includes debug tools)
-#   -p, --prod        Production mode (optimized build)
+#   -p, --prod        Production profile (optimized, hardened, verified build)
 #   --skip-deps       Skip dependency installation
 #   --skip-db         Skip database setup (NOT RECOMMENDED - database is required)
 #   --install-systemd Install/update only the canonical systemd unit
@@ -292,6 +292,16 @@ EOF
     print_msg "$GREEN" "Database setup complete!"
 }
 
+# Fail the deployment when the installed executable lacks a required
+# production hardening property.
+verify_production_binary() {
+    print_msg "$GREEN" "Verifying production hardening of bin/luminari..."
+    if ! "$PROJECT_ROOT/scripts/deployment/verify_hardened_binary.sh" "$PROJECT_ROOT/bin/luminari"; then
+        print_msg "$RED" "Production binary failed the hardening check"
+        exit 1
+    fi
+}
+
 # Function to build the project
 build_project() {
     print_header "Building LuminariMUD"
@@ -317,10 +327,12 @@ build_project() {
             chmod +x unittests/CuTest/make-tests.sh
         fi
 
-        # Configure
+        # Configure.  configure.ac makes unknown options fatal, so a
+        # misspelled or removed profile can never silently fall back to the
+        # default flags.
         print_msg "$GREEN" "Running configure..."
         if [[ "$BUILD_TYPE" == "production" ]]; then
-            ./configure --enable-optimizations
+            ./configure --enable-production
         else
             ./configure
         fi
@@ -342,6 +354,10 @@ build_project() {
 
         print_msg "$GREEN" "Build and install complete: bin/luminari"
 
+        if [[ "$BUILD_TYPE" == "production" ]]; then
+            verify_production_binary
+        fi
+
     elif [[ -f CMakeLists.txt ]]; then
         print_msg "$GREEN" "Building with CMake..."
 
@@ -349,9 +365,10 @@ build_project() {
         rm -rf build
         mkdir -p build
 
-        # Configure
+        # Configure.  The production profile owns optimization and
+        # debug-symbol policy, so it replaces CMAKE_BUILD_TYPE.
         if [[ "$BUILD_TYPE" == "production" ]]; then
-            cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Release
+            cmake -S . -B build/ -DLUMINARI_PRODUCTION=ON
         else
             cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Debug
         fi
@@ -361,6 +378,10 @@ build_project() {
 
         # Install the immutable server release and utility binaries.
         cmake --install build/
+
+        if [[ "$BUILD_TYPE" == "production" ]]; then
+            verify_production_binary
+        fi
 
     else
         print_msg "$RED" "No build system found!"
@@ -998,7 +1019,7 @@ Options:
     -h, --help        Show this help message
     --auto            Automated setup with defaults (no prompts)
     -d, --dev         Development mode (includes debug tools)
-    -p, --prod        Production mode (optimized build)
+    -p, --prod        Production profile (optimized, hardened, verified build)
     --skip-deps       Skip dependency installation
     --skip-db         Skip database setup (NOT RECOMMENDED - database is REQUIRED)
     --init-world      Initialize minimal world data (enabled by default)
@@ -1012,7 +1033,7 @@ Examples:
     $0                            # RECOMMENDED: Full interactive setup (includes world init)
     $0 --auto                     # Automated setup with defaults
     $0 --dev                      # Development build with debug tools
-    $0 --prod                     # Production optimized build
+    $0 --prod                     # Production optimized and hardened build
     $0 --install-systemd          # Refresh the installed service definition
     $0 --install-systemd --restart-service
                                    # Refresh it and restart the service

--- a/scripts/deployment/production_profile.sh
+++ b/scripts/deployment/production_profile.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+#
+# Probe the C compiler for the LuminariMUD production build profile and print
+# the flags both build systems apply.  Autotools (configure.ac) and CMake
+# (CMakeLists.txt) call this script so the two builds share one contract.
+#
+# Output (one KEY=VALUE per line, every key always present):
+#   PRODUCTION_CFLAGS       compiler flags to append
+#   PRODUCTION_LDFLAGS      linker flags to append
+#   PRODUCTION_SUPPORTED    space-separated hardening features enabled
+#   PRODUCTION_UNSUPPORTED  space-separated hardening features the toolchain
+#                           rejected; the caller must report these
+#
+# Exit status is non-zero when the compiler cannot build a trivial program, an
+# option is unknown, or an explicitly requested LTO/PGO profile is unsupported.
+# Missing hardening features are reported through PRODUCTION_UNSUPPORTED, never
+# silently dropped.
+
+set -euo pipefail
+
+cc=
+base_cflags=
+production=0
+lto=0
+pgo_generate=
+pgo_use=
+
+usage()
+{
+  cat >&2 <<'USAGE'
+usage: production_profile.sh --cc COMPILER [--cflags FLAGS] [--production]
+                             [--lto] [--pgo-generate DIR] [--pgo-use PATH]
+USAGE
+  exit 2
+}
+
+fail()
+{
+  printf 'production profile: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --cc)
+      [[ $# -ge 2 ]] || usage
+      cc=$2
+      shift 2
+      ;;
+    --cflags)
+      [[ $# -ge 2 ]] || usage
+      base_cflags=$2
+      shift 2
+      ;;
+    --production)
+      production=1
+      shift
+      ;;
+    --lto)
+      lto=1
+      shift
+      ;;
+    --pgo-generate)
+      [[ $# -ge 2 ]] || usage
+      pgo_generate=$2
+      shift 2
+      ;;
+    --pgo-use)
+      [[ $# -ge 2 ]] || usage
+      pgo_use=$2
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -n "$cc" ]] || usage
+if [[ -n "$pgo_generate" && -n "$pgo_use" ]]; then
+  fail "--pgo-generate and --pgo-use are mutually exclusive"
+fi
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/luminari-production-profile.XXXXXX")
+trap 'rm -rf -- "$work_dir"' EXIT
+
+trivial_source="$work_dir/trivial.c"
+cat > "$trivial_source" <<'SOURCE'
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+  char buffer[32];
+
+  snprintf(buffer, sizeof(buffer), "%d", argc);
+  return argv[0] != NULL && strlen(buffer) > 0 ? 0 : 1;
+}
+SOURCE
+
+fortify_source="$work_dir/fortify.c"
+cat > "$fortify_source" <<'SOURCE'
+#include <string.h>
+
+#if !defined(__USE_FORTIFY_LEVEL) || __USE_FORTIFY_LEVEL < 3
+#error "_FORTIFY_SOURCE=3 is not available with this compiler and C library"
+#endif
+
+int main(int argc, char **argv)
+{
+  char buffer[8];
+
+  (void)argc;
+  strcpy(buffer, "x");
+  return argv[0] != NULL && buffer[0] == 'x' ? 0 : 1;
+}
+SOURCE
+
+# try_build SOURCE STRICT FLAGS...: compile and link SOURCE with FLAGS.  With
+# STRICT=1 every warning is fatal so a flag that is merely tolerated (for
+# example "unused command-line argument") counts as unsupported.
+try_build()
+{
+  local source=$1
+  local strict=$2
+  shift 2
+  local -a strict_flags=()
+
+  if [[ "$strict" == 1 ]]; then
+    # shellcheck disable=SC2054
+    strict_flags=(-Werror -Wl,--fatal-warnings)
+  fi
+  # shellcheck disable=SC2086
+  "$cc" $base_cflags "${strict_flags[@]}" "$@" -o "$work_dir/probe" "$source" \
+    >"$work_dir/probe.log" 2>&1
+}
+
+# shellcheck disable=SC2086
+"$cc" $base_cflags -o "$work_dir/probe" "$trivial_source" >"$work_dir/probe.log" 2>&1 ||
+  fail "$cc cannot build a trivial program: $(tr '\n' ' ' < "$work_dir/probe.log")"
+
+is_clang=0
+if "$cc" -dM -E - </dev/null 2>/dev/null | grep -q '__clang__'; then
+  is_clang=1
+fi
+
+cflags=()
+ldflags=()
+supported=()
+unsupported=()
+
+# probe_feature NAME CFLAGS LDFLAGS [SOURCE]: enable one hardening feature when
+# the toolchain accepts it, otherwise record it as unsupported.
+probe_feature()
+{
+  local name=$1
+  local feature_cflags=$2
+  local feature_ldflags=$3
+  local source=${4:-$trivial_source}
+
+  # shellcheck disable=SC2086
+  if try_build "$source" 1 -O2 "${cflags[@]}" $feature_cflags "${ldflags[@]}" \
+    $feature_ldflags; then
+    # shellcheck disable=SC2206
+    cflags+=($feature_cflags)
+    # shellcheck disable=SC2206
+    ldflags+=($feature_ldflags)
+    supported+=("$name")
+  else
+    unsupported+=("$name")
+  fi
+}
+
+if [[ "$production" == 1 ]]; then
+  # Optimization and symbol policy: -O2 with full DWARF.  The versioned
+  # installer splits the debug information into a .debug companion keyed by
+  # ELF build ID, so production keeps symbolizable crashes without shipping a
+  # bloated executable.  Assertions stay enabled (no NDEBUG): a MUD that stops
+  # with a core file is preferable to one that keeps running on corrupt state.
+  #
+  # LUMINARI_PRODUCTION_PROFILE makes src/constants.c embed a marker section
+  # that verify_hardened_binary.sh requires, so a binary built from default
+  # toolchain flags fails verification even on a distribution whose defaults
+  # already happen to include every hardening property below.
+  cflags+=(-O2 -g -DLUMINARI_PRODUCTION_PROFILE=1)
+
+  # Every hardening item is requested explicitly and probed individually.
+  # GCC 14's -fhardened bundle is deliberately not used: distributions that
+  # already define _FORTIFY_SOURCE in the compiler spec (Ubuntu) make
+  # -Whardened reject it, and the explicit set is identical on every GCC and
+  # Clang the project supports.
+  probe_feature fortify-source "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3" "" \
+    "$fortify_source"
+  probe_feature pie "-fPIE" "-pie"
+  probe_feature relro "" "-Wl,-z,relro"
+  probe_feature bind-now "" "-Wl,-z,now"
+  probe_feature stack-protector "-fstack-protector-strong" ""
+  probe_feature stack-clash-protection "-fstack-clash-protection" ""
+  probe_feature cf-protection "-fcf-protection=full" ""
+  probe_feature noexecstack "" "-Wl,-z,noexecstack"
+fi
+
+if [[ "$lto" == 1 ]]; then
+  if [[ "$is_clang" == 1 ]]; then
+    lto_flag=-flto=thin
+  else
+    lto_flag=-flto=auto
+  fi
+  try_build "$trivial_source" 0 -O2 "${cflags[@]}" "$lto_flag" "${ldflags[@]}" "$lto_flag" ||
+    fail "$cc does not support link-time optimization ($lto_flag): $(tr '\n' ' ' < "$work_dir/probe.log")"
+  cflags+=("$lto_flag")
+  ldflags+=("$lto_flag")
+fi
+
+if [[ -n "$pgo_generate" ]]; then
+  pgo_flags=("-fprofile-generate=$pgo_generate")
+  try_build "$trivial_source" 0 -O2 "${cflags[@]}" "${pgo_flags[@]}" "${ldflags[@]}" \
+    "${pgo_flags[@]}" ||
+    fail "$cc does not support profile generation: $(tr '\n' ' ' < "$work_dir/probe.log")"
+  cflags+=("${pgo_flags[@]}")
+  ldflags+=("${pgo_flags[@]}")
+fi
+
+if [[ -n "$pgo_use" ]]; then
+  [[ -e "$pgo_use" ]] || fail "profile data path does not exist: $pgo_use"
+  if [[ "$is_clang" == 1 ]]; then
+    pgo_flags=("-fprofile-use=$pgo_use")
+  else
+    pgo_flags=("-fprofile-use=$pgo_use" -fprofile-correction -Wno-missing-profile)
+  fi
+  try_build "$trivial_source" 0 -O2 "${cflags[@]}" "${pgo_flags[@]}" "${ldflags[@]}" \
+    "${pgo_flags[@]}" ||
+    fail "$cc rejected the profile data at $pgo_use: $(tr '\n' ' ' < "$work_dir/probe.log")"
+  cflags+=("${pgo_flags[@]}")
+  ldflags+=("${pgo_flags[@]}")
+fi
+
+printf 'PRODUCTION_CFLAGS=%s\n' "${cflags[*]-}"
+printf 'PRODUCTION_LDFLAGS=%s\n' "${ldflags[*]-}"
+printf 'PRODUCTION_SUPPORTED=%s\n' "${supported[*]-}"
+printf 'PRODUCTION_UNSUPPORTED=%s\n' "${unsupported[*]-}"

--- a/scripts/deployment/test_production_profile.sh
+++ b/scripts/deployment/test_production_profile.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Regression coverage for the production build profile contract:
+#   - production_profile.sh emits the four output keys and a usable flag set;
+#   - a program built with those flags passes verify_hardened_binary.sh;
+#   - the same program built with the compiler's default flags fails it, so
+#     distribution defaults cannot masquerade as the repository profile;
+#   - verify_hardened_binary.sh names every property a degraded build lacks.
+
+set -euo pipefail
+
+project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+profile="$project_root/scripts/deployment/production_profile.sh"
+verify="$project_root/scripts/deployment/verify_hardened_binary.sh"
+cc=${CC:-cc}
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/luminari-production-profile-test.XXXXXX")
+
+fail()
+{
+  printf 'production profile test: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup()
+{
+  if [[ -d "$test_root" ]] && [[ $(basename "$test_root") == luminari-production-profile-test.* ]]; then
+    rm -rf -- "$test_root"
+  fi
+}
+trap cleanup EXIT
+
+field()
+{
+  awk -F= -v key="$2" '$1 == key {print substr($0, index($0, "=") + 1); exit}' <<< "$1"
+}
+
+# The helper mirrors src/constants.c: the marker section exists only when the
+# profile's LUMINARI_PRODUCTION_PROFILE definition reaches the compile line.
+cat > "$test_root/helper.c" <<'HELPER'
+#include <stdio.h>
+#include <string.h>
+
+#ifdef LUMINARI_PRODUCTION_PROFILE
+const char helper_profile[] __attribute__((used, section(".luminari.profile"))) =
+  "LuminariMUD production profile";
+#endif
+
+int main(int argc, char **argv)
+{
+  char buffer[64];
+
+  snprintf(buffer, sizeof(buffer), "%d", argc);
+  return argv[0] != NULL && strlen(buffer) > 0 ? 0 : 1;
+}
+HELPER
+
+# 1. The probe rejects unknown options and a missing compiler.
+if "$profile" --cc "$cc" --bogus >/dev/null 2>&1; then
+  fail "probe accepted an unknown option"
+fi
+if "$profile" --production >/dev/null 2>&1; then
+  fail "probe ran without --cc"
+fi
+if "$profile" --cc "$cc" --pgo-use "$test_root/missing-profile" >/dev/null 2>&1; then
+  fail "probe accepted a missing PGO profile path"
+fi
+
+# 2. The production probe emits the contract keys and the optimization policy.
+output=$("$profile" --cc "$cc" --production) || fail "production probe failed for $cc"
+for key in PRODUCTION_CFLAGS PRODUCTION_LDFLAGS PRODUCTION_SUPPORTED PRODUCTION_UNSUPPORTED; do
+  grep -q "^$key=" <<< "$output" || fail "probe output lacks $key"
+done
+cflags=$(field "$output" PRODUCTION_CFLAGS)
+ldflags=$(field "$output" PRODUCTION_LDFLAGS)
+supported=$(field "$output" PRODUCTION_SUPPORTED)
+[[ " $cflags " == *" -O2 "* ]] || fail "production CFLAGS do not select -O2: $cflags"
+[[ " $cflags " == *" -g "* ]] || fail "production CFLAGS do not retain debug symbols: $cflags"
+[[ " $cflags " != *"NDEBUG"* ]] || fail "production CFLAGS must keep assertions enabled"
+[[ -n "$supported" ]] || fail "probe reported no supported hardening features"
+
+# 3. Without --production the probe adds nothing.
+empty=$("$profile" --cc "$cc") || fail "bare probe failed"
+[[ -z "$(field "$empty" PRODUCTION_CFLAGS)" ]] || fail "bare probe emitted CFLAGS"
+[[ -z "$(field "$empty" PRODUCTION_LDFLAGS)" ]] || fail "bare probe emitted LDFLAGS"
+
+# 4. A program built with the profile passes the ELF verifier.
+# shellcheck disable=SC2086
+"$cc" $cflags $ldflags -o "$test_root/hardened" "$test_root/helper.c" ||
+  fail "could not build the hardened helper"
+"$verify" "$test_root/hardened" >"$test_root/hardened.log" 2>&1 ||
+  fail "hardened helper failed verification: $(cat "$test_root/hardened.log")"
+grep -q 'result: PASS' "$test_root/hardened.log" || fail "verifier did not report PASS"
+
+# 5. The verifier rejects the same program built with default flags, whatever
+#    hardening the distribution toolchain applies on its own.
+"$cc" -O2 -g -o "$test_root/default" "$test_root/helper.c" ||
+  fail "could not build the default helper"
+if "$verify" "$test_root/default" >"$test_root/default.log" 2>&1; then
+  fail "verifier accepted a binary built without the production profile"
+fi
+grep -q 'MISSING:.*\bproduction-profile\b' "$test_root/default.log" ||
+  fail "verifier did not report the missing profile marker: $(cat "$test_root/default.log")"
+
+# 6. The verifier rejects a degraded build and names each missing property.
+"$cc" -O2 -g -fno-PIE -no-pie -fno-stack-protector -U_FORTIFY_SOURCE \
+  -Wl,-z,norelro -Wl,-z,lazy -Wl,-z,execstack -Wl,-rpath,/opt/luminari-test \
+  -o "$test_root/degraded" "$test_root/helper.c" ||
+  fail "could not build the degraded helper"
+if "$verify" "$test_root/degraded" >"$test_root/degraded.log" 2>&1; then
+  fail "verifier accepted a degraded binary"
+fi
+for property in production-profile pie noexecstack relro bind-now stack-protector \
+  fortify-source no-rpath; do
+  grep -q "MISSING:.*\b$property\b" "$test_root/degraded.log" ||
+    fail "verifier did not report missing $property: $(cat "$test_root/degraded.log")"
+done
+
+# 7. The verifier refuses non-ELF input.
+if "$verify" "$test_root/helper.c" >/dev/null 2>&1; then
+  fail "verifier accepted a non-ELF file"
+fi
+
+printf 'production profile test: PASS (%s: %s)\n' "$cc" "$supported"

--- a/scripts/deployment/verify_hardened_binary.sh
+++ b/scripts/deployment/verify_hardened_binary.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Verify that a linked LuminariMUD executable was built with the production
+# profile and carries its required ELF properties.  Uses only readelf so the
+# same check runs on a developer machine, in deploy.sh, and in CI.  Exit
+# status 1 lists every missing property; nothing is optional on the
+# architectures this checks.
+#
+# The hardening properties alone cannot distinguish the profile from a
+# distribution whose compiler defaults already include them, so the profile
+# also embeds a marker section (see LUMINARI_PRODUCTION_PROFILE in
+# src/constants.c) and this check requires it.
+
+set -euo pipefail
+
+binary=${1:?usage: verify_hardened_binary.sh EXECUTABLE}
+
+fail()
+{
+  printf 'hardened binary check: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v readelf >/dev/null 2>&1 || fail "readelf is required"
+[[ -f "$binary" ]] || fail "not a regular file: $binary"
+
+header=$(readelf -hW "$binary") || fail "not an ELF file: $binary"
+program_headers=$(readelf -lW "$binary")
+dynamic=$(readelf -dW "$binary")
+notes=$(readelf -nW "$binary")
+dynamic_symbols=$(readelf --dyn-syms -W "$binary")
+
+machine=$(awk -F: '/^ *Machine:/ {sub(/^ +/, "", $2); print $2; exit}' <<< "$header")
+missing=()
+present=()
+
+check()
+{
+  local name=$1
+  local ok=$2
+
+  if [[ "$ok" == 1 ]]; then
+    present+=("$name")
+  else
+    missing+=("$name")
+  fi
+}
+
+# Profile marker: src/constants.c places this section only when the compile
+# line carried the profile's LUMINARI_PRODUCTION_PROFILE definition.
+profile_marker=0
+if readelf -W -p .luminari.profile "$binary" 2>/dev/null | grep -q 'LuminariMUD production profile'; then
+  profile_marker=1
+fi
+check production-profile "$profile_marker"
+
+# PIE: a position-independent executable is ET_DYN with a program interpreter.
+pie=0
+if grep -q '^ *Type: *DYN' <<< "$header" && grep -q 'INTERP' <<< "$program_headers"; then
+  pie=1
+fi
+check pie "$pie"
+
+# Non-executable stack: PT_GNU_STACK must exist and must not carry E.
+nx_stack=0
+if stack_line=$(grep 'GNU_STACK' <<< "$program_headers"); then
+  if ! grep -Eq 'RWE|R E' <<< "$stack_line"; then
+    nx_stack=1
+  fi
+fi
+check noexecstack "$nx_stack"
+
+# Full RELRO: a PT_GNU_RELRO segment plus immediate binding.
+relro=0
+grep -q 'GNU_RELRO' <<< "$program_headers" && relro=1
+check relro "$relro"
+
+bind_now=0
+if grep -Eq '\(BIND_NOW\)|\(FLAGS\).*BIND_NOW|\(FLAGS_1\).*NOW' <<< "$dynamic"; then
+  bind_now=1
+fi
+check bind-now "$bind_now"
+
+# Stack protector: the strong protector always references __stack_chk_fail in
+# a program with local arrays, which every game source file has.
+stack_protector=0
+grep -q '__stack_chk_fail' <<< "$dynamic_symbols" && stack_protector=1
+check stack-protector "$stack_protector"
+
+# FORTIFY_SOURCE: fortified libc wrappers (excluding the stack protector's own
+# __stack_chk_* symbols) must be referenced.
+fortify=0
+if grep -E '__[A-Za-z0-9_]+_chk(@|$)' <<< "$dynamic_symbols" | grep -vq '__stack_chk_'; then
+  fortify=1
+fi
+check fortify-source "$fortify"
+
+# Build ID: required by the versioned installer and crash symbolization.
+build_id=0
+grep -q 'Build ID:' <<< "$notes" && build_id=1
+check build-id "$build_id"
+
+# Control-flow protection is only verifiable on x86-64, where the linked
+# property note must advertise both indirect-branch tracking and shadow stack.
+if [[ "$machine" == *X86-64* ]]; then
+  cf_protection=0
+  if grep -q 'IBT' <<< "$notes" && grep -q 'SHSTK' <<< "$notes"; then
+    cf_protection=1
+  fi
+  check cf-protection "$cf_protection"
+fi
+
+# Dangerous link-time properties that must be absent.
+no_rpath=1
+grep -Eq '\((RPATH|RUNPATH)\)' <<< "$dynamic" && no_rpath=0
+check no-rpath "$no_rpath"
+
+no_textrel=1
+grep -Eq '\(TEXTREL\)|\(FLAGS\).*TEXTREL' <<< "$dynamic" && no_textrel=0
+check no-textrel "$no_textrel"
+
+printf 'hardened binary check: %s\n' "$binary"
+printf '  machine: %s\n' "$machine"
+printf '  present: %s\n' "${present[*]-}"
+if [[ ${#missing[@]} -gt 0 ]]; then
+  printf '  MISSING: %s\n' "${missing[*]}"
+  fail "required production properties are missing: ${missing[*]}"
+fi
+printf '  result: PASS\n'

--- a/scripts/events/test_demand_driven_architecture.sh
+++ b/scripts/events/test_demand_driven_architecture.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+# CPPFLAGS lets a CMake tree point the preprocessor at its generated conf.h;
+# an Autotools tree already has src/conf.h.
+# shellcheck disable=SC2086
 active_world="$project_root/src/active_world.c"
 mob_activity="$project_root/src/mob/mob_act.c"
 runtime_services="$project_root/src/comm.c"
@@ -72,7 +75,7 @@ if grep -q 'RUNTIME_SERVICE_MOBILE_ACTIVITY' "$runtime_services"; then
   fail "whole-mobile rollback service must be removed"
 fi
 
-"${CC:-cc}" -E -P -I"$project_root/src" "$runtime_services" >"$default_comm"
+"${CC:-cc}" ${CPPFLAGS:-} -E -P -I"$project_root/src" "$runtime_services" >"$default_comm"
 if grep -Eq '^[[:space:]]*mobile_activity_run_legacy_(cycle|slice)[[:space:]]*\(' "$default_comm"; then
   fail "the default preprocessed runtime still dispatches whole-mobile rollback work"
 fi

--- a/scripts/events/test_native_event_architecture.sh
+++ b/scripts/events/test_native_event_architecture.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+# CPPFLAGS lets a CMake tree point the preprocessor at its generated conf.h;
+# an Autotools tree already has src/conf.h.
+# shellcheck disable=SC2086
 default_dg_event=$(mktemp)
 default_event_runtime=$(mktemp)
 default_public_header=$(mktemp)
@@ -47,31 +50,31 @@ fi
 # product build sees them. Rollback APIs and selectors must disappear, not
 # merely remain unused.
 printf '#include "dgscript/dg_event.h"\n' |
-  "${CC:-cc}" -E -P -I"$project_root/src" -xc - >"$default_public_header"
+  "${CC:-cc}" ${CPPFLAGS:-} -E -P -I"$project_root/src" -xc - >"$default_public_header"
 if grep -Eq 'EVENTFUNC|EVENT_BACKEND_LEGACY_QUEUE|event_schedule(_[[:alnum:]_]+)?[[:space:]]*\(|event_handle_(cancel|time|is_live|is_queued)' \
     "$default_public_header"; then
   fail "the default public header exposes the rollback event facade"
 fi
 printf '#include "dgscript/dg_scripts.h"\n' |
-  "${CC:-cc}" -DLUMINARI_ENABLE_EVENT_ROLLBACK=0 -E -P \
+  "${CC:-cc}" ${CPPFLAGS:-} -DLUMINARI_ENABLE_EVENT_ROLLBACK=0 -E -P \
     -I"$project_root/src" -xc - >"$default_public_header"
 if grep -Eq 'EVENTFUNC|event_schedule(_[[:alnum:]_]+)?[[:space:]]*\(|event_handle_(cancel|time|is_live|is_queued)' \
     "$default_public_header"; then
   fail "an explicit zero rollback definition exposes the DG rollback facade"
 fi
-"${CC:-cc}" -E -P -I"$project_root/src" \
+"${CC:-cc}" ${CPPFLAGS:-} -E -P -I"$project_root/src" \
   "$project_root/src/dgscript/dg_event.c" >"$default_dg_event"
 if grep -Eq 'EVENT_BACKEND_LEGACY_QUEUE|legacy_event|event_schedule(_[[:alnum:]_]+)?[[:space:]]*\(|event_create(_[[:alnum:]_]+)?[[:space:]]*\(|queue_(init|enq|deq|head|key|free)[[:space:]]*\(' \
     "$default_dg_event"; then
   fail "the default timed-event implementation still contains rollback architecture"
 fi
-"${CC:-cc}" -DLUMINARI_ENABLE_EVENT_ROLLBACK=0 -E -P -I"$project_root/src" \
+"${CC:-cc}" ${CPPFLAGS:-} -DLUMINARI_ENABLE_EVENT_ROLLBACK=0 -E -P -I"$project_root/src" \
   "$project_root/src/dgscript/dg_event.c" >"$default_dg_event"
 if grep -Eq 'EVENT_BACKEND_LEGACY_QUEUE|legacy_event|event_schedule(_[[:alnum:]_]+)?[[:space:]]*\(|event_create(_[[:alnum:]_]+)?[[:space:]]*\(|queue_(init|enq|deq|head|key|free)[[:space:]]*\(' \
     "$default_dg_event"; then
   fail "an explicit zero rollback definition retains rollback implementation"
 fi
-"${CC:-cc}" -E -P -I"$project_root/src" \
+"${CC:-cc}" ${CPPFLAGS:-} -E -P -I"$project_root/src" \
   "$project_root/src/event_runtime.c" >"$default_event_runtime"
 if grep -Eq 'legacy_event|EVENT_BACKEND_LEGACY_QUEUE|event_schedule(_[[:alnum:]_]+)?[[:space:]]*\(' \
     "$default_event_runtime"; then

--- a/scripts/world/tests/test_rol_transform.py
+++ b/scripts/world/tests/test_rol_transform.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import os
 import re
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -2302,6 +2304,7 @@ class RolTransformTests(unittest.TestCase):
     preprocessed = subprocess.run(
         [
             "cc",
+            *shlex.split(os.environ.get("CPPFLAGS", "")),
             "-E",
             "-P",
             f"-I{self.root / 'src'}",
@@ -2358,6 +2361,7 @@ class RolTransformTests(unittest.TestCase):
     preprocessed = subprocess.run(
         [
             "cc",
+            *shlex.split(os.environ.get("CPPFLAGS", "")),
             "-E",
             "-P",
             f"-I{source_root / 'src'}",

--- a/scripts/world/tests/test_shops.py
+++ b/scripts/world/tests/test_shops.py
@@ -81,6 +81,7 @@ class ShopConverterTests(unittest.TestCase):
         shlex.split(os.environ.get("CC", "gcc"))
         + ["-std=gnu2x", "-O1", "-g", "-Wall", "-Wextra", "-Werror",
            "-D_FORTIFY_SOURCE=3", "-I", str(root / "src")]
+        + shlex.split(os.environ.get("CPPFLAGS", ""))
         + shlex.split(os.environ.get("SHOPCONV_TEST_CFLAGS", ""))
         + [str(root / "util/shopconv.c"), "-o", str(cls.binary)],
         check=True, capture_output=True, text=True,

--- a/src/bsd-snprintf.c
+++ b/src/bsd-snprintf.c
@@ -704,6 +704,11 @@ static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c)
 }
 #endif /* !defined(HAVE_SNPRINTF) || !defined(HAVE_VSNPRINTF) */
 
+/* A fortified C library wraps these names in macros; the fallback must define
+ * the plain functions. */
+#undef vsnprintf
+#undef snprintf
+
 #ifndef HAVE_VSNPRINTF
 int vsnprintf(char *str, size_t count, const char *fmt, va_list args)
 {

--- a/src/constants.c
+++ b/src/constants.c
@@ -43,6 +43,16 @@ cpp_extern const char *const luminari_version = "LuminariMUD 2.5063-beta (tbaMUD
 cpp_extern const char *const luminari_build_git_commit = LUMINARI_BUILD_GIT_COMMIT;
 cpp_extern const bool luminari_build_git_dirty = LUMINARI_BUILD_GIT_DIRTY != 0;
 
+/* scripts/deployment/production_profile.sh defines LUMINARI_PRODUCTION_PROFILE
+ * in the production CFLAGS.  This marker section lets
+ * scripts/deployment/verify_hardened_binary.sh prove the profile reached the
+ * compile line, rather than trusting hardening that a distribution compiler
+ * may apply by default. */
+#ifdef LUMINARI_PRODUCTION_PROFILE
+const char luminari_production_profile[] __attribute__((used, section(".luminari.profile"))) =
+    "LuminariMUD production profile";
+#endif
+
 /* strings corresponding to ordinals/bitvectors in structs.h */
 
 /* Luminari moon names */

--- a/unittests/CuTest/Makefile
+++ b/unittests/CuTest/Makefile
@@ -40,6 +40,16 @@ FUZZ_CFLAGS ?= -Wall -Wextra $(CSTD_FLAG) -g -O1 -fno-omit-frame-pointer \
 	-fsanitize=fuzzer,address,undefined
 FUZZ_LDFLAGS ?= -lm -ljson-c -fsanitize=fuzzer,address,undefined
 
+# Hot-parser microbenchmark.  Override PROTOCOL_BENCH_CFLAGS/LDFLAGS with the
+# flags from scripts/deployment/production_profile.sh to compare profiles.
+PROTOCOL_BENCH_CC ?= $(CC)
+PROTOCOL_BENCH_CFLAGS ?= -Wall -Wextra $(CSTD_FLAG) -O2 -g
+PROTOCOL_BENCH_LDFLAGS ?= -lm -ljson-c
+PROTOCOL_BENCH_OBJ = $(BUILD_DIR)/bench_protocol_parser.o
+PROTOCOL_BENCH_SOURCE_OBJ = $(BUILD_DIR)/protocol_bench.o
+MSDP_JSON_BENCH_SOURCE_OBJ = $(BUILD_DIR)/msdp_json_bench.o
+PROTOCOL_BENCH_EXE = protocol_parser_bench
+
 all: $(PROTOCOL_PARSER_TEST_EXE)
 
 $(BUILD_DIR):
@@ -88,6 +98,22 @@ $(PROTOCOL_FUZZ_EXE): $(PROTOCOL_FUZZ_OBJ) $(PROTOCOL_FUZZ_SOURCE_OBJ) \
 		$(MSDP_JSON_FUZZ_SOURCE_OBJ)
 	$(FUZZ_CC) $(FUZZ_CFLAGS) -o $@ $^ $(FUZZ_LDFLAGS)
 
+$(PROTOCOL_BENCH_OBJ): bench_protocol_parser.c fuzz_protocol_parser.c \
+		../../src/net/protocol.h ../../src/structs.h ../../src/net/onboarding.h | $(BUILD_DIR)
+	$(PROTOCOL_BENCH_CC) $(PROTOCOL_BENCH_CFLAGS) -I../../src -c bench_protocol_parser.c -o $@
+
+$(PROTOCOL_BENCH_SOURCE_OBJ): ../../src/net/protocol.c ../../src/net/protocol.h \
+		../../src/net/msdp_json.h ../../src/structs.h ../../src/net/onboarding.h | $(BUILD_DIR)
+	$(PROTOCOL_BENCH_CC) $(PROTOCOL_BENCH_CFLAGS) -I../../src -c ../../src/net/protocol.c -o $@
+
+$(MSDP_JSON_BENCH_SOURCE_OBJ): ../../src/net/msdp_json.c ../../src/net/msdp_json.h \
+		../../src/net/protocol.h ../../src/structs.h | $(BUILD_DIR)
+	$(PROTOCOL_BENCH_CC) $(PROTOCOL_BENCH_CFLAGS) -I../../src -c ../../src/net/msdp_json.c -o $@
+
+$(PROTOCOL_BENCH_EXE): $(PROTOCOL_BENCH_OBJ) $(PROTOCOL_BENCH_SOURCE_OBJ) \
+		$(MSDP_JSON_BENCH_SOURCE_OBJ)
+	$(PROTOCOL_BENCH_CC) $(PROTOCOL_BENCH_CFLAGS) -o $@ $^ $(PROTOCOL_BENCH_LDFLAGS)
+
 production:
 	$(MAKE) -C ../.. test
 
@@ -107,6 +133,11 @@ protocol-fuzz: $(PROTOCOL_FUZZ_EXE)
 	./$(PROTOCOL_FUZZ_EXE) -max_total_time=$(FUZZ_SECONDS) -timeout=5 \
 		-print_funcs=0 -verbosity=0 -max_len=16384 "$$fuzz_work"
 
+protocol-bench-build: $(PROTOCOL_BENCH_EXE)
+
+protocol-bench: $(PROTOCOL_BENCH_EXE)
+	./$(PROTOCOL_BENCH_EXE) fuzz_corpus/*
+
 test: production
 
 test-all:
@@ -118,7 +149,7 @@ valgrind-protocol: $(PROTOCOL_PARSER_TEST_EXE)
 
 clean:
 	rm -rf $(BUILD_DIR)
-	rm -f $(PROTOCOL_PARSER_TEST_EXE) $(PROTOCOL_FUZZ_EXE)
+	rm -f $(PROTOCOL_PARSER_TEST_EXE) $(PROTOCOL_FUZZ_EXE) $(PROTOCOL_BENCH_EXE)
 
 rebuild: clean all
 
@@ -129,9 +160,10 @@ help:
 	@echo "  production         - Run the root production-linked CuTest suite"
 	@echo "  protocol-parser    - Run the focused protocol parser harness"
 	@echo "  protocol-fuzz      - Run bounded ASan/UBSan libFuzzer coverage"
+	@echo "  protocol-bench     - Time the protocol parser (PROTOCOL_BENCH_CFLAGS)"
 	@echo "  test-all           - Run the authoritative root test-all target"
 	@echo "  valgrind-protocol  - Run the protocol harness with Valgrind"
 	@echo "  clean              - Remove standalone build artifacts"
 
-.PHONY: all production protocol-parser protocol-fuzz-build protocol-fuzz test \
-	test-all valgrind-protocol clean rebuild help
+.PHONY: all production protocol-parser protocol-fuzz-build protocol-fuzz \
+	protocol-bench-build protocol-bench test test-all valgrind-protocol clean rebuild help

--- a/unittests/CuTest/bench_protocol_parser.c
+++ b/unittests/CuTest/bench_protocol_parser.c
@@ -1,0 +1,149 @@
+/*
+ * Hot-parser microbenchmark for the telnet/MSDP/GMCP protocol layer.
+ *
+ * Reuses the synthetic fuzz harness (its descriptor setup, stubs, and the
+ * chunked input/output driver) so the benchmark exercises exactly the paths
+ * the parser tests and fuzzer cover.  Build it with the flags under
+ * evaluation (see PROTOCOL_BENCH_CFLAGS in the Makefile) and compare the
+ * median nanoseconds per iteration between profiles.  The live game-loop
+ * benchmark remains the event-core performance gate; this target isolates
+ * parser cost from world, database, and scheduler effects.
+ */
+
+#include "fuzz_protocol_parser.c"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <time.h>
+
+#define BENCH_MAX_INPUTS 32
+#define BENCH_MAX_INPUT_SIZE 16384
+#define BENCH_DEFAULT_ITERATIONS 2000
+#define BENCH_ROUNDS 5
+
+struct bench_input
+{
+  const char *name;
+  uint8_t data[BENCH_MAX_INPUT_SIZE];
+  size_t size;
+};
+
+static struct bench_input bench_inputs[BENCH_MAX_INPUTS];
+static size_t bench_input_count;
+
+static int load_input(const char *path)
+{
+  FILE *file;
+  struct bench_input *input;
+
+  if (bench_input_count >= BENCH_MAX_INPUTS)
+    return -1;
+
+  file = fopen(path, "rb");
+  if (file == NULL)
+    return -1;
+
+  input = &bench_inputs[bench_input_count];
+  input->name = path;
+  input->size = fread(input->data, 1, sizeof(input->data), file);
+  fclose(file);
+
+  if (input->size == 0)
+    return -1;
+
+  bench_input_count++;
+  return 0;
+}
+
+static long long elapsed_ns(const struct timespec *start, const struct timespec *end)
+{
+  return (long long)(end->tv_sec - start->tv_sec) * 1000000000LL +
+         (long long)(end->tv_nsec - start->tv_nsec);
+}
+
+static int compare_ns(const void *left, const void *right)
+{
+  long long a = *(const long long *)left;
+  long long b = *(const long long *)right;
+
+  return (a > b) - (a < b);
+}
+
+/* Drive every loaded input through each harness mode (whole, split, small
+ * chunks, and output parsing) once per iteration. */
+static void run_iteration(void)
+{
+  uint8_t buffer[BENCH_MAX_INPUT_SIZE + 1];
+  size_t index;
+  unsigned mode;
+
+  for (index = 0; index < bench_input_count; index++)
+  {
+    for (mode = 0; mode < 4; mode++)
+    {
+      buffer[0] = (uint8_t)mode;
+      memcpy(buffer + 1, bench_inputs[index].data, bench_inputs[index].size);
+      LLVMFuzzerTestOneInput(buffer, bench_inputs[index].size + 1);
+    }
+  }
+}
+
+int main(int argc, char **argv)
+{
+  long long rounds[BENCH_ROUNDS];
+  struct timespec start;
+  struct timespec end;
+  long iterations = BENCH_DEFAULT_ITERATIONS;
+  const char *iterations_env;
+  char *end_ptr;
+  long iteration;
+  int round;
+  int arg;
+
+  if (argc < 2)
+  {
+    fprintf(stderr, "usage: %s INPUT_FILE...\n", argv[0]);
+    return 2;
+  }
+
+  iterations_env = getenv("PROTOCOL_BENCH_ITERATIONS");
+  if (iterations_env != NULL && *iterations_env != '\0')
+  {
+    errno = 0;
+    iterations = strtol(iterations_env, &end_ptr, 10);
+    if (errno != 0 || *end_ptr != '\0' || iterations <= 0)
+    {
+      fprintf(stderr, "invalid PROTOCOL_BENCH_ITERATIONS: %s\n", iterations_env);
+      return 2;
+    }
+  }
+
+  for (arg = 1; arg < argc; arg++)
+  {
+    if (load_input(argv[arg]) != 0)
+    {
+      fprintf(stderr, "cannot load benchmark input: %s\n", argv[arg]);
+      return 2;
+    }
+  }
+
+  /* Warm up allocator and caches before timing. */
+  for (iteration = 0; iteration < iterations / 10 + 1; iteration++)
+    run_iteration();
+
+  for (round = 0; round < BENCH_ROUNDS; round++)
+  {
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (iteration = 0; iteration < iterations; iteration++)
+      run_iteration();
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    rounds[round] = elapsed_ns(&start, &end) / iterations;
+  }
+
+  qsort(rounds, BENCH_ROUNDS, sizeof(rounds[0]), compare_ns);
+  printf("protocol-parser-bench inputs=%zu iterations=%ld rounds=%d "
+         "median_ns_per_iteration=%lld min_ns_per_iteration=%lld max_ns_per_iteration=%lld\n",
+         bench_input_count, iterations, BENCH_ROUNDS, rounds[BENCH_ROUNDS / 2], rounds[0],
+         rounds[BENCH_ROUNDS - 1]);
+  return 0;
+}

--- a/unittests/CuTest/fuzz_protocol_parser.c
+++ b/unittests/CuTest/fuzz_protocol_parser.c
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/comm.h"

--- a/unittests/CuTest/test_activity_manager.c
+++ b/unittests/CuTest/test_activity_manager.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/activity_manager.h"

--- a/unittests/CuTest/test_ai_secrets.c
+++ b/unittests/CuTest/test_ai_secrets.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_artifact_integration.c
+++ b/unittests/CuTest/test_artifact_integration.c
@@ -21,7 +21,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_artifacts.c
+++ b/unittests/CuTest/test_artifacts.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_ashenport_welcome_trigger.c
+++ b/unittests/CuTest/test_ashenport_welcome_trigger.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_bardic_performance.c
+++ b/unittests/CuTest/test_bardic_performance.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_bounds_checking.c
+++ b/unittests/CuTest/test_bounds_checking.c
@@ -6,7 +6,7 @@
 #include <sys/stat.h>
 
 /* Include the actual headers from src */
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_combat_encounters.c
+++ b/unittests/CuTest/test_combat_encounters.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/comm.h"

--- a/unittests/CuTest/test_combat_production.c
+++ b/unittests/CuTest/test_combat_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_copyover_timer.c
+++ b/unittests/CuTest/test_copyover_timer.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_damage_trigger.c
+++ b/unittests/CuTest/test_damage_trigger.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_dg_scripts_production.c
+++ b/unittests/CuTest/test_dg_scripts_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_domain_events.c
+++ b/unittests/CuTest/test_domain_events.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_door_events.c
+++ b/unittests/CuTest/test_door_events.c
@@ -1,5 +1,5 @@
 #include "CuTest.h"
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_elf_build_id.c
+++ b/unittests/CuTest/test_elf_build_id.c
@@ -7,7 +7,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/elf_build_id.h"
 

--- a/unittests/CuTest/test_event_runtime.c
+++ b/unittests/CuTest/test_event_runtime.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/comm.h"

--- a/unittests/CuTest/test_game_scheduler.c
+++ b/unittests/CuTest/test_game_scheduler.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/game_scheduler.h"

--- a/unittests/CuTest/test_gameplay_e2e.c
+++ b/unittests/CuTest/test_gameplay_e2e.c
@@ -1,7 +1,7 @@
 #include "CuTest.h"
 #include "test_spec_fixtures.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_help_sync.c
+++ b/unittests/CuTest/test_help_sync.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_i3_client_production.c
+++ b/unittests/CuTest/test_i3_client_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_lists_production.c
+++ b/unittests/CuTest/test_lists_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/lists.h"

--- a/unittests/CuTest/test_mob_autoroll.c
+++ b/unittests/CuTest/test_mob_autoroll.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_msdp_production.c
+++ b/unittests/CuTest/test_msdp_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_native_event_integration.c
+++ b/unittests/CuTest/test_native_event_integration.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_necromancer.c
+++ b/unittests/CuTest/test_necromancer.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_password.c
+++ b/unittests/CuTest/test_password.c
@@ -2,7 +2,7 @@
  * crypt() verification, rehash detection, and boundary handling. */
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_perfmon_production.c
+++ b/unittests/CuTest/test_perfmon_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_pet_lifetime.c
+++ b/unittests/CuTest/test_pet_lifetime.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_pet_persistence.c
+++ b/unittests/CuTest/test_pet_persistence.c
@@ -2,7 +2,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_pet_policy.c
+++ b/unittests/CuTest/test_pet_policy.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_player_rename.c
+++ b/unittests/CuTest/test_player_rename.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_protocol_parser.c
+++ b/unittests/CuTest/test_protocol_parser.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_race_equivalence.c
+++ b/unittests/CuTest/test_race_equivalence.c
@@ -2,7 +2,7 @@
 
 #include <string.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_reactor.c
+++ b/unittests/CuTest/test_reactor.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_rol_feats.c
+++ b/unittests/CuTest/test_rol_feats.c
@@ -3,7 +3,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_assign_table.c
+++ b/unittests/CuTest/test_spec_assign_table.c
@@ -10,7 +10,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_authored_bindings.c
+++ b/unittests/CuTest/test_spec_authored_bindings.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_binding_round_trip.c
+++ b/unittests/CuTest/test_spec_binding_round_trip.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_combat_secondary.c
+++ b/unittests/CuTest/test_spec_combat_secondary.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_command_pulse.c
+++ b/unittests/CuTest/test_spec_command_pulse.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_dispatch.c
+++ b/unittests/CuTest/test_spec_dispatch.c
@@ -6,7 +6,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_effective_binding.c
+++ b/unittests/CuTest/test_spec_effective_binding.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_fixtures.c
+++ b/unittests/CuTest/test_spec_fixtures.c
@@ -1,4 +1,4 @@
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_fixtures.h
+++ b/unittests/CuTest/test_spec_fixtures.h
@@ -1,7 +1,7 @@
 #ifndef TEST_SPEC_FIXTURES_H
 #define TEST_SPEC_FIXTURES_H
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/spec/spec_registry.h"

--- a/unittests/CuTest/test_spec_mechanics.c
+++ b/unittests/CuTest/test_spec_mechanics.c
@@ -5,7 +5,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_owner_aware_olc.c
+++ b/unittests/CuTest/test_spec_owner_aware_olc.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_registry_persistence.c
+++ b/unittests/CuTest/test_spec_registry_persistence.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_registry_validation.c
+++ b/unittests/CuTest/test_spec_registry_validation.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spec_typed_handlers.c
+++ b/unittests/CuTest/test_spec_typed_handlers.c
@@ -5,7 +5,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_spells_skills_production.c
+++ b/unittests/CuTest/test_spells_skills_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_study_pet_menus.c
+++ b/unittests/CuTest/test_study_pet_menus.c
@@ -2,7 +2,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_syntax_check_boot.c
+++ b/unittests/CuTest/test_syntax_check_boot.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_thrown_weapons.c
+++ b/unittests/CuTest/test_thrown_weapons.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_transport_production.c
+++ b/unittests/CuTest/test_transport_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_traps_production.c
+++ b/unittests/CuTest/test_traps_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_unassigned_spells.c
+++ b/unittests/CuTest/test_unassigned_spells.c
@@ -2,7 +2,7 @@
 
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_upstream_regressions.c
+++ b/unittests/CuTest/test_upstream_regressions.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_vessel_boarding.c
+++ b/unittests/CuTest/test_vessel_boarding.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_vessel_events.c
+++ b/unittests/CuTest/test_vessel_events.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_vessel_lookout.c
+++ b/unittests/CuTest/test_vessel_lookout.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_vessel_narrative.c
+++ b/unittests/CuTest/test_vessel_narrative.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_vessel_tactical.c
+++ b/unittests/CuTest/test_vessel_tactical.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_web_onboarding.c
+++ b/unittests/CuTest/test_web_onboarding.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <openssl/evp.h>
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"

--- a/unittests/CuTest/test_world_loading_production.c
+++ b/unittests/CuTest/test_world_loading_production.c
@@ -1,6 +1,6 @@
 #include "CuTest.h"
 
-#include "../../src/conf.h"
+#include "conf.h"
 #include "../../src/sysdep.h"
 #include "../../src/structs.h"
 #include "../../src/utils.h"


### PR DESCRIPTION
Fixes #93.

## Why

`deploy.sh --prod` invoked `./configure --enable-optimizations`, an option `configure.ac` never defined. Production builds silently fell back to the default `-g -O2` flags and every observed hardening property came from Ubuntu toolchain defaults rather than a repository-owned contract.

## What changed

- **One shared profile contract.** `scripts/deployment/production_profile.sh` feature-detects the flags for the selected compiler and is called by both `configure.ac` (`--enable-production`) and `CMakeLists.txt` (`LUMINARI_PRODUCTION=ON`), each passing its GNU C23 dialect flag. Policy: `-O2 -g`, assertions kept, debug symbols split by the existing versioned installer. Hardening: `_FORTIFY_SOURCE=3`, PIE, full RELRO + BIND_NOW, strong stack protector, stack-clash protection, `-fcf-protection=full`, non-executable stack, each requested explicitly and probed individually. Unsupported items are reported by configure/CMake, never silently dropped. GCC 14's `-fhardened` bundle is deliberately not used: Ubuntu's compiler spec already defines `_FORTIFY_SOURCE`, so `-Whardened` rejects the bundle and the branch was unreachable on every supported distribution.
- **Unknown configure options are fatal in `configure.ac` itself** (`enable_option_checking=fatal` default), not only when a caller remembers the flag. `--enable-option-checking=warn` still overrides deliberately. CI asserts `./configure --enable-optimizations` is rejected.
- **A real profile proof.** The profile defines `LUMINARI_PRODUCTION_PROFILE`, and `src/constants.c` embeds a marker in a `.luminari.profile` ELF section. `scripts/deployment/verify_hardened_binary.sh` requires that marker plus PIE, NX stack, RELRO/NOW, stack protector, fortify, build ID, CET notes on x86-64, and no RPATH/TEXTREL. A default `gcc -O2 -g` binary (and `/bin/true`) now fails the check on Ubuntu 24.04; `test_production_profile.sh` asserts that negative case alongside the degraded-build case.
- **Explicit LTO/PGO.** `--enable-lto`, `--with-pgo-generate=DIR`, `--with-pgo-use=PATH` and the CMake equivalents. Requesting one the compiler cannot honor is a configuration error.
- **CI.** `production-profile` matrix: Autotools with GCC, GCC 14, and Clang; CMake with GCC and Clang. Every cell builds the profile, verifies the server and test binaries, runs the full production-linked suite (Autotools `make test`, CMake full `ctest`) against that artifact, installs, and verifies `bin/luminari`. The release workflow builds and verifies the same profile. The three new scripts are executable in git.
- **CMake tests build and run on a clean tree.** The 65 CuTest sources and one shared header included `../../src/conf.h`, which only exists after an Autotools configure; they now include `conf.h` through the include path each build system already provides. The event-architecture and world-tool test scripts that preprocess game sources honor `CPPFLAGS`, and CMake points them at its generated header.
- **Benchmark.** `make -C unittests/CuTest protocol-bench` times the protocol parser under any flag set. Baseline recorded in the deployment guide: hardening cost and LTO gain are both within noise on the parser. This is parser-only evidence; the live event-core game-loop gate needs a dedicated database snapshot and is not run in CI, so LTO/PGO stay opt-in until it is measured on the hardened server.
- **Fix.** `src/bsd-snprintf.c` undefines the fortified `snprintf`/`vsnprintf` macros before its fallback definitions.
- Docs: deployment, setup, and testing guides.

## Verification

Local (Ubuntu 24.04, glibc 2.39, x86-64):

- `test_production_profile.sh` passes with GCC 13.3, Clang 18, and GCC 14.2 (the GCC 14 probe yields the identical explicit set).
- `./configure --enable-optimizations` errors out; `--enable-option-checking=warn` downgrades it to the old warning.
- Autotools + GCC `--enable-production`: 0 warnings, verifier PASS on `./luminari` and installed `bin/luminari`, `make install` alias correct, no root binary. `make test` reaches `./cutest` with 1387/1388 passing against the local dev MariaDB; the one remaining test is the syntax-check boot, which needs the isolated CI runtime that only a `*test*`/`*ci*` database name can create, and this host has no privileges to create one. The hardened binary's own `-c` boot ran through DB init and world loading against the dev `lib/`. The CI cells have that runtime.
- CMake + GCC `LUMINARI_PRODUCTION=ON -DBUILD_TESTS=ON` with `src/conf.h` moved away: configures and builds `cutest`, 0 warnings, verifier PASS on `build/bin/luminari` and `build/cutest`, all 21 `ctest` entries pass (syntax boot skipped for the same reason), installed `bin/luminari` verified.
- `make -C unittests/CuTest protocol-parser`: 31/31.
- Verifier rejects `/bin/true` and a default-flag helper.

Not verified locally: non-x86 architectures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in production build profile for Autotools and CMake, with optional LTO and PGO support.
  * Added hardened binary verification for production builds and deployments.
  * Added protocol-parser benchmarking with configurable compiler flags and iterations.

* **Bug Fixes**
  * Configuration now rejects unknown options by default.
  * Improved compatibility for fortified C library implementations.

* **Documentation**
  * Expanded build, deployment, and testing guides with production profile and verification instructions.

* **Tests**
  * Added comprehensive production-profile validation across supported compilers and build systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->