### PR TITLE
Restore clean-clone CMake builds and enforce Autotools/CMake parity (#87)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ on:
       - 'docs/TECHNICAL_DOCUMENTATION_MASTER_INDEX.md'
       - 'docs/web/**'
       - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'cmake/**'
       - 'configure.ac'
       - 'Makefile.am'
       - 'util/Makefile.am'
@@ -51,6 +53,8 @@ on:
       - 'docs/TECHNICAL_DOCUMENTATION_MASTER_INDEX.md'
       - 'docs/web/**'
       - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'cmake/**'
       - 'configure.ac'
       - 'Makefile.am'
       - 'util/Makefile.am'
@@ -120,6 +124,148 @@ jobs:
           python scripts/world/wtool.py \
             --world-root scripts/world/tests/fixtures/phase2/complete \
             refs hlquest 10000 >/dev/null
+
+  build-parity:
+    name: Autotools/CMake manifest parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Check that Makefile.am and CMakeLists.txt list the same sources
+        run: python scripts/ci/check_build_parity.py
+
+  cmake:
+    name: CMake ${{ matrix.compiler }} (strict, blocking)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc
+            preset: ci-gcc
+            packages: gcc
+          - compiler: clang
+            preset: ci-clang
+            packages: clang
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: test_root_password
+          MARIADB_DATABASE: luminari_test
+          MARIADB_USER: luminari_test
+          MARIADB_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      LUMINARI_TEST_MYSQL_ENABLE: '1'
+      LUMINARI_TEST_MYSQL_HOST: 127.0.0.1
+      LUMINARI_TEST_MYSQL_USER: luminari_test
+      LUMINARI_TEST_MYSQL_PASSWORD: test_password
+      LUMINARI_TEST_MYSQL_DATABASE: luminari_test
+      LUMINARI_TEST_MYSQL_PORT: '3306'
+      LUMINARI_TEST_DATA_DIR: ${{ github.workspace }}/.ci-runtime/lib
+      LUMINARI_TEST_CONFIG_FILE: .ci-runtime/lib/etc/config
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ${{ matrix.packages }} cmake pkg-config libcurl4-openssl-dev libevent-dev \
+            libgd-dev libjson-c-dev libmariadb-dev libssl-dev mariadb-client pandoc zlib1g-dev
+
+      - name: Copy config headers
+        run: |
+          cp src/campaign.example.h src/campaign.h
+          cp src/mud_options.example.h src/mud_options.h
+          cp src/vnums.example.h src/vnums.h
+
+      - name: Configure (${{ matrix.preset }})
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }} -j"$(nproc)"
+
+      - name: Prepare isolated test runtime
+        run: scripts/ci/prepare_test_runtime.sh "$LUMINARI_TEST_DATA_DIR"
+
+      - name: Test
+        run: ctest --preset ${{ matrix.preset }}
+
+      - name: Install
+        run: |
+          cmake --install build/${{ matrix.preset }}
+          test -x bin/luminari
+          test -L bin/luminari
+
+  clean-archive:
+    name: Clean archive, both build systems (blocking)
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: test_root_password
+          MARIADB_DATABASE: luminari_test
+          MARIADB_USER: luminari_test
+          MARIADB_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      LUMINARI_TEST_MYSQL_ENABLE: '1'
+      LUMINARI_TEST_MYSQL_HOST: 127.0.0.1
+      LUMINARI_TEST_MYSQL_USER: luminari_test
+      LUMINARI_TEST_MYSQL_PASSWORD: test_password
+      LUMINARI_TEST_MYSQL_DATABASE: luminari_test
+      LUMINARI_TEST_MYSQL_PORT: '3306'
+      LUMINARI_TEST_DATA_DIR: ${{ github.workspace }}/.ci-runtime/lib
+      LUMINARI_TEST_CONFIG_FILE: ${{ github.workspace }}/.ci-runtime/lib/etc/config
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf automake build-essential cmake libcurl4-openssl-dev libevent-dev \
+            libgd-dev libjson-c-dev libmariadb-dev libssl-dev libtool mariadb-client \
+            pandoc pkg-config ripgrep zlib1g-dev
+
+      - name: Prepare isolated test runtime
+        run: scripts/ci/prepare_test_runtime.sh "$LUMINARI_TEST_DATA_DIR"
+
+      - name: Build, test, and install git archive HEAD through Autotools and CMake
+        run: scripts/ci/check_clean_archive.sh
 
   build:
     name: Behavioral tests (Luminari)

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ bak/
 ####################
 # Ignore everything in build directory
 build/*
+CMakeUserPresets.json
 # But keep the directory structure
 !build/.gitkeep
 !build/CMakeFiles/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ never print or modify credentials.
 - NEVER attribute AI (Claude or anybody else) in commits or anywhere else.  NEVER post session links.
 - NEVER modify `src/campaign.h`, `src/mud_options.h`, `src/vnums.h` - they are local, customized configuration (gitignored). Edit the `.example.h` templates instead if a template change is needed. Only copy `.example.h` -> `.h` on a fresh clone where the real headers do not exist yet.
 - `lib/mysql_config` and `lib/.env` contain credentials: you may read them, never modify them without permission. Edit `lib/mysql_config_example` / `lib/.env.example` instead.
-- When adding or removing a source file, update BOTH `Makefile.am` and `CMakeLists.txt`.
+- When adding or removing a source file, update BOTH `Makefile.am` and `CMakeLists.txt`, then
+  run `python3 scripts/ci/check_build_parity.py` (CI blocks on drift).
 - All documentation must be valid ASCII, UTF-8, LF line endings.
 - Always trace code; never assume naming conventions.
 - After planning a task and before implementation, read and apply

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,32 @@ cmake_minimum_required(VERSION 3.21)
 # Version: Keep in sync with src/constants.c, src/structs.h, configure.ac
 project(LuminariMUD VERSION 2.5063 LANGUAGES C)
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBEVENT REQUIRED IMPORTED_TARGET libevent_core>=2.1.12)
-
 # Build as GNU C23 while retaining the project's established source style.
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 
-# Include checker modules
+# ========== User-facing options ==========
+# Every option is documented in docs/development/CMAKE_BUILD_GUIDE.md.
+option(BUILD_UTILS "Build the util/ helper programs" ON)
+option(BUILD_TESTS "Build production-linked unit tests and register CTest entries" OFF)
+option(DEVELOPER_MODE "Enable additional diagnostic warnings for development builds" OFF)
+option(MEMORY_DEBUG "Compile with the in-tree MEMORY_DEBUG allocation tracing" OFF)
+option(DMALLOC "Link against the dmalloc debugging allocator" OFF)
+option(STATIC_ANALYSIS "Run clang-tidy on every compiled source" OFF)
+option(LUMINARI_WERROR "Treat compiler warnings as errors" OFF)
+option(LUMINARI_COVERAGE "Instrument all targets for gcov/gcovr line and branch coverage" OFF)
+option(LUMINARI_HARDENING "Apply hardened Release flags (fortify, stack protector, PIE, RELRO)" OFF)
+set(LUMINARI_SANITIZERS "" CACHE STRING
+    "Comma-separated -fsanitize= list applied to every target (for example address,undefined)")
+
 include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckTypeSize)
 include(CheckStructHasMember)
 include(CheckSymbolExists)
 include(CheckCSourceCompiles)
+include(CheckCCompilerFlag)
 
 check_c_source_compiles(
     "int main(void) {
@@ -79,10 +90,6 @@ if (GIT_HEAD_REFERENCE)
     endif()
 endif()
 
-# Prefer CMake's binary directory for generated headers.
-include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
-include_directories(src)
-
 # Check for required configuration headers
 if (NOT EXISTS ${CMAKE_SOURCE_DIR}/src/campaign.h)
     message(FATAL_ERROR "campaign.h not found! Copy src/campaign.example.h to src/campaign.h and configure it.")
@@ -94,346 +101,149 @@ if (NOT EXISTS ${CMAKE_SOURCE_DIR}/src/vnums.h)
     message(FATAL_ERROR "vnums.h not found! Copy src/vnums.example.h to src/vnums.h and configure it.")
 endif()
 
-# ========== Compiler flags ==========
-if (CMAKE_COMPILER_IS_GNUCC)
-    include(CheckCCompilerFlag)
+# ========== Dependencies ==========
+# Autotools links every one of these unconditionally (luminari_LDADD in
+# Makefile.am), so they are required here as well. Minimum versions are the
+# oldest releases the supported Ubuntu LTS images ship; see
+# docs/development/CMAKE_BUILD_GUIDE.md.
+find_package(PkgConfig REQUIRED)
+find_package(Threads REQUIRED)
+find_package(CURL 7.68 REQUIRED)
+find_package(OpenSSL 1.1.1 REQUIRED)
+pkg_check_modules(LIBEVENT REQUIRED IMPORTED_TARGET libevent_core>=2.1.12)
+pkg_check_modules(JSONC REQUIRED IMPORTED_TARGET json-c>=0.13)
+pkg_check_modules(GD REQUIRED IMPORTED_TARGET gdlib>=2.2)
+pkg_check_modules(MARIADB IMPORTED_TARGET libmariadb>=3.1)
+if (MARIADB_FOUND)
+    set(LUMINARI_MYSQL_TARGET PkgConfig::MARIADB)
+else()
+    pkg_check_modules(MYSQLCLIENT REQUIRED IMPORTED_TARGET mysqlclient>=3.1)
+    set(LUMINARI_MYSQL_TARGET PkgConfig::MYSQLCLIENT)
+endif()
+find_library(CRYPT_LIBRARY crypt REQUIRED)
 
-    check_c_compiler_flag(-Wall SUPPORTS_WALL)
-    check_c_compiler_flag(-Wextra SUPPORTS_WEXTRA)
-    check_c_compiler_flag(-Wno-char-subscripts SUPPORTS_WNO_CHAR_SUBSCRIPTS)
-
-    if (SUPPORTS_WALL)
-        set(MYFLAGS "-Wall")
-        if (SUPPORTS_WEXTRA)
-            set(MYFLAGS "${MYFLAGS} -Wextra")
-        endif()
-        if (SUPPORTS_WNO_CHAR_SUBSCRIPTS)
-            set(MYFLAGS "${MYFLAGS} -Wno-char-subscripts")
-        endif()
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${MYFLAGS}")
-    endif()
+add_library(luminari_deps INTERFACE)
+target_link_libraries(luminari_deps INTERFACE
+    ${LUMINARI_MYSQL_TARGET}
+    PkgConfig::GD
+    PkgConfig::JSONC
+    PkgConfig::LIBEVENT
+    CURL::libcurl
+    OpenSSL::SSL
+    OpenSSL::Crypto
+    Threads::Threads
+    ${CRYPT_LIBRARY}
+    m)
+if (DMALLOC)
+    find_library(DMALLOC_LIBRARY dmalloc REQUIRED)
+    target_link_libraries(luminari_deps INTERFACE ${DMALLOC_LIBRARY})
 endif()
 
-# Static analysis is opt-in so normal builds are reproducible regardless of
-# whether clang-tidy happens to be installed on the build machine.
-option(STATIC_ANALYSIS "Enable static analysis with clang-tidy" OFF)
+# ========== Platform feature checks (mirror configure.ac) ==========
+foreach(HEADER
+        fcntl.h sys/fcntl.h errno.h net/errno.h string.h strings.h
+        limits.h sys/time.h sys/select.h sys/types.h unistd.h
+        memory.h crypt.h assert.h arpa/telnet.h arpa/inet.h
+        sys/stat.h sys/socket.h sys/resource.h netinet/in.h netdb.h
+        signal.h sys/uio.h mcheck.h sys/wait.h time.h
+        stdio.h stdlib.h inttypes.h stdint.h)
+    string(TOUPPER "${HEADER}" _upper_name)
+    string(REGEX REPLACE "[./]" "_" _upper_name "${_upper_name}")
+    check_include_file("${HEADER}" HAVE_${_upper_name})
+endforeach()
 
-if(STATIC_ANALYSIS)
-    find_program(CLANG_TIDY_EXE NAMES clang-tidy)
-    if(NOT CLANG_TIDY_EXE)
-        message(FATAL_ERROR "STATIC_ANALYSIS requested but clang-tidy not found")
-    endif()
-
-    message(STATUS "clang-tidy enabled: ${CLANG_TIDY_EXE}")
-    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_EXE}")
-    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-endif()
-
-# ========== Header checks ==========
-check_include_file("fcntl.h" HAVE_FCNTL_H)
-check_include_file("errno.h" HAVE_ERRNO_H)
-check_include_file("string.h" HAVE_STRING_H)
-check_include_file("strings.h" HAVE_STRINGS_H)
-check_include_file("limits.h" HAVE_LIMITS_H)
-check_include_file("sys/select.h" HAVE_SYS_SELECT_H)
-check_include_file("sys/wait.h" HAVE_SYS_WAIT_H)
-check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
-check_include_file("unistd.h" HAVE_UNISTD_H)
-check_include_file("memory.h" HAVE_MEMORY_H)
-check_include_file("assert.h" HAVE_ASSERT_H)
-check_include_file("arpa/telnet.h" HAVE_ARPA_TELNET_H)
-check_include_file("arpa/inet.h" HAVE_ARPA_INET_H)
-check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
-check_include_file("sys/socket.h" HAVE_SYS_SOCKET_H)
-check_include_file("sys/resource.h" HAVE_SYS_RESOURCE_H)
-check_include_file("netinet/in.h" HAVE_NETINET_IN_H)
-check_include_file("netdb.h" HAVE_NETDB_H)
-check_include_file("signal.h" HAVE_SIGNAL_H)
-check_include_file("sys/uio.h" HAVE_SYS_UIO_H)
-check_include_file("mcheck.h" HAVE_MCHECK_H)
-check_include_file("stdlib.h" HAVE_STDLIB_H)
-check_include_file("stdarg.h" HAVE_STDARG_H)
-check_include_file("float.h" HAVE_FLOAT_H)
-
-if (HAVE_STDLIB_H AND HAVE_STDARG_H AND HAVE_STRING_H AND HAVE_FLOAT_H)
+if (HAVE_STDLIB_H AND HAVE_STDIO_H AND HAVE_STRING_H)
     set(STDC_HEADERS 1)
 endif()
 
-# macros
-macro(check_run_return_value CODE EXPECTED_RESULT VAR_NAME)
-    set(_file "${CMAKE_BINARY_DIR}/check_run_${VAR_NAME}.c")
-    file(WRITE "${_file}" "${CODE}")
-    try_run(_run_result _compile_result
-            ${CMAKE_BINARY_DIR} ${_file}
-    )
-    if (_compile_result EQUAL 0 AND _run_result EQUAL ${EXPECTED_RESULT})
-        set(${VAR_NAME} TRUE)
-    else()
-        set(${VAR_NAME} FALSE)
-    endif()
-endmacro()
+set(CMAKE_REQUIRED_LIBRARIES ${CRYPT_LIBRARY})
+check_function_exists(crypt CIRCLE_CRYPT)
+unset(CMAKE_REQUIRED_LIBRARIES)
 
-# ========== Function checks ==========
+set(CMAKE_REQUIRED_LIBRARIES PkgConfig::JSONC)
+check_function_exists(json_object_new_object HAVE_JSON_C)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
 foreach(FUNC gettimeofday select snprintf strcasecmp strdup strerror
         stricmp strlcpy strncasecmp strnicmp strstr vsnprintf vprintf
-        inet_addr inet_aton)
+        inet_addr inet_aton gethostbyaddr socket)
     string(TOUPPER "${FUNC}" _upper_name)
     check_function_exists(${FUNC} HAVE_${_upper_name})
 endforeach()
-
-if (NOT HAVE_VPRINTF)
-    check_function_exists(_doprnt HAVE_DOPRNT)
+if (NOT HAVE_GETHOSTBYADDR)
+    find_library(NSL_LIBRARY nsl REQUIRED)
+    target_link_libraries(luminari_deps INTERFACE ${NSL_LIBRARY})
+endif()
+if (NOT HAVE_SOCKET)
+    find_library(SOCKET_LIBRARY socket REQUIRED)
+    target_link_libraries(luminari_deps INTERFACE ${SOCKET_LIBRARY})
 endif()
 
-
-# ========== Type checks ==========
+# Missing system types become the same conf.h fallbacks configure.ac emits.
 check_type_size("pid_t" HAVE_PID_T)
 check_type_size("size_t" HAVE_SIZE_T)
 check_type_size("ssize_t" HAVE_SSIZE_T)
 set(CMAKE_EXTRA_INCLUDE_FILES "sys/socket.h")
 check_type_size("socklen_t" HAVE_SOCKLEN_T)
 unset(CMAKE_EXTRA_INCLUDE_FILES)
-
-
 if (NOT HAVE_PID_T)
     set(pid_t int)
 endif()
-
 if (NOT HAVE_SIZE_T)
-    set(size_t "unsigned")
+    set(size_t "unsigned int")
 endif()
-
 if (NOT HAVE_SSIZE_T)
     set(ssize_t int)
 endif()
-
 if (NOT HAVE_SOCKLEN_T)
     set(socklen_t int)
 endif()
-
-# ========== const ==========
-check_c_source_compiles("
-int main() {
-
-/* Ultrix mips cc rejects this.  */
-typedef int charset[2]; const charset x;
-/* SunOS 4.1.1 cc rejects this.  */
-char const *const *ccp;
-char **p;
-/* NEC SVR4.0.2 mips cc rejects this.  */
-struct point {int x, y;};
-static struct point const zero = {0,0};
-/* AIX XL C 1.02.0.0 rejects this.
-   It does not let you subtract one const X* pointer from another in an arm
-   of an if-expression whose if-part is not a constant expression */
-const char *g = \"string\";
-ccp = &g + (g ? g-g : 0);
-/* HPUX 7.0 cc rejects these. */
-++ccp;
-p = (char**) ccp;
-ccp = (char const *const *) p;
-{ /* SCO 3.2v4 cc rejects this.  */
-  char *t;
-  char const *s = 0 ? (char *) 0 : (char const *) 0;
-
-  *t++ = 0;
-}
-{ /* Someone thinks the Sun supposedly-ANSI compiler will reject this.  */
-  int x[] = {25, 17};
-  const int *foo = &x[0];
-  ++foo;
-}
-{ /* Sun SC1.0 ANSI compiler rejects this -- but not the above. */
-  typedef const int *iptr;
-  iptr p = 0;
-  ++p;
-}
-{ /* AIX XL C 1.02.0.0 rejects this saying
-     \"k.c\", line 2.27: 1506-025 (S) Operand must be a modifiable lvalue. */
-  struct s { int j; const int *ap[3]; };
-  struct s *b; b->j = 5;
-}
-{ /* ULTRIX-32 V3.1 (Rev 9) vcc rejects this */
-  const int foo = 10;
-}
-
-; return 0; }
-" HAVE_CONST)
-
-if (HAVE_CONST)
-    set(CONST_KEYWORD const)
-else()
-    set(CONST_KEYWORD "")
-endif()
-
-# ========== Struct checks ==========
 if (HAVE_NETINET_IN_H)
     check_struct_has_member("struct in_addr" s_addr netinet/in.h HAVE_STRUCT_IN_ADDR)
 endif()
-
-# ========== MySQL/MariaDB support ==========
-find_package(PkgConfig)
-if (PkgConfig_FOUND)
-    # Try MariaDB first (preferred)
-    pkg_check_modules(MARIADB mariadb)
-    if (MARIADB_FOUND)
-        message(STATUS "Found MariaDB: ${MARIADB_LIBRARIES}")
-        list(APPEND EXTRA_LIBS ${MARIADB_LIBRARIES})
-        include_directories(${MARIADB_INCLUDE_DIRS})
-        set(CIRCLE_MYSQL 1)
-    else()
-        # Fall back to MySQL
-        pkg_check_modules(MYSQL mysqlclient)
-        if (MYSQL_FOUND)
-            message(STATUS "Found MySQL: ${MYSQL_LIBRARIES}")
-            list(APPEND EXTRA_LIBS ${MYSQL_LIBRARIES})
-            include_directories(${MYSQL_INCLUDE_DIRS})
-            set(CIRCLE_MYSQL 1)
-        else()
-            # Try manual search for MariaDB/MySQL
-            find_path(MYSQL_INCLUDE_DIR mysql.h
-                PATHS /usr/include/mariadb /usr/include/mysql /usr/local/include/mariadb /usr/local/include/mysql
-                PATH_SUFFIXES mariadb mysql)
-            find_library(MYSQL_LIBRARY
-                NAMES mariadb mysqlclient
-                PATHS /usr/lib /usr/local/lib
-                PATH_SUFFIXES mariadb mysql)
-            if (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-                message(STATUS "Found MariaDB/MySQL manually: ${MYSQL_LIBRARY}")
-                list(APPEND EXTRA_LIBS ${MYSQL_LIBRARY})
-                include_directories(${MYSQL_INCLUDE_DIR})
-                set(CIRCLE_MYSQL 1)
-            else()
-                message(WARNING "MariaDB/MySQL not found. Database support will be disabled.")
-            endif()
-        endif()
-    endif()
-endif()
-
-# ========== GD Graphics Library ==========
-find_package(PkgConfig)
-if (PkgConfig_FOUND)
-    pkg_check_modules(GD gdlib)
-    if (GD_FOUND)
-        message(STATUS "Found GD: ${GD_LIBRARIES}")
-        list(APPEND EXTRA_LIBS ${GD_LIBRARIES})
-        include_directories(${GD_INCLUDE_DIRS})
-    else()
-        find_library(GD_LIBRARY gd)
-        if (GD_LIBRARY)
-            message(STATUS "Found GD manually: ${GD_LIBRARY}")
-            list(APPEND EXTRA_LIBS ${GD_LIBRARY})
-        endif()
-    endif()
-endif()
-
-# ========== crypt()/libcrypt ==========
-
-find_library(CRYPT_LIBRARY crypt)
-if (CRYPT_LIBRARY)
-    message(STATUS "Found libcrypt: ${CRYPT_LIBRARY}")
-    list(APPEND EXTRA_LIBS ${CRYPT_LIBRARY})
-    set(_saved_lib_list ${CMAKE_REQUIRED_LIBRARIES})
-    set(CMAKE_REQUIRED_LIBRARIES ${CRYPT_LIBRARY})
-    check_include_file("crypt.h" HAVE_CRYPT_H)
-    check_function_exists(crypt CIRCLE_CRYPT)
-
-    check_run_return_value("
-#include <string.h>
-#include <unistd.h>
-${HAVE_CRYPT_H} ? \"#include <crypt.h>\" : \"\"
-
-int main(void)
-{
-  char pwd[11], pwd2[11];
-
-  strncpy(pwd, (char *)crypt(\"FooBar\", \"BazQux\"), 10);
-  pwd[10] = '\\\\0';
-  strncpy(pwd2, (char *)crypt(\"xyzzy\", \"BazQux\"), 10);
-  pwd2[10] = '\\\\0';
-  if (strcmp(pwd, pwd2) == 0)
-    exit(0);
-  exit(1);
-}
-    " 0 HAVE_UNSAFE_CRYPT)
-
-    set(CMAKE_REQUIRED_LIBRARIES ${_saved_lib_list})
-endif()
-
-
-# ========== network libs ==========
-check_function_exists(gethostbyaddr HAVE_GETHOSTBYADDR)
-if (NOT HAVE_GETHOSTBYADDR)
-    message(STATUS "gethostbyaddr() not available, trying nsllib")
-    find_library(NSL_LIBRARY nsl)
-    if (NSL_LIBRARY)
-        message(STATUS "...nsllib found.")
-        list(APPEND EXTRA_LIBS ${NSL_LIBRARY})
-    endif()
-endif()
-
-check_function_exists(socket HAVE_SOCKET)
-if (NOT HAVE_SOCKET)
-    message(STATUS "socket() not available, trying socketlib")
-    find_library(SOCKET_LIBRARY socket)
-    if (SOCKET_LIBRARY)
-        message(STATUS "...socketlib found")
-        list(APPEND EXTRA_LIBS ${SOCKET_LIBRARY})
-    endif()
-endif()
-
-# ========== time.h needs special treatment ==========
-check_include_file("sys/time.h" HAVE_SYS_TIME_H)
-check_include_file("time.h" HAVE_TIME_H)
-
-if (HAVE_SYS_TIME_H AND HAVE_TIME_H)
-    check_c_source_compiles("
-#include <sys/types.h>
-#include <sys/time.h>
-#include <time.h>
-int main() {
-struct tm *tp;
-; return 0; }
-    " TIME_WITH_SYS_TIME)
-endif()
-
-# ========== Determine return value of signal() ==========
-check_c_source_compiles("
-    #include <signal.h>
-    int handler(int sig) { return 0; }
-    int main() {
-        signal(SIGINT, handler);
-        return 1;
-    }
-" SIGNAL_RETURNS_INT FAIL_REGEX ".*incompatible pointer type.*")
-
-check_c_source_compiles("
-    #include <signal.h>
-    void handler(int sig) { }
-    int main() {
-        signal(SIGINT, handler);
-        return 1;
-    }
-" SIGNAL_RETURNS_VOID FAIL_REGEX ".*incompatible pointer type.*")
-
-if (SIGNAL_RETURNS_INT)
-    message(STATUS "signal() returns int.")
-    set(RETSIGTYPE int)
-elseif (SIGNAL_RETURNS_VOID)
-    message(STATUS "signal() returns void.")
-    set(RETSIGTYPE void)
-else()
-    message(FATAL_ERROR "Could not determine return value from signal handler.")
-endif()
-
-# ========== Define general UNIX-system ==========
 if (UNIX)
     set(CIRCLE_UNIX 1)
 endif()
 
 # Generate the header included by both the server and utility sources after all
-# platform checks have populated their feature variables.
-configure_file(cmake/cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/conf.h)
+# platform checks have populated their feature variables. It lands at
+# src/conf.h, the same gitignored location configure.ac uses, because the
+# standalone test scripts under scripts/ preprocess sources with -Isrc.
+configure_file(cmake/cmake_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/src/conf.h)
+
+# ========== Shared build interface ==========
+# Every compiled target links this interface library instead of relying on
+# directory-wide include paths or global CMAKE_C_FLAGS edits.
+add_library(luminari_build INTERFACE)
+target_include_directories(luminari_build INTERFACE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+set(LUMINARI_GNU_LIKE "$<C_COMPILER_ID:GNU,Clang,AppleClang>")
+target_compile_options(luminari_build INTERFACE
+    $<${LUMINARI_GNU_LIKE}:-Wall;-Wextra>
+    $<$<AND:${LUMINARI_GNU_LIKE},$<BOOL:${LUMINARI_WERROR}>>:-Werror>
+    $<$<AND:${LUMINARI_GNU_LIKE},$<BOOL:${DEVELOPER_MODE}>>:-Wshadow;-Wcast-qual;-Wwrite-strings;-Wconversion;-Wunreachable-code>)
+target_compile_definitions(luminari_build INTERFACE
+    $<$<BOOL:${MEMORY_DEBUG}>:MEMORY_DEBUG>
+    $<$<BOOL:${DMALLOC}>:DMALLOC>)
+if (LUMINARI_SANITIZERS)
+    target_compile_options(luminari_build INTERFACE
+        -fsanitize=${LUMINARI_SANITIZERS} -fno-omit-frame-pointer)
+    target_link_options(luminari_build INTERFACE -fsanitize=${LUMINARI_SANITIZERS})
+endif()
+if (LUMINARI_COVERAGE)
+    target_compile_options(luminari_build INTERFACE --coverage)
+    target_link_options(luminari_build INTERFACE --coverage)
+endif()
+if (LUMINARI_HARDENING)
+    target_compile_definitions(luminari_build INTERFACE
+        $<$<NOT:$<CONFIG:Debug>>:_FORTIFY_SOURCE=3>)
+    target_compile_options(luminari_build INTERFACE
+        -fstack-protector-strong -fstack-clash-protection -fPIE)
+    target_link_options(luminari_build INTERFACE
+        -pie -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack)
+endif()
 
 # ========== Source files ==========
 # Main C source files
@@ -800,16 +610,13 @@ set(SRC_C_FILES
     src/net/i3_client.c
     src/net/i3_commands.c
     src/net/i3_utils.c
-    # Temporarily commented out problematic I3 files to fix build
-    # src/net/i3_config.c
-    # src/net/i3_error.c
-    # src/net/i3_memory.c
-    # src/net/i3_protocol.c
-    # src/net/i3_security.c
-    # src/net/i3_test.c
+    src/pet_vnums.h
+    src/elf_build_id.h
+    src/player_rename.h
+    src/tactical_effects.h
 )
 
-set(SRC_FILES ${SRC_C_FILES} ${BUILD_IDENTITY_HEADER} src/pet_vnums.h)
+set(SRC_FILES ${SRC_C_FILES} ${BUILD_IDENTITY_HEADER})
 set_source_files_properties(${BUILD_IDENTITY_HEADER} PROPERTIES GENERATED TRUE)
 
 # ========== Build main executable FIRST ==========
@@ -823,128 +630,10 @@ add_custom_target(refresh_build_identity ALL
     COMMENT "Refreshing embedded Git build identity")
 add_dependencies(luminari refresh_build_identity)
 
-# Add compile definitions based on detected features
-target_compile_definitions(luminari PRIVATE
-    $<$<BOOL:${CIRCLE_MYSQL}>:CIRCLE_MYSQL>
-    $<$<BOOL:${CIRCLE_UNIX}>:CIRCLE_UNIX>
-    $<$<BOOL:${CIRCLE_CRYPT}>:CIRCLE_CRYPT>
-    $<$<BOOL:${HAVE_FCNTL_H}>:HAVE_FCNTL_H>
-    $<$<BOOL:${HAVE_ERRNO_H}>:HAVE_ERRNO_H>
-    $<$<BOOL:${HAVE_STRING_H}>:HAVE_STRING_H>
-    $<$<BOOL:${HAVE_STRINGS_H}>:HAVE_STRINGS_H>
-    $<$<BOOL:${HAVE_LIMITS_H}>:HAVE_LIMITS_H>
-    $<$<BOOL:${HAVE_SYS_SELECT_H}>:HAVE_SYS_SELECT_H>
-    $<$<BOOL:${HAVE_SYS_WAIT_H}>:HAVE_SYS_WAIT_H>
-    $<$<BOOL:${HAVE_SYS_TYPES_H}>:HAVE_SYS_TYPES_H>
-    $<$<BOOL:${HAVE_UNISTD_H}>:HAVE_UNISTD_H>
-    $<$<BOOL:${HAVE_MEMORY_H}>:HAVE_MEMORY_H>
-    $<$<BOOL:${HAVE_ASSERT_H}>:HAVE_ASSERT_H>
-    $<$<BOOL:${HAVE_ARPA_TELNET_H}>:HAVE_ARPA_TELNET_H>
-    $<$<BOOL:${HAVE_ARPA_INET_H}>:HAVE_ARPA_INET_H>
-    $<$<BOOL:${HAVE_SYS_STAT_H}>:HAVE_SYS_STAT_H>
-    $<$<BOOL:${HAVE_SYS_SOCKET_H}>:HAVE_SYS_SOCKET_H>
-    $<$<BOOL:${HAVE_SYS_RESOURCE_H}>:HAVE_SYS_RESOURCE_H>
-    $<$<BOOL:${HAVE_NETINET_IN_H}>:HAVE_NETINET_IN_H>
-    $<$<BOOL:${HAVE_NETDB_H}>:HAVE_NETDB_H>
-    $<$<BOOL:${HAVE_SIGNAL_H}>:HAVE_SIGNAL_H>
-    $<$<BOOL:${HAVE_SYS_UIO_H}>:HAVE_SYS_UIO_H>
-    $<$<BOOL:${HAVE_MCHECK_H}>:HAVE_MCHECK_H>
-    $<$<BOOL:${HAVE_STDLIB_H}>:HAVE_STDLIB_H>
-    $<$<BOOL:${HAVE_STDARG_H}>:HAVE_STDARG_H>
-    $<$<BOOL:${HAVE_FLOAT_H}>:HAVE_FLOAT_H>
-    $<$<BOOL:${HAVE_SYS_TIME_H}>:HAVE_SYS_TIME_H>
-    $<$<BOOL:${HAVE_TIME_H}>:HAVE_TIME_H>
-    $<$<BOOL:${HAVE_CRYPT_H}>:HAVE_CRYPT_H>
-    $<$<BOOL:${STDC_HEADERS}>:STDC_HEADERS>
-    $<$<BOOL:${TIME_WITH_SYS_TIME}>:TIME_WITH_SYS_TIME>
-    $<$<BOOL:${HAVE_GETTIMEOFDAY}>:HAVE_GETTIMEOFDAY>
-    $<$<BOOL:${HAVE_SELECT}>:HAVE_SELECT>
-    $<$<BOOL:${HAVE_SNPRINTF}>:HAVE_SNPRINTF>
-    $<$<BOOL:${HAVE_STRCASECMP}>:HAVE_STRCASECMP>
-    $<$<BOOL:${HAVE_STRDUP}>:HAVE_STRDUP>
-    $<$<BOOL:${HAVE_STRERROR}>:HAVE_STRERROR>
-    $<$<BOOL:${HAVE_STRICMP}>:HAVE_STRICMP>
-    $<$<BOOL:${HAVE_STRLCPY}>:HAVE_STRLCPY>
-    $<$<BOOL:${HAVE_STRNCASECMP}>:HAVE_STRNCASECMP>
-    $<$<BOOL:${HAVE_STRNICMP}>:HAVE_STRNICMP>
-    $<$<BOOL:${HAVE_STRSTR}>:HAVE_STRSTR>
-    $<$<BOOL:${HAVE_VSNPRINTF}>:HAVE_VSNPRINTF>
-    $<$<BOOL:${HAVE_VPRINTF}>:HAVE_VPRINTF>
-    $<$<BOOL:${HAVE_INET_ADDR}>:HAVE_INET_ADDR>
-    $<$<BOOL:${HAVE_INET_ATON}>:HAVE_INET_ATON>
-    $<$<BOOL:${HAVE_STRUCT_IN_ADDR}>:HAVE_STRUCT_IN_ADDR>
-    $<$<BOOL:${HAVE_CONST}>:HAVE_CONST>
-    $<$<BOOL:${HAVE_UNSAFE_CRYPT}>:HAVE_UNSAFE_CRYPT>
-    RETSIGTYPE=${RETSIGTYPE}
-)
-
-# Add type definitions if needed
-if (NOT HAVE_PID_T)
-    target_compile_definitions(luminari PRIVATE pid_t=int)
-endif()
-if (NOT HAVE_SIZE_T)
-    target_compile_definitions(luminari PRIVATE size_t=unsigned)
-endif()
-if (NOT HAVE_SSIZE_T)
-    target_compile_definitions(luminari PRIVATE ssize_t=int)
-endif()
-if (NOT HAVE_SOCKLEN_T)
-    target_compile_definitions(luminari PRIVATE socklen_t=int)
-endif()
-
-# Link required libraries
-target_link_libraries(luminari ${EXTRA_LIBS} m pthread PkgConfig::LIBEVENT)
-
-# Find and link additional libraries
-find_library(CURL_LIBRARY curl)
-if (CURL_LIBRARY)
-    target_link_libraries(luminari ${CURL_LIBRARY})
-endif()
-
-find_library(SSL_LIBRARY ssl)
-if (SSL_LIBRARY)
-    target_link_libraries(luminari ${SSL_LIBRARY})
-endif()
-
-find_library(CRYPTO_LIBRARY crypto)
-if (CRYPTO_LIBRARY)
-    target_link_libraries(luminari ${CRYPTO_LIBRARY})
-endif()
-
-find_library(JSON_C_LIBRARY json-c)
-if (JSON_C_LIBRARY)
-    target_link_libraries(luminari ${JSON_C_LIBRARY})
-    target_compile_definitions(luminari PRIVATE HAVE_JSON_C)
-endif()
-
-# ========== Compiler warnings and options ==========
-if (CMAKE_COMPILER_IS_GNUCC)
-    # Additional warnings for development
-    if (DEVELOPER_MODE)
-        target_compile_options(luminari PRIVATE -Wshadow -Wcast-qual
-                               -Wwrite-strings -Wconversion -Wunreachable-code)
-    endif()
-endif()
-
-# ========== Feature toggles ==========
-if (MEMORY_DEBUG)
-    message(STATUS "MEMORY_DEBUG is activated")
-    target_compile_definitions(luminari PRIVATE MEMORY_DEBUG)
-endif()
-
-if (DMALLOC)
-    message(STATUS "DMALLOC is activated")
-    target_compile_definitions(luminari PRIVATE DMALLOC)
-    find_library(DMALLOC_LIBRARY dmalloc)
-    if (DMALLOC_LIBRARY)
-        target_link_libraries(luminari ${DMALLOC_LIBRARY})
-    endif()
-endif()
+target_link_libraries(luminari PRIVATE luminari_build luminari_deps)
 
 # ========== Build utilities AFTER main executable ==========
 # Build utilities by default (can be disabled with -DBUILD_UTILS=OFF)
-option(BUILD_UTILS "Build utility programs" ON)
-
 if (BUILD_UTILS)
     # Utilities from util/ directory
     add_executable(autowiz util/autowiz.c)
@@ -960,14 +649,14 @@ if (BUILD_UTILS)
     add_executable(split util/split.c)
     add_executable(wld2html util/wld2html.c)
 
-    # Set output directory for utilities
-    set_target_properties(autowiz asciipasswd plrtoascii rebuildAsciiIndex
-                          rebuildMailIndex rol_mob_calculator shopconv sign split wld2html
+    set(LUMINARI_UTIL_TARGETS autowiz asciipasswd plrtoascii rebuildAsciiIndex
+        rebuildMailIndex rol_mob_calculator shopconv sign split wld2html)
+    set_target_properties(${LUMINARI_UTIL_TARGETS}
                           PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIR})
-
-    # Link libraries for utilities that need them
-    target_link_libraries(asciipasswd ${CRYPT_LIBRARY})
-
+    foreach(UTIL_TARGET ${LUMINARI_UTIL_TARGETS})
+        target_link_libraries(${UTIL_TARGET} PRIVATE luminari_build)
+    endforeach()
+    target_link_libraries(asciipasswd PRIVATE ${CRYPT_LIBRARY})
 endif()
 
 # ========== Standalone world-data tools ==========
@@ -1249,7 +938,6 @@ add_custom_target(test-help-sync-integration
 
 # ========== Build unit tests AFTER main executable ==========
 # The focused protocol parser harness remains available under unittests/CuTest.
-option(BUILD_TESTS "Build production-linked unit tests" OFF)
 
 # Keep this list synchronized with cutest_test_files in Makefile.am.
 set(CUTEST_TEST_SOURCES
@@ -1333,7 +1021,7 @@ if (BUILD_TESTS)
     target_compile_definitions(bsd_snprintf_fallback_test PRIVATE
         BROKEN_SNPRINTF
         TEST_SNPRINTF)
-    target_link_libraries(bsd_snprintf_fallback_test PRIVATE m)
+    target_link_libraries(bsd_snprintf_fallback_test PRIVATE luminari_build m)
     add_test(NAME bsd-snprintf-fallback COMMAND bsd_snprintf_fallback_test)
 
     set(CUTEST_GENERATOR
@@ -1363,20 +1051,27 @@ if (BUILD_TESTS)
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     target_include_directories(cutest PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/unittests/CuTest)
+    target_compile_definitions(cutest PRIVATE LUMINARI_CUTEST)
+    target_link_libraries(cutest PRIVATE luminari_build luminari_deps)
 
-    get_target_property(LUMINARI_COMPILE_DEFINITIONS
-        luminari COMPILE_DEFINITIONS)
-    target_compile_definitions(cutest PRIVATE
-        ${LUMINARI_COMPILE_DEFINITIONS}
-        LUMINARI_CUTEST)
-
-    get_target_property(LUMINARI_COMPILE_OPTIONS luminari COMPILE_OPTIONS)
-    if (LUMINARI_COMPILE_OPTIONS)
-        target_compile_options(cutest PRIVATE ${LUMINARI_COMPILE_OPTIONS})
-    endif()
-
-    get_target_property(LUMINARI_LINK_LIBRARIES luminari LINK_LIBRARIES)
-    target_link_libraries(cutest PRIVATE ${LUMINARI_LINK_LIBRARIES})
+    add_test(NAME build-parity
+        COMMAND Python3::Interpreter scripts/ci/check_build_parity.py)
+    add_test(NAME sql-interpolation-self-test
+        COMMAND Python3::Interpreter scripts/ci/check_sql_interpolation.py --self-test)
+    add_test(NAME sql-interpolation
+        COMMAND Python3::Interpreter scripts/ci/check_sql_interpolation.py)
+    add_test(NAME help-sync
+        COMMAND Python3::Interpreter -m unittest discover
+                -s scripts/help-sync/tests -p test_*.py -v)
+    add_test(NAME background-help-entries
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_background_help_entries.sh)
+    set_tests_properties(
+        build-parity
+        sql-interpolation-self-test
+        sql-interpolation
+        help-sync
+        background-help-entries
+        PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_test(NAME production-cutest COMMAND cutest)
     set_tests_properties(production-cutest PROPERTIES
@@ -1495,6 +1190,27 @@ add_custom_target(test-healthcheck
     COMMENT "Running healthcheck regression tests"
 )
 
+# ========== Static analysis ==========
+# Opt-in so normal builds are reproducible regardless of whether clang-tidy is
+# installed. The analyzer is attached to each executable target rather than
+# set through the directory-wide CMAKE_C_CLANG_TIDY variable.
+if (STATIC_ANALYSIS)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+    if (NOT CLANG_TIDY_EXE)
+        message(FATAL_ERROR "STATIC_ANALYSIS requested but clang-tidy not found")
+    endif()
+    message(STATUS "clang-tidy enabled: ${CLANG_TIDY_EXE}")
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    get_directory_property(LUMINARI_ALL_TARGETS BUILDSYSTEM_TARGETS)
+    foreach(ANALYZED_TARGET IN LISTS LUMINARI_ALL_TARGETS)
+        get_target_property(ANALYZED_TYPE ${ANALYZED_TARGET} TYPE)
+        if (ANALYZED_TYPE STREQUAL "EXECUTABLE")
+            set_target_properties(${ANALYZED_TARGET} PROPERTIES
+                C_CLANG_TIDY "${CLANG_TIDY_EXE}")
+        endif()
+    endforeach()
+endif()
+
 # ========== Installation ==========
 install(CODE "
     execute_process(
@@ -1523,10 +1239,16 @@ endif()
 message(STATUS "========================================")
 message(STATUS "LuminariMUD CMake Configuration Summary:")
 message(STATUS "  C Standard: GNU C23")
-message(STATUS "  MySQL Support: ${CIRCLE_MYSQL}")
+message(STATUS "  C Compiler: ${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
+message(STATUS "  MySQL Client: ${LUMINARI_MYSQL_TARGET}")
 message(STATUS "  Build Type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "  Build Utilities: ${BUILD_UTILS}")
 message(STATUS "  Build Tests: ${BUILD_TESTS}")
+message(STATUS "  Developer Mode: ${DEVELOPER_MODE}")
+message(STATUS "  Warnings As Errors: ${LUMINARI_WERROR}")
+message(STATUS "  Sanitizers: ${LUMINARI_SANITIZERS}")
+message(STATUS "  Coverage: ${LUMINARI_COVERAGE}")
+message(STATUS "  Hardening: ${LUMINARI_HARDENING}")
 message(STATUS "  Install Binary Output: ${INSTALL_BIN_OUTPUT_DIR}")
 message(STATUS "  Install Prefix: ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "  Binary Output: ${BIN_OUTPUT_DIR}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,115 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "BUILD_TESTS": "ON",
+        "BUILD_UTILS": "ON"
+      }
+    },
+    {
+      "name": "dev",
+      "displayName": "Developer Debug (system compiler)",
+      "inherits": "base",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "dev-clang",
+      "displayName": "Developer Debug (Clang)",
+      "inherits": "dev",
+      "cacheVariables": { "CMAKE_C_COMPILER": "clang" }
+    },
+    {
+      "name": "ci-gcc",
+      "displayName": "Strict CI (GCC, warnings are errors)",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_C_COMPILER": "gcc",
+        "LUMINARI_WERROR": "ON"
+      }
+    },
+    {
+      "name": "ci-clang",
+      "displayName": "Strict CI (Clang, warnings are errors)",
+      "inherits": "ci-gcc",
+      "cacheVariables": { "CMAKE_C_COMPILER": "clang" }
+    },
+    {
+      "name": "sanitizers",
+      "displayName": "AddressSanitizer + UndefinedBehaviorSanitizer",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "LUMINARI_SANITIZERS": "address,undefined"
+      }
+    },
+    {
+      "name": "coverage",
+      "displayName": "gcov/gcovr coverage instrumentation",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "gcc",
+        "LUMINARI_COVERAGE": "ON"
+      }
+    },
+    {
+      "name": "release-hardened",
+      "displayName": "Hardened Release",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTS": "OFF",
+        "LUMINARI_HARDENING": "ON"
+      }
+    },
+    {
+      "name": "cross-aarch64",
+      "displayName": "Cross build for aarch64-linux-gnu",
+      "inherits": "base",
+      "toolchainFile": "${sourceDir}/cmake/toolchains/aarch64-linux-gnu.cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTS": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "dev", "configurePreset": "dev" },
+    { "name": "dev-clang", "configurePreset": "dev-clang" },
+    { "name": "ci-gcc", "configurePreset": "ci-gcc" },
+    { "name": "ci-clang", "configurePreset": "ci-clang" },
+    { "name": "sanitizers", "configurePreset": "sanitizers" },
+    { "name": "coverage", "configurePreset": "coverage" },
+    { "name": "release-hardened", "configurePreset": "release-hardened" },
+    { "name": "cross-aarch64", "configurePreset": "cross-aarch64" }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "output": { "outputOnFailure": true },
+      "execution": { "stopOnFailure": false }
+    },
+    { "name": "dev", "inherits": "base", "configurePreset": "dev" },
+    { "name": "dev-clang", "inherits": "base", "configurePreset": "dev-clang" },
+    { "name": "ci-gcc", "inherits": "base", "configurePreset": "ci-gcc" },
+    { "name": "ci-clang", "inherits": "base", "configurePreset": "ci-clang" },
+    {
+      "name": "sanitizers",
+      "inherits": "base",
+      "configurePreset": "sanitizers",
+      "environment": {
+        "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1",
+        "UBSAN_OPTIONS": "print_stacktrace=1:halt_on_error=1"
+      }
+    },
+    { "name": "coverage", "inherits": "base", "configurePreset": "coverage" }
+  ]
+}

--- a/Makefile.am
+++ b/Makefile.am
@@ -576,6 +576,20 @@ src/constants.c: $(filter-out src/constants.c,$(luminari_SOURCES))
 # Standalone Python world-data tooling. Keep this list synchronized with
 # WORLD_TOOL_SOURCES in CMakeLists.txt.
 world_tool_sources = \
+	scripts/world/install_pet_constructs.py \
+	data/pet-constructs/196.mob \
+	data/pet-planar-allies/197.mob \
+	data/pet-undead/198.mob \
+	data/pet-lycanthropes/195.mob \
+	data/pet-lycanthropes/195.zon \
+	data/pet-illusions/199.mob \
+	data/pet-illusions/199.zon \
+	data/pet-undead/198.zon \
+	data/pet-undead/README.md \
+	data/pet-planar-allies/197.zon \
+	data/pet-planar-allies/README.md \
+	data/pet-constructs/README.md \
+	data/pet-constructs/196.zon \
 	scripts/world/generate_rol_periodic_profiles.py \
 	scripts/world/generate_rol_state_periodic_profiles.py \
 	scripts/world/wtool.py \
@@ -794,20 +808,6 @@ help_sync_sources = \
 
 # Extra files to distribute
 EXTRA_DIST = \
-	data/pet-constructs/196.mob \
-	data/pet-planar-allies/197.mob \
-	data/pet-undead/198.mob \
-	data/pet-lycanthropes/195.mob \
-	data/pet-lycanthropes/195.zon \
-	data/pet-illusions/199.mob \
-	data/pet-illusions/199.zon \
-	data/pet-undead/198.zon \
-	data/pet-undead/README.md \
-	data/pet-planar-allies/197.zon \
-	data/pet-planar-allies/README.md \
-	data/pet-constructs/README.md \
-	data/pet-constructs/196.zon \
-	scripts/world/install_pet_constructs.py \
 	scripts/development/generate_msp_sounds.py \
 	lib/sounds/README.md \
 	lib/sounds/luminari-test.wav \
@@ -1014,8 +1014,16 @@ EXTRA_DIST = \
 	sql/master_schema.sql \
 	README.md
 
+# Fail when the Autotools and CMake source manifests drift apart.
+check-build-parity:
+	cd "$(abs_top_srcdir)" && python3 scripts/ci/check_build_parity.py
+
+# Configure, build, and test an untouched git archive through both build systems.
+distcheck-archive:
+	"$(abs_top_srcdir)/scripts/ci/check_clean_archive.sh"
+
 # Run unit tests
-test: check test-help-sync test-autorun-supervision test-versioned-binary-install \
+test: check check-build-parity test-help-sync test-autorun-supervision test-versioned-binary-install \
 	test-binary-name-static test-healthcheck test-sql-interpolation \
 	test-background-help-entries test-demand-driven-architecture test-event-admission \
 	test-event-core-performance-gate test-native-event-architecture test-pubsub-retirement \
@@ -1024,7 +1032,7 @@ test: check test-help-sync test-autorun-supervision test-versioned-binary-instal
 		LUMINARI_TEST_SPEC_WORLD_ROOT="$(abs_top_srcdir)/unittests/CuTest/fixtures/spec_world_inventory" \
 		./cutest
 
-.PHONY: check-world-docs rol-mob-calculator test-all test-world-tools test-help-sync \
+.PHONY: check-build-parity distcheck-archive check-world-docs rol-mob-calculator test-all test-world-tools test-help-sync \
 	test-help-sync-integration test-protocol test-protocol-fuzz test-character-rename-static \
 	test-character-rename-schema test-background-help-entries test-autorun-supervision \
 	test-versioned-binary-install test-binary-name-static test-healthcheck \

--- a/README.md
+++ b/README.md
@@ -113,13 +113,14 @@ The focused protocol parser harness is separate:
 make -C unittests/CuTest protocol-parser
 ```
 
-For CMake, explicitly enable tests in a fresh build directory:
+For CMake, use a checked-in preset (tests are enabled by every preset except
+`release-hardened` and `cross-aarch64`):
 
 ```bash
-cmake -S . -B build -DBUILD_TESTS=ON
-cmake --build build -j"$(nproc)"
-ctest --test-dir build --output-on-failure
-cmake --install build
+cmake --preset dev
+cmake --build --preset dev -j"$(nproc)"
+ctest --preset dev
+cmake --install build/dev
 ```
 
 See the [testing guide](docs/guides/TESTING_GUIDE.md) for fixture, database,

--- a/cmake/cmake_config.h.in
+++ b/cmake/cmake_config.h.in
@@ -1,29 +1,31 @@
-/* CMake configuration header. */
+/* CMake configuration header. Keep the macro set aligned with the checks in
+ * configure.ac so both build systems compile identical feature definitions. */
 
 #cmakedefine CIRCLE_CRYPT 1
-#cmakedefine CIRCLE_MYSQL 1
 #cmakedefine CIRCLE_UNIX 1
 
 #cmakedefine HAVE_ARPA_INET_H 1
 #cmakedefine HAVE_ARPA_TELNET_H 1
 #cmakedefine HAVE_ASSERT_H 1
-#cmakedefine HAVE_CONST 1
 #cmakedefine HAVE_CRYPT_H 1
 #cmakedefine HAVE_ERRNO_H 1
 #cmakedefine HAVE_FCNTL_H 1
-#cmakedefine HAVE_FLOAT_H 1
 #cmakedefine HAVE_GETTIMEOFDAY 1
 #cmakedefine HAVE_INET_ADDR 1
 #cmakedefine HAVE_INET_ATON 1
+#cmakedefine HAVE_INTTYPES_H 1
+#cmakedefine HAVE_JSON_C 1
 #cmakedefine HAVE_LIMITS_H 1
 #cmakedefine HAVE_MCHECK_H 1
 #cmakedefine HAVE_MEMORY_H 1
 #cmakedefine HAVE_NETDB_H 1
 #cmakedefine HAVE_NETINET_IN_H 1
+#cmakedefine HAVE_NET_ERRNO_H 1
 #cmakedefine HAVE_SELECT 1
 #cmakedefine HAVE_SIGNAL_H 1
 #cmakedefine HAVE_SNPRINTF 1
-#cmakedefine HAVE_STDARG_H 1
+#cmakedefine HAVE_STDINT_H 1
+#cmakedefine HAVE_STDIO_H 1
 #cmakedefine HAVE_STDLIB_H 1
 #cmakedefine HAVE_STRCASECMP 1
 #cmakedefine HAVE_STRDUP 1
@@ -36,6 +38,7 @@
 #cmakedefine HAVE_STRNICMP 1
 #cmakedefine HAVE_STRSTR 1
 #cmakedefine HAVE_STRUCT_IN_ADDR 1
+#cmakedefine HAVE_SYS_FCNTL_H 1
 #cmakedefine HAVE_SYS_RESOURCE_H 1
 #cmakedefine HAVE_SYS_SELECT_H 1
 #cmakedefine HAVE_SYS_SOCKET_H 1
@@ -46,10 +49,12 @@
 #cmakedefine HAVE_SYS_WAIT_H 1
 #cmakedefine HAVE_TIME_H 1
 #cmakedefine HAVE_UNISTD_H 1
-#cmakedefine HAVE_UNSAFE_CRYPT 1
 #cmakedefine HAVE_VPRINTF 1
 #cmakedefine HAVE_VSNPRINTF 1
 #cmakedefine STDC_HEADERS 1
-#cmakedefine TIME_WITH_SYS_TIME 1
 
-#define RETSIGTYPE @RETSIGTYPE@
+/* Fallback definitions for system types configure.ac also probes. */
+#cmakedefine pid_t @pid_t@
+#cmakedefine size_t @size_t@
+#cmakedefine socklen_t @socklen_t@
+#cmakedefine ssize_t @ssize_t@

--- a/cmake/toolchains/aarch64-linux-gnu.cmake
+++ b/cmake/toolchains/aarch64-linux-gnu.cmake
@@ -1,0 +1,29 @@
+# Cross toolchain for aarch64-linux-gnu. Used by the cross-aarch64 preset.
+#
+# Requires the GNU cross compiler (Debian/Ubuntu: gcc-aarch64-linux-gnu) and a
+# sysroot that already contains the aarch64 development packages listed in
+# docs/development/CMAKE_BUILD_GUIDE.md. Point LUMINARI_SYSROOT at that root:
+#
+#   cmake --preset cross-aarch64 -DLUMINARI_SYSROOT=/srv/sysroots/aarch64
+#
+# pkg-config is redirected into the sysroot so the pkg_check_modules() calls in
+# CMakeLists.txt resolve libevent, json-c, gd, and the MariaDB client there.
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(LUMINARI_CROSS_TRIPLE aarch64-linux-gnu)
+set(CMAKE_C_COMPILER ${LUMINARI_CROSS_TRIPLE}-gcc)
+
+set(LUMINARI_SYSROOT "" CACHE PATH "Sysroot holding the aarch64 development packages")
+if (LUMINARI_SYSROOT)
+    set(CMAKE_SYSROOT ${LUMINARI_SYSROOT})
+    set(CMAKE_FIND_ROOT_PATH ${LUMINARI_SYSROOT})
+    set(ENV{PKG_CONFIG_SYSROOT_DIR} ${LUMINARI_SYSROOT})
+    set(ENV{PKG_CONFIG_LIBDIR}
+        "${LUMINARI_SYSROOT}/usr/lib/${LUMINARI_CROSS_TRIPLE}/pkgconfig:${LUMINARI_SYSROOT}/usr/share/pkgconfig")
+endif()
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/docs/development/CMAKE_BUILD_GUIDE.md
+++ b/docs/development/CMAKE_BUILD_GUIDE.md
@@ -2,230 +2,239 @@
 
 ## Overview
 
-This guide covers building LuminariMUD using CMake as an alternative to the traditional Autotools approach. CMake provides cross-platform build configuration, better IDE integration, and modern build system features.
+CMake is the supported secondary build. Autotools remains preferred for
+incremental development, but both systems must compile the same production
+and production-linked test sources with the same feature definitions, and CI
+builds and tests CMake with GCC and Clang on every change.
 
-**IMPORTANT**: LuminariMUD uses GNU C23. The initial migration retains the established source formatting and declaration style.
+LuminariMUD uses GNU C23. The build retains the established source formatting
+and declaration style.
 
 ## Prerequisites
 
-- CMake 3.21 or higher
-- GCC or Clang compiler with GNU C23 support
-- MariaDB development libraries (libmariadb-dev) or MySQL development libraries
-- GD graphics library (optional)
+| Dependency | Minimum | Ubuntu package |
+|------------|---------|----------------|
+| CMake | 3.21 | `cmake` |
+| GCC or Clang with GNU C23 | GCC 13 / Clang 16 | `gcc` or `clang` |
+| pkg-config | any | `pkg-config` |
+| libevent core | 2.1.12 | `libevent-dev` |
+| MariaDB Connector/C (or MySQL client) | 3.1 | `libmariadb-dev` |
+| json-c | 0.13 | `libjson-c-dev` |
+| GD | 2.2 | `libgd-dev` |
+| libcurl | 7.68 | `libcurl4-openssl-dev` |
+| OpenSSL | 1.1.1 | `libssl-dev` |
+| libcrypt | any | `libcrypt-dev` |
+| Python | 3.10 | `python3` |
+
+Every library above is required. Autotools links all of them unconditionally,
+so CMake resolves each through an imported target (`PkgConfig::LIBEVENT`,
+`PkgConfig::JSONC`, `PkgConfig::GD`, `PkgConfig::MARIADB` or
+`PkgConfig::MYSQLCLIENT`, `CURL::libcurl`, `OpenSSL::SSL`, `OpenSSL::Crypto`,
+`Threads::Threads`) and fails configuration when one is missing. Libraries
+installed outside the default search paths are found through
+`PKG_CONFIG_PATH` or `CMAKE_PREFIX_PATH`. The one exception is libcrypt,
+which ships neither a pkg-config file nor a CMake package: it is resolved
+with `find_library(CRYPT_LIBRARY crypt REQUIRED)`, so `CRYPT_LIBRARY` is the
+only library cache entry you may need to set by hand. `nsl`, `socket`, and
+`dmalloc` use the same mechanism but are only probed on platforms (or with
+options) that need them.
 
 ## Quick Start
 
 ```bash
-# Configure required headers (one-time setup)
+# Configure required headers (one-time setup on a fresh clone)
 cp src/campaign.example.h src/campaign.h
 cp src/mud_options.example.h src/mud_options.h
 cp src/vnums.example.h src/vnums.h
 
-# Configure and build with CMake
-cmake -S . -B build/
-cmake --build build/ -j"$(nproc)"
-cmake --install build/
-
-# The candidate is build/bin/luminari; installation activates bin/luminari
-ls -la bin/luminari
+cmake --preset dev
+cmake --build --preset dev -j"$(nproc)"
+ctest --preset dev
+cmake --install build/dev
 ```
 
-## Configuration Options
+`cmake --install` promotes `build/<preset>/bin/luminari` into an immutable
+build-ID release and activates `bin/luminari`.
 
-### Basic Options
+## Presets
+
+`CMakePresets.json` defines the supported configurations. Each configure
+preset has matching `--build` and (where tests apply) `ctest` presets and
+writes to `build/<preset>`.
+
+| Preset | Purpose |
+|--------|---------|
+| `dev` | Debug build with tests and utilities, system compiler |
+| `dev-clang` | The same with `clang` |
+| `ci-gcc` | RelWithDebInfo, `-Wall -Wextra -Werror`, blocking in CI |
+| `ci-clang` | The same with `clang`, blocking in CI |
+| `sanitizers` | Debug with `-fsanitize=address,undefined` |
+| `coverage` | Debug with `--coverage` for gcov/gcovr |
+| `release-hardened` | Release with fortify, stack protector, PIE, RELRO, no tests |
+| `cross-aarch64` | Release cross build through `cmake/toolchains/aarch64-linux-gnu.cmake` |
+
+Personal variations belong in the gitignored `CMakeUserPresets.json`.
+
+### Cross builds
+
+The `cross-aarch64` preset uses the GNU cross compiler
+(`gcc-aarch64-linux-gnu`) and a sysroot containing the aarch64 versions of the
+libraries listed above:
 
 ```bash
-# Debug build
-cmake -DCMAKE_BUILD_TYPE=Debug ..
-
-# Release build with optimizations
-cmake -DCMAKE_BUILD_TYPE=Release ..
-
-# Build with utilities
-cmake -DBUILD_UTILS=ON ..
-
-# Build with unit tests
-cmake -DBUILD_TESTS=ON ..
+cmake --preset cross-aarch64 -DLUMINARI_SYSROOT=/srv/sysroots/aarch64
+cmake --build --preset cross-aarch64 -j"$(nproc)"
 ```
 
-### Feature Toggles
+The toolchain file redirects pkg-config into the sysroot. Copy it to add
+another target triple. No GitHub Actions job exercises this preset: the hosted
+runners have no aarch64 sysroot, and a configure-only run against host
+`.pc` files would prove nothing. Cross builds are verified by hand on a
+machine that has the sysroot.
+
+## Options
+
+All options are declared in `CMakeLists.txt` and printed in the configuration
+summary.
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `BUILD_UTILS` | `ON` | Build the `util/` helper programs |
+| `BUILD_TESTS` | `OFF` | Build `cutest` and register the CTest entries |
+| `DEVELOPER_MODE` | `OFF` | Add `-Wshadow -Wcast-qual -Wwrite-strings -Wconversion -Wunreachable-code` |
+| `MEMORY_DEBUG` | `OFF` | Define `MEMORY_DEBUG` for the in-tree allocation tracing |
+| `DMALLOC` | `OFF` | Define `DMALLOC` and link the dmalloc allocator (required when set) |
+| `STATIC_ANALYSIS` | `OFF` | Run clang-tidy on every compiled source and export compile commands |
+| `LUMINARI_WERROR` | `OFF` | Add `-Werror` |
+| `LUMINARI_COVERAGE` | `OFF` | Add `--coverage` to compile and link |
+| `LUMINARI_HARDENING` | `OFF` | Add `_FORTIFY_SOURCE=3`, `-fstack-protector-strong`, `-fstack-clash-protection`, PIE, RELRO, and `-z now` |
+| `LUMINARI_SANITIZERS` | empty | Comma-separated `-fsanitize=` list, for example `address,undefined` |
+
+Options compose with any preset. `DEVELOPER_MODE` is deliberately not
+enabled by a checked-in preset because `-Wconversion` alone reports thousands
+of pre-existing warnings; turn it on for a focused pass:
 
 ```bash
-# Enable memory debugging
-cmake -DMEMORY_DEBUG=ON ..
-
-# Enable dmalloc support
-cmake -DDMALLOC=ON ..
-
-# Enable developer warnings
-cmake -DDEVELOPER_MODE=ON ..
-
-# Enable static analysis with clang-tidy
-cmake -DSTATIC_ANALYSIS=ON ..
+cmake --preset dev -DDEVELOPER_MODE=ON
 ```
 
-### Library Paths
-
-If CMake can't find your libraries automatically:
+Every flag, definition, include path, and link option is attached to the
+`luminari_build` and `luminari_deps` interface targets, which the server,
+`cutest`, and every utility link. `STATIC_ANALYSIS` likewise sets the
+`C_CLANG_TIDY` property on each executable target instead of the
+directory-wide `CMAKE_C_CLANG_TIDY` variable. The build never edits
+`CMAKE_C_FLAGS` or global include directories, so `CMAKE_C_FLAGS` remains
+free for caller additions:
 
 ```bash
-# Specify MariaDB paths (if not found automatically)
-cmake -DMARIADB_INCLUDE_DIR=/usr/include/mariadb \
-      -DMARIADB_LIBRARY=/usr/lib/libmariadb.so ..
-
-# Or for MySQL compatibility
-cmake -DMYSQL_INCLUDE_DIR=/usr/include/mysql \
-      -DMYSQL_LIBRARY=/usr/lib/libmysqlclient.so ..
-
-# Specify GD library
-cmake -DGD_LIBRARY=/usr/lib/libgd.so ..
+cmake --preset dev -DCMAKE_C_FLAGS="-march=native"
 ```
+
+## Feature definitions
+
+Configuration writes the same platform macros `configure.ac` produces into the
+gitignored `src/conf.h` from `cmake/cmake_config.h.in`. Keeping the header in
+`src/` matches Autotools and lets the standalone scripts under `scripts/`
+preprocess sources with `-Isrc`. The generated `build_identity.h` lives in the
+build directory.
+
+The two headers differ only in macros no source consumes: Autotools also
+emits `PACKAGE_*`, `VERSION`, and `HAVE_EVENT2_EVENT_H`. Fallback `pid_t`,
+`size_t`, `ssize_t`, and `socklen_t` definitions are written into `conf.h` by
+both systems. The obsolete Autoconf `TIME_WITH_SYS_TIME` probe is defined by
+neither; `sysdep.h` includes `<time.h>` unconditionally alongside
+`<sys/time.h>` when that header exists.
+
+## Manifest parity
+
+`Makefile.am` and `CMakeLists.txt` list sources by hand. The check
+
+```bash
+python3 scripts/ci/check_build_parity.py
+```
+
+fails when `luminari_SOURCES`/`SRC_C_FILES`,
+`cutest_test_files`/`CUTEST_TEST_SOURCES`, or the world-tool and help-sync
+lists differ, contain duplicates, or name files that are missing or untracked.
+Variable references are expanded before comparison (`$(luminari_SOURCES)`
+inside `cutest_SOURCES`, `${SRC_FILES}` inside the CMake `cutest` target), so
+the check also verifies that both production-linked suites compile exactly the
+harness, every test file, and every production source, and that CMake compiles
+the generated `AllTests.c` registry. Removing `$(luminari_SOURCES)` from
+`cutest_SOURCES`, or `${SRC_FILES}` from `add_executable(cutest ...)`, fails
+the check. It runs as the `build-parity` CTest entry, through
+`make check-build-parity` (part of `make test`), and as a blocking GitHub
+Actions job.
+
+## Distribution check
+
+```bash
+make distcheck-archive
+# or
+scripts/ci/check_clean_archive.sh
+```
+
+exports `git archive HEAD` into a temporary directory and, for each build
+system in turn, configures, builds, runs that system's full test entry point
+(`make test`, then `ctest` for the CMake preset), and installs. It proves that
+no untracked local file or generated artifact is required. The blocking
+`Clean archive, both build systems` GitHub Actions job runs this script after
+`scripts/ci/prepare_test_runtime.sh` has provisioned the isolated MariaDB
+runtime; a plain checkout is not a substitute, because it still contains
+`.git` and any local build output. The script is not part of `make test`
+because it rebuilds the whole tree twice; run it before tagging a release or
+whenever the manifests, install scripts, or generated headers change. Without
+the MariaDB runtime, export `LUMINARI_TEST_SKIP_SYNTAX_BOOT=1` so the boot
+test skips instead of failing on missing world data.
+
+The two test entry points are not identical. Autotools `make test` and CTest
+both run the production-linked CuTest suite, the manifest parity check, the
+help-sync, SQL interpolation, and background-help checks, and the event,
+autorun, versioned-install, binary-name, and healthcheck scripts. CTest
+additionally runs the world-data tool tests, the `bsd-snprintf` fallback
+test, and the vessel and process-memory tooling checks that Autotools
+exposes through `make test-all` and `make test-vessel-tooling`.
 
 ## Build Targets
 
 ```bash
-# Build main server
-cmake --build build/ --target luminari
-
-# Install the server release after it has been tested
-cmake --install build/
-
-# Build specific utility (if enabled)
-cmake --build build/ --target autowiz
-
-# Build all utilities
-cmake -S . -B build/ -DBUILD_UTILS=ON
-cmake --build build/
-
-# Build unit tests
-cmake -S . -B build/ -DBUILD_TESTS=ON
-cmake --build build/ --target cutest
-
-# Clean build
-cmake --build build/ --target clean
-# Or simply:
-rm -rf build/*
+cmake --build build/dev --target luminari
+cmake --build build/dev --target cutest
+cmake --build build/dev --target test-world-tools
+cmake --build build/dev --target test-help-sync
+cmake --build build/dev --target clean
 ```
 
 ## IDE Integration
 
-### Visual Studio Code
-
-Create `.vscode/settings.json`:
-```json
-{
-    "cmake.sourceDirectory": "${workspaceFolder}",
-    "cmake.buildDirectory": "${workspaceFolder}/build",
-    "cmake.configureSettings": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "BUILD_UTILS": "ON"
-    }
-}
-```
-
-### CLion
-
-1. Open project root containing CMakeLists.txt
-2. CLion will automatically detect CMake project
-3. Configure build profiles in Settings -> Build -> CMake
-
-### Eclipse CDT
-
-```bash
-# Generate Eclipse project files
-mkdir build-eclipse
-cd build-eclipse
-cmake -G"Eclipse CDT4 - Unix Makefiles" ..
-```
+Any IDE that reads `CMakePresets.json` (VS Code with the CMake Tools
+extension, CLion) lists the presets above directly. Enable
+`CMAKE_EXPORT_COMPILE_COMMANDS` or the `STATIC_ANALYSIS` option for clangd.
 
 ## Troubleshooting
 
-### Source Style Note
+### Missing dependency
 
-GNU C23 accepts `//` comments, but project style continues to use `/* */` comments. Existing code is not mechanically restyled as part of the language migration.
+Configuration stops with the pkg-config module or package name that was not
+found. Install the matching development package from the table above, or set
+`PKG_CONFIG_PATH` to a prefix that contains its `.pc` file.
 
-### Missing MySQL
-
-```bash
-# Ubuntu/Debian
-sudo apt-get install libmysqlclient-dev
-
-# CentOS/RHEL
-sudo yum install mysql-devel
-
-# Specify paths manually
-cmake -DMYSQL_INCLUDE_DIR=/path/to/mysql/include \
-      -DMYSQL_LIBRARY=/path/to/libmysqlclient.so ..
-```
-
-### Configuration Headers Missing
+### Configuration headers missing
 
 ```
 CMake Error: campaign.h not found!
 ```
 
-Solution:
-```bash
-cp src/campaign.example.h src/campaign.h
-cp src/mud_options.example.h src/mud_options.h
-cp src/vnums.example.h src/vnums.h
-# Edit files as needed, then re-run cmake
-```
+Copy the three `.example.h` templates as shown in the quick start. Never
+overwrite an existing local header.
 
-## Comparison with Autotools Build
+### Source style
 
-| Feature | Autotools | CMake |
-|---------|-----------|--------|
-| Configure | `./configure` | `cmake ..` |
-| Build | `make` | `make` |
-| Clean | `make clean` | `make clean` |
-| Utilities | `make utils` | `cmake -DBUILD_UTILS=ON ..` |
-| IDE Support | Limited | Excellent |
-| Cross-platform | Unix-like only | Windows, Mac, Linux |
-
-## Advanced Usage
-
-### Custom Compiler Flags
-
-```bash
-# Add custom flags
-cmake -DCMAKE_C_FLAGS="-march=native -mtune=native" ..
-
-# Debug with sanitizers
-cmake -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_C_FLAGS="-fsanitize=address -fsanitize=undefined" ..
-```
-
-### Export Compile Commands
-
-For tools like clang-tidy, clangd:
-```bash
-cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-```
-
-### Parallel Builds
-
-```bash
-# Use all CPU cores
-make -j$(nproc)
-
-# Or specify number
-make -j4
-```
-
-## Notes
-
-1. Autotools is preferred for incremental development; CMake remains supported
-2. CMake builds the candidate at `build/bin/luminari`; `cmake --install build/`
-   retains it and its symbols under `bin/releases/<ELF-build-ID>/` and
-   atomically activates `bin/luminari`
-3. CMake requires GNU C23 and retains compiler extensions
-4. The build configuration no longer generates `conf.h` - all defines are passed directly to the compiler
-5. MySQL configuration still uses `lib/mysql_config` file
-6. Build artifacts are cleanly separated in the `build/` directory
+GNU C23 accepts `//` comments, but project style continues to use `/* */`
+comments. Existing code is not mechanically restyled.
 
 ## See Also
 
-- [Deployment Guide](../deployment/DEPLOYMENT_GUIDE.md) - Traditional build process
-- [Developer Guide](../guides/DEVELOPER_GUIDE_AND_API.md) - Coding standards
-- [Testing Guide](../guides/TESTING_GUIDE.md) - Running tests
+- [Setup and Build Guide](../guides/SETUP_AND_BUILD_GUIDE.md)
+- [Testing Guide](../guides/TESTING_GUIDE.md)
+- [Developer Guide](../guides/DEVELOPER_GUIDE_AND_API.md)

--- a/docs/guides/DEVELOPER_GUIDE_AND_API.md
+++ b/docs/guides/DEVELOPER_GUIDE_AND_API.md
@@ -286,7 +286,8 @@ a second consumer proves the same contract.
    callers.
 6. Add production-linked registry, OLC, persistence, and invocation coverage as
    applicable.
-7. Update both `Makefile.am` and `CMakeLists.txt` for source membership changes.
+7. Update both `Makefile.am` and `CMakeLists.txt` for source membership changes
+   and run `python3 scripts/ci/check_build_parity.py`.
 8. Update builder documentation and database-first help migration/verifier when
    the contract changes.
 

--- a/docs/guides/SETUP_AND_BUILD_GUIDE.md
+++ b/docs/guides/SETUP_AND_BUILD_GUIDE.md
@@ -23,9 +23,13 @@ flags with `./scripts/deployment/deploy.sh --help`.
 sudo apt-get update
 sudo apt-get install -y build-essential git make autoconf automake libtool \
   cmake pkg-config mariadb-server libmariadb-dev libcrypt-dev libgd-dev \
-  libcurl4-openssl-dev libssl-dev libjson-c-dev zlib1g-dev mariadb-client \
-  curl pandoc gdb valgrind
+  libevent-dev libcurl4-openssl-dev libssl-dev libjson-c-dev zlib1g-dev \
+  mariadb-client curl pandoc gdb valgrind
 ```
+
+Minimum supported dependency versions are listed in the
+[CMake build guide](../development/CMAKE_BUILD_GUIDE.md); both build systems
+require the same libraries.
 
 ## Existing Configured Checkout
 
@@ -75,15 +79,28 @@ fresh minimal world rather than assembling the required indexes manually.
 
 ## CMake
 
-CMake is the supported secondary build. Tests are disabled by default and must
-be enabled explicitly for validation:
+CMake is the supported secondary build. Use the checked-in presets, which
+enable tests and write to `build/<preset>`:
 
 ```bash
-cmake -S . -B build -DBUILD_TESTS=ON
-cmake --build build -j"$(nproc)"
-ctest --test-dir build --output-on-failure
-cmake --install build
+cmake --preset dev
+cmake --build --preset dev -j"$(nproc)"
+ctest --preset dev
+cmake --install build/dev
 ```
+
+`dev-clang`, `ci-gcc`, `ci-clang`, `sanitizers`, `coverage`,
+`release-hardened`, and `cross-aarch64` cover the other supported workflows.
+Options such as `DEVELOPER_MODE`, `LUMINARI_WERROR`, and `LUMINARI_SANITIZERS`
+are documented in the [CMake build guide](../development/CMAKE_BUILD_GUIDE.md).
+
+Both build systems must list the same sources. `make check-build-parity` (also
+run by `make test`, CTest, and CI) fails when `Makefile.am` and
+`CMakeLists.txt` drift, including the production-source membership of both
+`cutest` targets. `make distcheck-archive` configures, builds, tests, and
+installs an untouched `git archive HEAD` through both systems; CI runs it as
+a blocking job, and it is not part of `make test` because it rebuilds the
+tree twice.
 
 ## Run and Verify
 

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -47,9 +47,9 @@ queue, compatibility heartbeat, and population-loop implementations are not
 compiled into that executable:
 
 ```sh
-cmake -S . -B build-native
-cmake --build build-native -j"$(nproc)"
-build-native/bin/luminari -c
+cmake --preset dev
+cmake --build --preset dev -j"$(nproc)"
+build/dev/bin/luminari -c
 ```
 
 The loop-based rollback executable and its build/runtime selectors were
@@ -317,8 +317,8 @@ candidate. Phase 8 runs the same check while its assembled candidate exists.
 Equivalent CMake and CTest entry points are:
 
 ```sh
-cmake --build build --target test-world-tools
-ctest --test-dir build --output-on-failure -R '^world-tool'
+cmake --build build/dev --target test-world-tools
+ctest --preset dev -R '^world-tool'
 ```
 
 Focused checks are also available:
@@ -500,6 +500,29 @@ PubSub exclusion. Run the consolidated event check directly with:
 scripts/events/test_native_event_architecture.sh
 ```
 
+## Build System Parity
+
+```sh
+make check-build-parity
+make distcheck-archive
+```
+
+The first command compares every hand-maintained source list in `Makefile.am`
+with its `CMakeLists.txt` counterpart and fails on missing, extra, duplicate,
+nonexistent, or untracked entries. Variable references are expanded first, so
+it also proves that `cutest_SOURCES` and the CMake `cutest` target both
+compile every production source plus the harness and test files. It runs
+inside `make test`, as the `build-parity` CTest entry, and as a blocking CI
+job. The second exports `git archive HEAD` to a temporary directory and, for
+Autotools and then the CMake `dev` preset (override with `CMAKE_PRESET=<name>`),
+configures, builds, runs `make test` or `ctest`, and installs, so a
+distribution never depends on repository-only files. It runs as the blocking
+`Clean archive, both build systems` CI job after the isolated MariaDB runtime
+is prepared; locally, export `LUMINARI_TEST_SKIP_SYNTAX_BOOT=1` when no world
+data is available. It is not part of `make test` because it rebuilds the tree
+twice. The CMake `sanitizers` and `coverage` presets provide the same
+instrumentation as the Autotools `CFLAGS` recipes in the workflow.
+
 ## Coverage
 
 The GitHub Actions coverage job:
@@ -618,9 +641,11 @@ or gameplay checks for the affected packages before production deployment.
 3. Use synthetic fixtures and restore any modified globals before returning.
 4. Add the file to `cutest_SOURCES` and `cutest_test_files` in `Makefile.am`.
 5. Add the file to `CUTEST_TEST_SOURCES` in `CMakeLists.txt`.
-6. Run `autoreconf -fvi`, `./configure`, `make test`, and the relevant focused
+6. Run `python3 scripts/ci/check_build_parity.py`; it fails until both lists
+   match.
+7. Run `autoreconf -fvi`, `./configure`, `make test`, and the relevant focused
    harness.
-7. Run Valgrind for code that allocates, frees, or mutates global registries.
+8. Run Valgrind for code that allocates, frees, or mutates global registries.
 
 Tests must include positive, negative, boundary, and cleanup assertions where
 they are meaningful. An unconditional passing placeholder is not a test and
@@ -632,6 +657,9 @@ must not be added to the enforced suite.
 
 - standalone world-data unit, fixture, constants, documentation, and wrapper
   checks;
+- Autotools/CMake manifest parity (`scripts/ci/check_build_parity.py`);
+- blocking CMake configure, build, CTest, and install jobs with the strict
+  `ci-gcc` and `ci-clang` presets (`-Wall -Wextra -Werror`);
 - the supported Luminari behavioral suite;
 - root `make test-all`;
 - ASan, UBSan, and bounded protocol fuzzing;
@@ -645,8 +673,9 @@ every push: no tracked build products, valid UTF-8 with LF endings, and ASCII
 documentation. See the Source Tree Hygiene section of
 [SETUP_AND_BUILD_GUIDE.md](SETUP_AND_BUILD_GUIDE.md).
 
-The behavioral, authoritative, and coverage jobs also run the syntax-check
-boot against an isolated MariaDB service and tracked minimal world. The
+The behavioral, authoritative, CMake, and coverage jobs also run the
+syntax-check boot against an isolated MariaDB service and tracked minimal
+world. The
 integration workflow independently starts the network server and proves that
 it accepts a TCP connection.
 

--- a/scripts/ci/check_build_parity.py
+++ b/scripts/ci/check_build_parity.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Fail when the Autotools and CMake source manifests drift apart.
+
+Both build systems keep hand-maintained file lists. This check parses the
+variables that must stay equivalent, then reports entries that are missing
+from one side, duplicated within a list, or that name files absent from the
+tree (or untracked, when run inside a Git checkout).
+
+Usage: scripts/ci/check_build_parity.py [--root DIR]
+Exit status is 0 when every manifest pair matches, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+# (Makefile.am variable, CMakeLists.txt variable)
+MANIFEST_PAIRS = (
+    ("luminari_SOURCES", "SRC_C_FILES"),
+    ("cutest_test_files", "CUTEST_TEST_SOURCES"),
+    ("world_tool_sources", "WORLD_TOOL_SOURCES"),
+    ("world_tool_support_files", "WORLD_TOOL_SUPPORT_FILES"),
+    ("help_sync_sources", "HELP_SYNC_SOURCES"),
+)
+
+# The production-linked suite must compile the harness, every test file, and
+# every production source on both sides. Autotools lists them in
+# cutest_SOURCES (via $(luminari_SOURCES)); CMake lists them in the cutest
+# add_executable() call (via ${SRC_FILES}). The generated AllTests.c registry
+# is checked separately: Autotools carries it in nodist_cutest_SOURCES and
+# CMake writes it into the build directory.
+CUTEST_HARNESS = "unittests/CuTest/CuTest.c"
+CUTEST_REGISTRY = "unittests/CuTest/AllTests.c"
+
+MAKE_REFERENCE = re.compile(r"^\$\(([A-Za-z_][A-Za-z0-9_]*)\)$")
+CMAKE_REFERENCE = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+
+
+def expand(
+    variables: dict[str, list[str]],
+    tokens: list[str],
+    reference: re.Pattern[str],
+    seen: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Replace whole-token variable references with their expanded contents.
+
+    Tokens that still contain an unresolved substitution (generated paths such
+    as ${CMAKE_CURRENT_BINARY_DIR}/AllTests.c) are dropped: they never name a
+    tracked source and cannot be compared against the other manifest.
+    """
+    expanded: list[str] = []
+    for token in tokens:
+        match = reference.match(token)
+        if match and match.group(1) in variables and match.group(1) not in seen:
+            name = match.group(1)
+            expanded += expand(variables, variables[name], reference, seen | {name})
+        elif "$" not in token:
+            expanded.append(token)
+    return expanded
+
+
+def parse_makefile_am(text: str) -> dict[str, list[str]]:
+    """Return variable -> raw tokens for backslash-continued assignments."""
+    variables: dict[str, list[str]] = {}
+    pattern = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        match = pattern.match(lines[index])
+        if not match:
+            index += 1
+            continue
+        name = match.group(1)
+        body = match.group(2)
+        while body.rstrip().endswith("\\") and index + 1 < len(lines):
+            body = body.rstrip()[:-1] + " "
+            index += 1
+            body += lines[index]
+        variables[name] = body.split()
+        index += 1
+    return variables
+
+
+def parse_cmake_lists(text: str) -> dict[str, list[str]]:
+    """Return variable -> raw tokens for set(VAR ...) blocks, comments stripped."""
+    variables: dict[str, list[str]] = {}
+    for match in re.finditer(
+        r"^\s*set\(([A-Za-z_][A-Za-z0-9_]*)\s*(.*?)\)\s*$", text, re.S | re.M
+    ):
+        name = match.group(1)
+        body = re.sub(r"#[^\n]*", "", match.group(2))
+        variables[name] = body.split()
+    return variables
+
+
+def parse_cmake_executable(text: str, target: str) -> list[str] | None:
+    """Return the raw source tokens of add_executable(<target> ...)."""
+    match = re.search(
+        r"^\s*add_executable\(" + re.escape(target) + r"\s*(.*?)\)\s*$",
+        text,
+        re.S | re.M,
+    )
+    if match is None:
+        return None
+    return re.sub(r"#[^\n]*", "", match.group(1)).split()
+
+
+def tracked_files(root: Path) -> set[str] | None:
+    try:
+        output = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return {entry.decode() for entry in output.split(b"\0") if entry}
+
+
+def report_list(label: str, entries: list[str]) -> list[str]:
+    return [f"  {label}: {entry}" for entry in sorted(entries)]
+
+
+def check_pair(
+    am_name: str,
+    am_entries: list[str],
+    cm_name: str,
+    cm_entries: list[str],
+) -> list[str]:
+    problems: list[str] = []
+    am_dupes = [name for name, count in Counter(am_entries).items() if count > 1]
+    cm_dupes = [name for name, count in Counter(cm_entries).items() if count > 1]
+    problems += report_list(f"duplicate in Makefile.am {am_name}", am_dupes)
+    problems += report_list(f"duplicate in CMakeLists.txt {cm_name}", cm_dupes)
+    am_set, cm_set = set(am_entries), set(cm_entries)
+    problems += report_list(
+        f"listed in Makefile.am {am_name} but not CMakeLists.txt {cm_name}",
+        sorted(am_set - cm_set),
+    )
+    problems += report_list(
+        f"listed in CMakeLists.txt {cm_name} but not Makefile.am {am_name}",
+        sorted(cm_set - am_set),
+    )
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="repository root (default: derived from this script's location)",
+    )
+    args = parser.parse_args()
+    root: Path = args.root
+
+    am_text = (root / "Makefile.am").read_text()
+    cm_text = (root / "CMakeLists.txt").read_text()
+    am_raw = parse_makefile_am(am_text)
+    cm_raw = parse_cmake_lists(cm_text)
+    am_vars = {
+        name: expand(am_raw, tokens, MAKE_REFERENCE) for name, tokens in am_raw.items()
+    }
+    cm_vars = {
+        name: expand(cm_raw, tokens, CMAKE_REFERENCE) for name, tokens in cm_raw.items()
+    }
+
+    problems: list[str] = []
+    referenced: set[str] = set()
+    for am_name, cm_name in MANIFEST_PAIRS:
+        if am_name not in am_vars:
+            problems.append(f"  Makefile.am does not define {am_name}")
+            continue
+        if cm_name not in cm_vars:
+            problems.append(f"  CMakeLists.txt does not define {cm_name}")
+            continue
+        problems += check_pair(am_name, am_vars[am_name], cm_name, cm_vars[cm_name])
+        referenced.update(am_vars[am_name])
+        referenced.update(cm_vars[cm_name])
+
+    # Production-linked suite composition on both sides, after expansion.
+    expected_cutest = (
+        set(am_vars.get("cutest_test_files", []))
+        | set(am_vars.get("luminari_SOURCES", []))
+        | {CUTEST_HARNESS}
+    )
+    am_cutest = am_vars.get("cutest_SOURCES", [])
+    if CUTEST_REGISTRY not in am_vars.get("nodist_cutest_SOURCES", []):
+        problems.append(
+            f"  Makefile.am nodist_cutest_SOURCES does not list {CUTEST_REGISTRY}"
+        )
+    am_cutest = [entry for entry in am_cutest if entry != CUTEST_REGISTRY]
+    problems += report_list(
+        "duplicate in Makefile.am cutest_SOURCES",
+        [name for name, count in Counter(am_cutest).items() if count > 1],
+    )
+    problems += report_list(
+        "Makefile.am cutest_SOURCES is missing a production-linked source",
+        sorted(expected_cutest - set(am_cutest)),
+    )
+    problems += report_list(
+        "Makefile.am cutest_SOURCES lists a file outside the production-linked set",
+        sorted(set(am_cutest) - expected_cutest),
+    )
+
+    cm_cutest_raw = parse_cmake_executable(cm_text, "cutest")
+    if cm_cutest_raw is None:
+        problems.append("  CMakeLists.txt does not define add_executable(cutest ...)")
+    else:
+        if "${CUTEST_ALL_TESTS_SOURCE}" not in cm_cutest_raw:
+            problems.append(
+                "  CMakeLists.txt cutest target does not compile ${CUTEST_ALL_TESTS_SOURCE}"
+            )
+        cm_cutest = expand(cm_raw, cm_cutest_raw, CMAKE_REFERENCE)
+        problems += report_list(
+            "duplicate in CMakeLists.txt cutest target",
+            [name for name, count in Counter(cm_cutest).items() if count > 1],
+        )
+        problems += report_list(
+            "CMakeLists.txt cutest target is missing a production-linked source",
+            sorted(expected_cutest - set(cm_cutest)),
+        )
+        problems += report_list(
+            "CMakeLists.txt cutest target lists a file outside the production-linked set",
+            sorted(set(cm_cutest) - expected_cutest),
+        )
+
+    tracked = tracked_files(root)
+    generated = {CUTEST_REGISTRY}
+    for entry in sorted(referenced - generated):
+        if not (root / entry).exists():
+            problems.append(f"  manifest entry does not exist: {entry}")
+        elif tracked is not None and entry not in tracked:
+            problems.append(f"  manifest entry is not tracked by Git: {entry}")
+
+    if problems:
+        print("Build manifest parity check failed:")
+        print("\n".join(problems))
+        return 1
+    pair_names = ", ".join(f"{am}={cm}" for am, cm in MANIFEST_PAIRS)
+    print(
+        f"Build manifest parity OK ({pair_names}; "
+        f"production-linked cutest = {len(expected_cutest)} sources on both sides)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_clean_archive.sh
+++ b/scripts/ci/check_clean_archive.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Configure, build, test, and install an untouched `git archive HEAD` through
+# both the Autotools and CMake build systems. This is the repository's
+# distribution check: it proves no untracked local file or generated artifact
+# is required. Each half runs that system's full test entry point (`make test`
+# and `ctest`), so the archive has to satisfy the same gates as a checkout.
+#
+# Usage: scripts/ci/check_clean_archive.sh [--keep] [--skip-autotools] [--skip-cmake]
+#
+# Environment:
+#   CMAKE_PRESET   configure/build/test preset (default: dev)
+#   JOBS           parallel build jobs (default: nproc)
+#   LUMINARI_TEST_MYSQL_* / LUMINARI_TEST_DATA_DIR / LUMINARI_TEST_CONFIG_FILE
+#                  pass through to the production-linked suite; prepare them
+#                  with scripts/ci/prepare_test_runtime.sh (as the CI job does)
+#                  or export LUMINARI_TEST_SKIP_SYNTAX_BOOT=1 without world data.
+
+set -euo pipefail
+
+script_path=$(readlink -f -- "$0")
+repo_root=$(dirname "$(dirname "$(dirname "$script_path")")")
+keep=0
+run_autotools=1
+run_cmake=1
+preset=${CMAKE_PRESET:-dev}
+jobs=${JOBS:-$(nproc)}
+
+for argument in "$@"; do
+  case "$argument" in
+    --keep) keep=1 ;;
+    --skip-autotools) run_autotools=0 ;;
+    --skip-cmake) run_cmake=0 ;;
+    *)
+      printf 'Unknown argument: %s\n' "$argument" >&2
+      exit 2
+      ;;
+  esac
+done
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/luminari-archive.XXXXXX")
+cleanup() {
+  if [[ $keep -eq 0 ]]; then
+    rm -rf "$work_dir"
+  else
+    printf 'Archive tree kept at %s\n' "$work_dir"
+  fi
+}
+trap cleanup EXIT
+
+printf '==> Exporting git archive HEAD from %s\n' "$repo_root"
+git -C "$repo_root" archive --format=tar HEAD | tar -x -C "$work_dir"
+
+cd "$work_dir"
+cp src/campaign.example.h src/campaign.h
+cp src/mud_options.example.h src/mud_options.h
+cp src/vnums.example.h src/vnums.h
+export LUMINARI_TEST_ROOT="$work_dir"
+export LUMINARI_TEST_SPEC_WORLD_ROOT="$work_dir/unittests/CuTest/fixtures/spec_world_inventory"
+
+if [[ $run_autotools -eq 1 ]]; then
+  printf '==> Autotools: autoreconf, configure, build, make test, make install\n'
+  autoreconf -fvi >/dev/null
+  ./configure >/dev/null
+  make -j"$jobs" >/dev/null
+  make -j"$jobs" cutest bsd_snprintf_fallback_test >/dev/null
+  make test
+  make install >/dev/null
+  test -x bin/luminari
+  test ! -e luminari
+fi
+
+if [[ $run_cmake -eq 1 ]]; then
+  printf '==> CMake: preset %s configure, build, ctest, install\n' "$preset"
+  cmake --preset "$preset" >/dev/null
+  cmake --build --preset "$preset" -j"$jobs" >/dev/null
+  ctest --preset "$preset"
+  cmake --install "build/$preset" >/dev/null
+  test -x bin/luminari
+fi
+
+printf '==> Clean archive check passed\n'

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -11095,7 +11095,7 @@ ACMDU(do_borrow)
     // some uselkess bauble
     if (which <= 9)
     {
-      which = dice(1, NUM_KENDER_BAUBLES);
+      which = rand_number(0, NUM_KENDER_BAUBLES - 1);
       obj = read_object(KENDER_BAUBLE, VIRTUAL);
       if (!obj)
       {

--- a/src/constants.c
+++ b/src/constants.c
@@ -391,8 +391,8 @@ const char *fiendish_boon_descriptions[] = {
     "adds 1d6 negative damage per hit",
     "causes bleed damage each hit",
     "gives an extra attack per round (won't stack with itself or haste)",
-    "5 percent chance on a critical hit to kill the target outright (won't work on undead, "
-    "constructs or oozes)",
+    ("5 percent chance on a critical hit to kill the target outright (won't work on undead, "
+     "constructs or oozes)"),
     "\n"};
 CHECK_TABLE_SIZE(fiendish_boon_descriptions, NUM_FIENDISH_BOONS + 1);
 

--- a/src/craft/alchemy.c
+++ b/src/craft/alchemy.c
@@ -151,8 +151,8 @@ const char *grand_alchemical_discovery_names[NUM_GR_ALC_DISCOVERIES] = {
 const char *grand_alchemical_discovery_descriptions[NUM_GR_ALC_DISCOVERIES] = {
     "none", "Your base intelligence raises by 2 permanently", "Heal 5 hp per round permanently",
     "Is able to poison others with a touch (poisontouch command)",
-    "Mutagens now bestow +8 to natural ac, str, dex and con, while -2 to int, wis and cha. "
-    "Cognatogens, Inspiring Cognatogens and Elemental Mutagens are also improved."};
+    ("Mutagens now bestow +8 to natural ac, str, dex and con, while -2 to int, wis and cha. "
+     "Cognatogens, Inspiring Cognatogens and Elemental Mutagens are also improved.")};
 
 const char *bomb_types[NUM_BOMB_TYPES] = {
     "none",       "normal",     "acid",  "blinding", "boneshard", "concussive", "confusion",

--- a/src/magic/magic.c
+++ b/src/magic/magic.c
@@ -12388,13 +12388,13 @@ static const char *mag_summon_msgs[] = {
     "\tYAs \tn$n\tY makes a strange magical gesture, you feel a sudden shift in the earth.\tn", // 9
     "\tBAs \tn$n\tB makes a strange magical gesture, you feel the dust swirl.\tn", // 10
     "$n magically divides!",                                                       // 11 clone
-    "$n animates a corpse!",                                         // 12 animate dead
-    "$N breaks through the ground and bows before $n.",              // 13 mummy lord
-    "With a roar $N soars to the ground next to $n.",                // 14 young red dragon
-    "$N pops into existence next to $n.",                            // 15 shelgarn's dragger
-    "$N skimpers into the area, then quickly moves next to $n.",     // 16 dire badger
-    "$N charges into the area, looks left, then right... "           /* 17 */
-    "then quickly moves next to $n.",                                // 18 dire boar
+    "$n animates a corpse!",                                     // 12 animate dead
+    "$N breaks through the ground and bows before $n.",          // 13 mummy lord
+    "With a roar $N soars to the ground next to $n.",            // 14 young red dragon
+    "$N pops into existence next to $n.",                        // 15 shelgarn's dragger
+    "$N skimpers into the area, then quickly moves next to $n.", // 16 dire badger
+    ("$N charges into the area, looks left, then right... "
+     "then quickly moves next to $n."),                              // 17 dire boar
     "$N moves into the area, sniffing cautiously.",                  // 19 dire wolf
     "$N walks up to $n.",                                            // 20 phantom steed
     "$N skitters into the area and moves next to $n.",               // 21 dire spider
@@ -12435,11 +12435,11 @@ static const char *mag_summon_to_msgs[] = {
     "You magically divide!",                                                   // 11 clone
     "You animate a corpse!",                                                   // 12 animate dead
     "$N breaks through the ground and bows before you.",                       // 13 mummy lord
-    "With a roar $N soars to the ground next to you.",                // 14 young red dragon
-    "$N pops into existence next to you.",                            // 15 shelgarn's dragger
-    "$N skimpers into the area, then quickly moves next to you.",     // 16 dire badger
-    "$N charges into the area, looks left, then right... "            // 17
-    "then quickly moves next to you.",                                // 18 dire boar
+    "With a roar $N soars to the ground next to you.",            // 14 young red dragon
+    "$N pops into existence next to you.",                        // 15 shelgarn's dragger
+    "$N skimpers into the area, then quickly moves next to you.", // 16 dire badger
+    ("$N charges into the area, looks left, then right... "
+     "then quickly moves next to you."),                              // 17 dire boar
     "$N moves into the area, sniffing cautiously.",                   // 19 dire wolf
     "$N walks up to you.",                                            // 20 phantom steed
     "$N skitters into the area and moves next to you.",               // 21 dire spider
@@ -14749,7 +14749,7 @@ void mag_alter_objs(int level, struct char_data *ch, struct obj_data *obj, int s
 
 #define LOOP_LIMIT_MAGCREATE 1000
 /* this function will hand spells that create objects */
-void mag_creations(int level, struct char_data *ch, struct char_data *vict,
+void mag_creations(int level __attribute__((unused)), struct char_data *ch, struct char_data *vict,
                    struct obj_data *obj __attribute__((unused)), int spellnum,
                    int casttype __attribute__((unused)))
 {

--- a/src/obj/treasure.c
+++ b/src/obj/treasure.c
@@ -4585,7 +4585,7 @@ int award_random_money(struct char_data *ch, int result)
 }
 
 const char *kender_loot[NUM_KENDER_BAUBLES] = {
-    "" // 0
+    "", // 0
     "a blue fungus-covered book titled \"how to care for your cheese-mold\"",
     "a cat teeth necklace",
     "a chewed up old dragon saddle",

--- a/src/spec/spec_rol_conversion.c
+++ b/src/spec/spec_rol_conversion.c
@@ -4914,8 +4914,8 @@ static const char *const rol_lighthouse_messages[] = {
     "$n says, 'This one used to be just fine, till they dug it all out.'",
     "$n grumbles, 'God knows what they were doin' down there..'\r\n$n chuckles.",
     "$n says, 'Course the military never tells us common folk what's really goin' on.'",
-    "$n says, 'Aahhhh well, 'tis just the same anyway.\r\n"
-    "$n says, 'If they don't wanna tell us, it probably isn't important.",
+    ("$n says, 'Aahhhh well, 'tis just the same anyway.\r\n"
+     "$n says, 'If they don't wanna tell us, it probably isn't important."),
     "$n says, 'You hear about the pirate traffic?'",
     "$n says, 'I heard it's gettin' worse, just what we need.'",
     "$n snarls, 'More jackass brigands to deal with.'",

--- a/src/spec/spec_rol_drow.c
+++ b/src/spec/spec_rol_drow.c
@@ -67,11 +67,11 @@ int rol_drow_decay_modulus(bool inside_object, int hour, bool sunlight)
   if (inside_object)
     decay--;
 
-  /* Preserve the source predicates exactly. Each OR is true for every hour. */
-  if (hour > 4 || hour < 22)
-    decay++;
-  if (hour > 5 || hour < 21)
-    decay += decay;
+  /* The source predicates (hour > 4 || hour < 22, then hour > 5 || hour < 21)
+   * are true for every hour, so both adjustments always apply. */
+  (void)hour;
+  decay++;
+  decay += decay;
   if (!inside_object && sunlight)
     decay += decay;
 

--- a/src/sysdep.h
+++ b/src/sysdep.h
@@ -146,16 +146,10 @@ extern void abort(), exit();
 #include <fcntl.h>
 #endif
 
-#ifdef TIME_WITH_SYS_TIME
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#include <time.h>
-#else
-#if HAVE_SYS_TIME_H
-#include <sys/time.h>
-#else
-#include <time.h>
 #endif
-#endif
+#include <time.h>
 
 #ifdef HAVE_ASSERT_H
 #include <assert.h>

--- a/src/vessels/vessels_docking.c
+++ b/src/vessels/vessels_docking.c
@@ -239,6 +239,7 @@ void remove_ship_connection(room_rnum room1, room_rnum room2)
   }
 
   VSSL_DEBUG_DOCK("Removed %d connection(s)", removed_count);
+  (void)removed_count;
   VSSL_DEBUG_EXIT("remove_ship_connection");
   for (dir = 0; dir < NUM_OF_DIRS * 2; dir++)
     door_state_finish(&operations[dir]);
@@ -702,6 +703,7 @@ bool perform_combat_boarding(struct char_data *ch, struct greyhawk_ship_data *ta
   }
 
   VSSL_DEBUG_DOCK("Combat initiated with %d defender(s)", defenders_found);
+  (void)defenders_found;
   VSSL_DEBUG_EXIT("perform_combat_boarding");
   return TRUE;
 }
@@ -741,6 +743,7 @@ void setup_boarding_defenses(struct greyhawk_ship_data *ship)
   }
 
   VSSL_DEBUG_DOCK("Sealed %d hatches", hatches_sealed);
+  (void)hatches_sealed;
 
   /* Alert crew */
   send_to_ship(ship, "BATTLE STATIONS! Prepare to repel boarders!");


### PR DESCRIPTION
Closes #87.

## Validity check against the audit

Re-audited at `cc0cca834`. The untracked `HELPFILE_SYNCHRONIZATION_DESIGN.md` entry and the duplicate `clan_edit.c` entry were already gone, but a clean `git archive HEAD` CMake build still failed: the CuTest sources include `../../src/conf.h`, and CMake wrote `conf.h` into the build directory only. Everything else in the audit was still present (global `CMAKE_C_FLAGS` edits, global include directories, ad hoc `find_library` fallbacks, GCC-only warnings, undeclared `DEVELOPER_MODE`, stale I3 comments, no presets, no CMake CI, no parity check).

## Changes

- **Clean clone**: CMake now generates `conf.h` at the same gitignored `src/conf.h` location `configure.ac` uses, which also fixes the event-architecture and world-tool scripts that preprocess with `-Isrc`. The template mirrors the `configure.ac` macro set, including the `pid_t`/`size_t`/`ssize_t`/`socklen_t` fallbacks; unused probes (`HAVE_CONST`, signal return type, unsafe crypt, `CIRCLE_MYSQL`, `TIME_WITH_SYS_TIME`) and the duplicated per-target define list are removed. `sysdep.h` drops its dead `TIME_WITH_SYS_TIME` branch (defined by neither build) and includes `<time.h>` unconditionally.
- **Target scoping**: all warnings, definitions, include paths, sanitizer/coverage/hardening flags, and link options live on the `luminari_build` and `luminari_deps` interface targets. Warnings apply to GCC and Clang. `STATIC_ANALYSIS` sets `C_CLANG_TIDY` per executable target. No global `CMAKE_C_FLAGS`, `include_directories`, or `CMAKE_C_CLANG_TIDY` remain.
- **Dependencies**: imported targets (`PkgConfig::LIBEVENT/JSONC/GD/MARIADB`, `CURL::libcurl`, `OpenSSL::*`, `Threads::Threads`), all required to match `luminari_LDADD`. libcrypt has no pkg-config or CMake package and stays on `find_library`; the guide says so. Minimum versions documented.
- **Options**: `BUILD_UTILS`, `BUILD_TESTS`, `DEVELOPER_MODE`, `MEMORY_DEBUG`, `DMALLOC`, `STATIC_ANALYSIS`, `LUMINARI_WERROR`, `LUMINARI_COVERAGE`, `LUMINARI_HARDENING`, `LUMINARI_SANITIZERS` declared and documented.
- **Presets**: `CMakePresets.json` with `dev`, `dev-clang`, `ci-gcc`, `ci-clang`, `sanitizers`, `coverage`, `release-hardened`, `cross-aarch64` plus `cmake/toolchains/aarch64-linux-gnu.cmake`.
- **Parity**: `scripts/ci/check_build_parity.py` expands `$(var)` / `${VAR}` references, compares every hand-maintained list pair, flags duplicates and missing/untracked files, and proves that `cutest_SOURCES` and the CMake `cutest` target both compile exactly the harness, every test file, and every production source (432 sources on each side). Removing `$(luminari_SOURCES)` or `${SRC_FILES}` fails it. Wired into `make test`, CTest (`build-parity`), and a blocking CI job. It immediately caught the pet-construct data listed in CMake's `WORLD_TOOL_SOURCES` but only in `EXTRA_DIST` on the Autotools side.
- **CI**: blocking `CMake gcc` and `CMake clang` jobs (strict presets with `-Werror`) that configure, build, run CTest against the isolated MariaDB runtime, and install, plus a blocking `Clean archive, both build systems` job.
- **Distribution check**: `scripts/ci/check_clean_archive.sh` / `make distcheck-archive` exports `git archive HEAD` and, for each build system, configures, builds, runs the full test entry point (`make test` / `ctest`), and installs. `make distcheck` itself cannot work because the install hook writes into the source tree's `bin/`.
- **CTest membership**: `help-sync`, `background-help-entries`, and the two `sql-interpolation` checks are now CTest entries, matching Autotools `make test`.
- **Clang `-Wall` fixes** needed for the strict presets: parenthesized intentional string-literal continuations, a tautological hour check in `spec_rol_drow.c` (behavior preserved, tests unchanged), three counters only read by no-op debug macros, and a **missing comma in `kender_loot`** that left the final slot NULL. The `borrow` command now indexes `kender_loot` with `rand_number(0, NUM_KENDER_BAUBLES - 1)` instead of `dice(1, NUM_KENDER_BAUBLES)`, which could read one past the array and never picked slot 0.
- Docs updated: CMake build guide rewritten, setup/testing/developer guides, README, AGENTS.md.

## Verification

All run locally on the rebased branch (GCC 13, Clang 18, CMake 3.28). The isolated MariaDB runtime is not available on this machine, so the syntax-boot test skipped (`LUMINARI_TEST_SKIP_SYNTAX_BOOT=1`) and the persistence round trip skipped, as before; CI runs both against the service.

| Check | Result |
|---|---|
| `make -j8 && make cutest && make test && make install` | pass: 1388 CuTest tests, 0 compiler warnings, parity OK, `bin/luminari` installed, no root-level binary |
| `cmake --preset ci-gcc` build + `ctest` + install (`-Werror`) | pass: 0 warnings, 25/25 CTest entries |
| `cmake --preset ci-clang` build + `ctest` (`-Werror`) | pass: 0 warnings, 25/25 |
| `sanitizers`, `coverage`, `release-hardened` presets | configure OK |
| `-DSTATIC_ANALYSIS=ON` | configure OK; `clang-tidy` appears in the per-target build rules for `luminari` and `cutest` |
| `scripts/ci/check_clean_archive.sh` (untouched `git archive HEAD`) | pass: Autotools `make test` (1388 tests) + install, then CMake `dev` `ctest` 25/25 + install |
| `scripts/ci/check_build_parity.py` | OK, 432 production-linked sources on both sides; three deliberate manifest breakages each fail with the entry named |
| CMake `src/conf.h` vs Autotools `src/conf.h` | identical except Autotools-only `PACKAGE_*`, `VERSION`, `HAVE_EVENT2_EVENT_H` |
