### PR TITLE
Bind every account query and ratchet down formatted SQL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -845,6 +845,8 @@ EXTRA_DIST = \
 	scripts/copyover/copyover_watchdog.sh \
 	scripts/copyover/enhanced_copyover_diagnostic.sh \
 	scripts/ci/prepare_test_runtime.sh \
+	scripts/ci/check_sql_interpolation.py \
+	scripts/ci/sql_interpolation_baseline.txt \
 	scripts/debugging/debug_game.sh \
 	scripts/debugging/verify_core_capture.sh \
 	scripts/debugging/vgrind.sh \
@@ -1012,7 +1014,7 @@ EXTRA_DIST = \
 
 # Run unit tests
 test: check test-help-sync test-autorun-supervision test-versioned-binary-install \
-	test-binary-name-static test-healthcheck \
+	test-binary-name-static test-healthcheck test-sql-interpolation \
 	test-background-help-entries test-demand-driven-architecture test-event-admission \
 	test-event-core-performance-gate test-native-event-architecture test-pubsub-retirement \
 	test-vessel-tooling
@@ -1024,6 +1026,7 @@ test: check test-help-sync test-autorun-supervision test-versioned-binary-instal
 	test-help-sync-integration test-protocol test-protocol-fuzz test-character-rename-static \
 	test-character-rename-schema test-background-help-entries test-autorun-supervision \
 	test-versioned-binary-install test-binary-name-static test-healthcheck \
+	test-sql-interpolation \
 	test-demand-driven-architecture test-event-admission test-native-event-architecture \
 	test-event-core-performance-gate test-pubsub-retirement \
 	test-vessel-tooling
@@ -1090,6 +1093,10 @@ test-binary-name-static:
 
 test-healthcheck:
 	./scripts/operations/test_healthcheck.sh
+
+# Blocks new formatted SQL with data values (issue #98 ratchet).
+test-sql-interpolation:
+	cd "$(abs_top_srcdir)" && python3 scripts/ci/check_sql_interpolation.py
 
 test-process-memory:
 	./scripts/process-memory/test_process_memory_details.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -1096,6 +1096,7 @@ test-healthcheck:
 
 # Blocks new formatted SQL with data values (issue #98 ratchet).
 test-sql-interpolation:
+	cd "$(abs_top_srcdir)" && python3 scripts/ci/check_sql_interpolation.py --self-test
 	cd "$(abs_top_srcdir)" && python3 scripts/ci/check_sql_interpolation.py
 
 test-process-memory:

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -61,7 +61,13 @@ supported. Use the current full-world acceptance report for migration checks.
 
 Run these from a prepared `lib/` data directory or pass its absolute path with
 `-d`. Database-linked tests must use the repository's isolated test fixture;
-do not point a test run at a shared development or production database. A game-
+do not point a test run at a shared development or production database.
+Database tests are enabled with `LUMINARI_TEST_MYSQL_ENABLE=1` and the
+`LUMINARI_TEST_MYSQL_HOST/USER/PASSWORD/DATABASE/PORT` variables; they create
+only temporary tables in that session. `make test` also runs the SQL
+interpolation ratchet (`scripts/ci/check_sql_interpolation.py`), which blocks
+new formatted SQL with data values; bind values through `PREPARED_STMT`
+instead (see `docs/systems/DATABASE_INTEGRATION.md`). A game-
 loop release candidate also requires a logged-in live test and a real copyover
 that verifies descriptor survival, service reconstruction, callback progress,
 handoff cleanup, and port closure.

--- a/docs/guides/TESTING_GUIDE.md
+++ b/docs/guides/TESTING_GUIDE.md
@@ -63,8 +63,11 @@ Run these from a prepared `lib/` data directory or pass its absolute path with
 `-d`. Database-linked tests must use the repository's isolated test fixture;
 do not point a test run at a shared development or production database.
 Database tests are enabled with `LUMINARI_TEST_MYSQL_ENABLE=1` and the
-`LUMINARI_TEST_MYSQL_HOST/USER/PASSWORD/DATABASE/PORT` variables; they create
-only temporary tables in that session. `make test` also runs the SQL
+`LUMINARI_TEST_MYSQL_HOST/USER/PASSWORD/DATABASE/PORT` variables. The
+prepared-statement and account persistence tests create only temporary tables
+in their session; other database tests, such as the live-schema pet migration
+check described under "MariaDB Persistence Test", need the isolated schema
+fixture that CI loads from `sql/master_schema.sql`. `make test` also runs the SQL
 interpolation ratchet (`scripts/ci/check_sql_interpolation.py`), which blocks
 new formatted SQL with data values; bind values through `PREPARED_STMT`
 instead (see `docs/systems/DATABASE_INTEGRATION.md`). A game-

--- a/docs/ongoing-projects/CHANGELOG.md
+++ b/docs/ongoing-projects/CHANGELOG.md
@@ -11,15 +11,17 @@
   `PREPARED_STMT` API with bound values; no account name, password hash, email, or
   character name is interpolated into SQL text, and unlock table identifiers come
   from a compile-time table.
-- Prepared statements bind 64-bit integer results such as `COUNT(*)` natively, expose
-  `mysql_stmt_get_long()`, and report executions to the performance monitor like
+- Prepared statements bind 64-bit integer results such as `COUNT(*)` natively, honor
+  `BIGINT UNSIGNED` metadata, expose `mysql_stmt_get_long()` and
+  `mysql_stmt_get_ulong()`, and report executions to the performance monitor like
   direct queries.
 
 #### Tests
 
 - `make test` runs `scripts/ci/check_sql_interpolation.py`, which fails when a source
   file gains formatted SQL with `%` conversions beyond the recorded baseline; the
-  baseline is lowered as call sites migrate.
+  scanner keeps SQL literals intact while stripping C comments, `--update` refuses to
+  record growth, and `--self-test` exercises the scanner on fixtures.
 - Added a database regression that saves and loads an account whose name, password
   hash, email, and character name carry quotes, backslashes, multibyte text, and
   SQL fragments under both the default and `NO_BACKSLASH_ESCAPES` session modes.

--- a/docs/ongoing-projects/CHANGELOG.md
+++ b/docs/ongoing-projects/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased] - September 11, 2026
 
+### Bound account SQL and interpolation ratchet
+
+#### Changed
+
+- Every account query (account lookup, character list and duplicate cleanup, unlock
+  sets, character link and unlink, and the account upsert) now runs through the
+  `PREPARED_STMT` API with bound values; no account name, password hash, email, or
+  character name is interpolated into SQL text, and unlock table identifiers come
+  from a compile-time table.
+- Prepared statements bind 64-bit integer results such as `COUNT(*)` natively, expose
+  `mysql_stmt_get_long()`, and report executions to the performance monitor like
+  direct queries.
+
+#### Tests
+
+- `make test` runs `scripts/ci/check_sql_interpolation.py`, which fails when a source
+  file gains formatted SQL with `%` conversions beyond the recorded baseline; the
+  baseline is lowered as call sites migrate.
+- Added a database regression that saves and loads an account whose name, password
+  hash, email, and character name carry quotes, backslashes, multibyte text, and
+  SQL fragments under both the default and `NO_BACKSLASH_ESCAPES` session modes.
+
 ### Adaptive password hashing
 
 #### Fixed

--- a/docs/systems/DATABASE_INTEGRATION.md
+++ b/docs/systems/DATABASE_INTEGRATION.md
@@ -143,34 +143,34 @@ CREATE TABLE combat_logs (
 #### Loading Player Data
 ```c
 struct char_data *load_player_from_db(const char *name) {
-    MYSQL_RES *result;
-    MYSQL_ROW row;
+    PREPARED_STMT *statement;
     struct char_data *ch = NULL;
-    char query[MAX_STRING_LENGTH];
+    const char *value;
 
-    mysql_ping(conn);
-
-    snprintf(query, sizeof(query),
-        "SELECT id, name, level, experience, class, race "
-        "FROM player_data WHERE name = '%s'", name);
-
-    if (mysql_query(conn, query)) {
-        log("SYSERR: MySQL query error: %s", mysql_error(conn));
+    statement = mysql_stmt_create(conn);
+    if (statement == NULL ||
+        !mysql_stmt_prepare_query(statement,
+                                  "SELECT id, name, level, experience, class, race "
+                                  "FROM player_data WHERE name = ?") ||
+        !mysql_stmt_bind_param_string(statement, 0, name) ||
+        !mysql_stmt_execute_prepared(statement)) {
+        log("SYSERR: Unable to load player %s.", name);
+        mysql_stmt_cleanup(statement);
         return NULL;
     }
 
-    result = mysql_store_result(conn);
-    if ((row = mysql_fetch_row(result))) {
+    if (mysql_stmt_fetch_row(statement)) {
         ch = create_char();
-        GET_IDNUM(ch) = atoi(row[0]);
-        strcpy(GET_NAME(ch), row[1]);
-        GET_LEVEL(ch) = atoi(row[2]);
-        GET_EXP(ch) = atoll(row[3]);
-        GET_CLASS(ch) = atoi(row[4]);
-        GET_RACE(ch) = atoi(row[5]);
+        GET_IDNUM(ch) = mysql_stmt_get_long(statement, 0);
+        value = mysql_stmt_get_string(statement, 1);
+        strlcpy(GET_NAME(ch), value != NULL ? value : "", MAX_NAME_LENGTH + 1);
+        GET_LEVEL(ch) = mysql_stmt_get_int(statement, 2);
+        GET_EXP(ch) = mysql_stmt_get_long(statement, 3);
+        GET_CLASS(ch) = mysql_stmt_get_int(statement, 4);
+        GET_RACE(ch) = mysql_stmt_get_int(statement, 5);
     }
 
-    mysql_free_result(result);
+    mysql_stmt_cleanup(statement);
     return ch;
 }
 ```
@@ -178,23 +178,25 @@ struct char_data *load_player_from_db(const char *name) {
 #### Saving Player Data
 ```c
 void save_player_to_db(struct char_data *ch) {
-    char query[MAX_STRING_LENGTH];
-    char escaped_name[MAX_NAME_LENGTH * 2 + 1];
+    PREPARED_STMT *statement;
 
-    mysql_ping(conn);
-    mysql_real_escape_string(conn, escaped_name, GET_NAME(ch), strlen(GET_NAME(ch)));
-
-    snprintf(query, sizeof(query),
-        "INSERT INTO player_data (name, level, experience, class, race, last_logon) "
-        "VALUES ('%s', %d, %lld, %d, %d, NOW()) "
-        "ON DUPLICATE KEY UPDATE "
-        "level = %d, experience = %lld, class = %d, race = %d, last_logon = NOW()",
-        escaped_name, GET_LEVEL(ch), GET_EXP(ch), GET_CLASS(ch), GET_RACE(ch),
-        GET_LEVEL(ch), GET_EXP(ch), GET_CLASS(ch), GET_RACE(ch));
-
-    if (mysql_query(conn, query)) {
-        log("SYSERR: Failed to save player %s: %s", GET_NAME(ch), mysql_error(conn));
+    statement = mysql_stmt_create(conn);
+    if (statement == NULL ||
+        !mysql_stmt_prepare_query(statement,
+                                  "INSERT INTO player_data (name, level, experience, class, race, last_logon) "
+                                  "VALUES (?, ?, ?, ?, ?, NOW()) "
+                                  "ON DUPLICATE KEY UPDATE level = VALUES(level), "
+                                  "experience = VALUES(experience), class = VALUES(class), "
+                                  "race = VALUES(race), last_logon = NOW()") ||
+        !mysql_stmt_bind_param_string(statement, 0, GET_NAME(ch)) ||
+        !mysql_stmt_bind_param_int(statement, 1, GET_LEVEL(ch)) ||
+        !mysql_stmt_bind_param_long(statement, 2, GET_EXP(ch)) ||
+        !mysql_stmt_bind_param_int(statement, 3, GET_CLASS(ch)) ||
+        !mysql_stmt_bind_param_int(statement, 4, GET_RACE(ch)) ||
+        !mysql_stmt_execute_prepared(statement)) {
+        log("SYSERR: Failed to save player %s.", GET_NAME(ch));
     }
+    mysql_stmt_cleanup(statement);
 }
 ```
 
@@ -203,20 +205,28 @@ void save_player_to_db(struct char_data *ch) {
 #### Room State Management
 ```c
 void save_room_state(room_rnum room) {
-    char query[MAX_STRING_LENGTH];
+    PREPARED_STMT *statement;
     struct room_data *rm = &world[room];
 
-    snprintf(query, sizeof(query),
-        "INSERT INTO room_data (vnum, name, description, zone_id, room_flags, sector_type) "
-        "VALUES (%d, '%s', '%s', %d, %lld, %d) "
-        "ON DUPLICATE KEY UPDATE "
-        "name = '%s', description = '%s', room_flags = %lld, sector_type = %d",
-        rm->number, rm->name, rm->description, rm->zone, rm->room_flags, rm->sector_type,
-        rm->name, rm->description, rm->room_flags, rm->sector_type);
-
-    if (mysql_query(conn, query)) {
-        log("SYSERR: Failed to save room %d: %s", rm->number, mysql_error(conn));
+    /* Room names and descriptions are builder text; they are bound, never formatted. */
+    statement = mysql_stmt_create(conn);
+    if (statement == NULL ||
+        !mysql_stmt_prepare_query(statement,
+                                  "INSERT INTO room_data (vnum, name, description, zone_id, room_flags, sector_type) "
+                                  "VALUES (?, ?, ?, ?, ?, ?) "
+                                  "ON DUPLICATE KEY UPDATE name = VALUES(name), "
+                                  "description = VALUES(description), room_flags = VALUES(room_flags), "
+                                  "sector_type = VALUES(sector_type)") ||
+        !mysql_stmt_bind_param_int(statement, 0, rm->number) ||
+        !mysql_stmt_bind_param_string(statement, 1, rm->name) ||
+        !mysql_stmt_bind_param_string(statement, 2, rm->description) ||
+        !mysql_stmt_bind_param_int(statement, 3, rm->zone) ||
+        !mysql_stmt_bind_param_long(statement, 4, rm->room_flags) ||
+        !mysql_stmt_bind_param_int(statement, 5, rm->sector_type) ||
+        !mysql_stmt_execute_prepared(statement)) {
+        log("SYSERR: Failed to save room %d.", rm->number);
     }
+    mysql_stmt_cleanup(statement);
 }
 ```
 
@@ -259,7 +269,8 @@ Binding notes:
 - `mysql_stmt_bind_param_int()` and `mysql_stmt_bind_param_long()` bind numbers;
   never format a number into the SQL text.
 - `mysql_stmt_get_long()` reads `BIGINT` columns and `COUNT(*)` aggregates;
-  `mysql_stmt_get_int()` reads smaller integer columns.
+  `mysql_stmt_get_ulong()` reads `BIGINT UNSIGNED` columns whose values can
+  exceed the signed range; `mysql_stmt_get_int()` reads smaller integer columns.
 - `mysql_stmt_affected_rows_count()` and `mysql_stmt_insert_id(statement->stmt)`
   replace `mysql_affected_rows()` and `mysql_insert_id()`.
 - Variable-length lists (`IN (...)`, multi-row `VALUES`) append placeholders
@@ -346,31 +357,44 @@ void release_db_connection(MYSQL *conn) {
 ```
 
 ### Batch Operations
+
+Multi-row statements append placeholders only; the row values are bound after
+the statement is prepared, exactly as `save_account_integer_set()` does for
+unlock sets in `src/account.c`.
+
 ```c
 void batch_save_players() {
     char query[MAX_STRING_LENGTH * 10];
-    strcpy(query, "INSERT INTO player_data (name, level, experience) VALUES ");
-
+    PREPARED_STMT *statement;
     struct char_data *ch;
-    bool first = TRUE;
+    bool bound;
+    int used;
+    int count = 0;
+    int slot = 0;
 
+    used = snprintf(query, sizeof(query),
+                    "INSERT INTO player_data (name, level, experience) VALUES ");
     for (ch = character_list; ch; ch = ch->next) {
         if (IS_NPC(ch) || !ch->desc) continue;
-
-        if (!first) strcat(query, ", ");
-
-        char values[256];
-        snprintf(values, sizeof(values), "('%s', %d, %lld)",
-                GET_NAME(ch), GET_LEVEL(ch), GET_EXP(ch));
-        strcat(query, values);
-        first = FALSE;
+        used = snprintf_append(query, sizeof(query), used, "%s(?, ?, ?)", count > 0 ? ", " : "");
+        count++;
     }
+    if (count == 0) return;
+    snprintf_append(query, sizeof(query), used,
+                    " ON DUPLICATE KEY UPDATE level = VALUES(level), experience = VALUES(experience)");
 
-    strcat(query, " ON DUPLICATE KEY UPDATE level = VALUES(level), experience = VALUES(experience)");
-
-    if (mysql_query(conn, query)) {
-        log("SYSERR: Batch save failed: %s", mysql_error(conn));
+    statement = mysql_stmt_create(conn);
+    bound = statement != NULL && mysql_stmt_prepare_query(statement, query);
+    for (ch = character_list; bound && ch; ch = ch->next) {
+        if (IS_NPC(ch) || !ch->desc) continue;
+        bound = mysql_stmt_bind_param_string(statement, slot++, GET_NAME(ch)) &&
+                mysql_stmt_bind_param_int(statement, slot++, GET_LEVEL(ch)) &&
+                mysql_stmt_bind_param_long(statement, slot++, GET_EXP(ch));
     }
+    if (!bound || !mysql_stmt_execute_prepared(statement)) {
+        log("SYSERR: Batch save failed.");
+    }
+    mysql_stmt_cleanup(statement);
 }
 ```
 
@@ -506,8 +530,9 @@ void log_database_stats() {
 - `make test` runs `scripts/ci/check_sql_interpolation.py`, which fails when a
   source file gains a formatted SQL statement with `%` conversions beyond the
   recorded baseline in `scripts/ci/sql_interpolation_baseline.txt`. After
-  migrating sites to bound statements, run the script with `--update` so the
-  baseline only shrinks. Use `--list` to see the remaining inventory for #98.
+  migrating sites to bound statements, run the script with `--update`; it
+  refuses to record growth, so the baseline only shrinks. Use `--list` to see
+  the remaining inventory for #98.
 
 ### Connection Security
 - Use secure passwords for database users

--- a/docs/systems/DATABASE_INTEGRATION.md
+++ b/docs/systems/DATABASE_INTEGRATION.md
@@ -223,37 +223,50 @@ void save_room_state(room_rnum room) {
 ### Query Optimization
 
 #### Prepared Statements
+
+`src/mysql.h` provides the `PREPARED_STMT` wrapper. It is the default way to
+run any SQL that carries a data value: the statement text stays constant and
+every value is bound, so quoting, character sets, backslashes, and the session
+`sql_mode` cannot change the statement's meaning. `src/account.c` is the
+reference migration for this pattern.
+
 ```c
-MYSQL_STMT *stmt_save_player;
+PREPARED_STMT *statement;
+const char *value;
 
-void init_prepared_statements() {
-    stmt_save_player = mysql_stmt_init(conn);
-    const char *query = "INSERT INTO player_data (name, level, experience) VALUES (?, ?, ?)";
-
-    if (mysql_stmt_prepare(stmt_save_player, query, strlen(query))) {
-        log("SYSERR: Failed to prepare statement: %s", mysql_stmt_error(stmt_save_player));
-    }
+statement = mysql_stmt_create(conn);
+if (statement == NULL ||
+    !mysql_stmt_prepare_query(statement,
+                              "SELECT id, email FROM account_data WHERE lower(name) = lower(?)") ||
+    !mysql_stmt_bind_param_string(statement, 0, name) ||
+    !mysql_stmt_execute_prepared(statement))
+{
+  log("SYSERR: Unable to load account row.");
+  mysql_stmt_cleanup(statement); /* NULL-safe; every error path releases it */
+  return -1;
 }
-
-void save_player_prepared(struct char_data *ch) {
-    MYSQL_BIND bind[3];
-    memset(bind, 0, sizeof(bind));
-
-    // Bind parameters
-    bind[0].buffer_type = MYSQL_TYPE_STRING;
-    bind[0].buffer = GET_NAME(ch);
-    bind[0].buffer_length = strlen(GET_NAME(ch));
-
-    bind[1].buffer_type = MYSQL_TYPE_LONG;
-    bind[1].buffer = &GET_LEVEL(ch);
-
-    bind[2].buffer_type = MYSQL_TYPE_LONGLONG;
-    bind[2].buffer = &GET_EXP(ch);
-
-    mysql_stmt_bind_param(stmt_save_player, bind);
-    mysql_stmt_execute(stmt_save_player);
+while (mysql_stmt_fetch_row(statement))
+{
+  account_id = mysql_stmt_get_int(statement, 0);
+  value = mysql_stmt_get_string(statement, 1); /* NULL for SQL NULL */
 }
+mysql_stmt_cleanup(statement);
 ```
+
+Binding notes:
+
+- `mysql_stmt_bind_param_string()` with a NULL pointer binds SQL `NULL`.
+- `mysql_stmt_bind_param_int()` and `mysql_stmt_bind_param_long()` bind numbers;
+  never format a number into the SQL text.
+- `mysql_stmt_get_long()` reads `BIGINT` columns and `COUNT(*)` aggregates;
+  `mysql_stmt_get_int()` reads smaller integer columns.
+- `mysql_stmt_affected_rows_count()` and `mysql_stmt_insert_id(statement->stmt)`
+  replace `mysql_affected_rows()` and `mysql_insert_id()`.
+- Variable-length lists (`IN (...)`, multi-row `VALUES`) append placeholders
+  only, then bind each value. Table and column names come from a compile-time
+  table indexed by an enum, never from data.
+- Executions are attributed to the performance monitor exactly like direct
+  queries, so `perfmon` SQL families keep working after a migration.
 
 ## Database Schema Management
 
@@ -483,10 +496,18 @@ void log_database_stats() {
 ## Security Considerations
 
 ### SQL Injection Prevention
-- Always use `mysql_real_escape_string()` for user input
-- Use prepared statements for complex queries
-- Validate input data before database operations
-- Implement proper access controls
+- Bind every data value (user, world, file, service, or database derived) with
+  the `PREPARED_STMT` API. Escaping with `mysql_real_escape_string()` is a
+  legacy compatibility technique, not the default abstraction.
+- Select dynamic table, column, and ordering identifiers from compile-time
+  allowlists; keep the values they operate on bound separately.
+- Validate input data before database operations and implement proper access
+  controls.
+- `make test` runs `scripts/ci/check_sql_interpolation.py`, which fails when a
+  source file gains a formatted SQL statement with `%` conversions beyond the
+  recorded baseline in `scripts/ci/sql_interpolation_baseline.txt`. After
+  migrating sites to bound statements, run the script with `--update` so the
+  baseline only shrinks. Use `--list` to see the remaining inventory for #98.
 
 ### Connection Security
 - Use secure passwords for database users

--- a/scripts/ci/check_sql_interpolation.py
+++ b/scripts/ci/check_sql_interpolation.py
@@ -17,9 +17,10 @@ like a clause is acceptable noise because only growth fails the check. Placehold
 when it mentions a keyword; keep placeholder building free of SQL keywords.
 
 Usage:
-  check_sql_interpolation.py            # compare against the baseline
-  check_sql_interpolation.py --list     # print every counted site
-  check_sql_interpolation.py --update   # rewrite the baseline from the tree
+  check_sql_interpolation.py              # compare against the baseline
+  check_sql_interpolation.py --list       # print every counted site
+  check_sql_interpolation.py --update     # lower the baseline; refuses growth
+  check_sql_interpolation.py --self-test  # exercise the scanner on fixtures
 """
 
 import os
@@ -44,8 +45,38 @@ STRING_LITERAL_PATTERN = re.compile(r'"((?:[^"\\]|\\.)*)"')
 
 
 def strip_comments(text):
-    text = re.sub(r"/\*.*?\*/", lambda match: " " * len(match.group(0)), text, flags=re.S)
-    return re.sub(r"//[^\n]*", "", text)
+    """Blank out C comments while leaving string and character literals intact.
+
+    Comment-like sequences inside literals ("-- //", "/* hint */") are SQL
+    text, not C comments, so a literal-aware scan is required to keep those
+    sites visible to the ratchet.
+    """
+    out = []
+    index = 0
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == '"' or char == "'":
+            quote = char
+            end = index + 1
+            while end < length and text[end] != quote:
+                end += 2 if text[end] == "\\" else 1
+            end = min(end + 1, length)
+            out.append(text[index:end])
+            index = end
+        elif text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            end = length if end < 0 else end + 2
+            out.append(re.sub(r"[^\n]", " ", text[index:end]))
+            index = end
+        elif text.startswith("//", index):
+            end = text.find("\n", index)
+            end = length if end < 0 else end
+            index = end
+        else:
+            out.append(char)
+            index += 1
+    return "".join(out)
 
 
 def iter_calls(text):
@@ -112,7 +143,57 @@ def write_baseline(sites):
             handle.write("%s %d\n" % (path, len(sites[path])))
 
 
+def count_sites_in_text(text):
+    """Count formatted SQL sites in one C source text (shared by the self-test)."""
+    stripped = strip_comments(text)
+    count = 0
+    for _offset, call_text in iter_calls(stripped):
+        fmt = call_format_string(call_text)
+        if KEYWORD_PATTERN.search(fmt) and CONVERSION_PATTERN.search(fmt):
+            count += 1
+    return count
+
+
+SELF_TEST_CASES = [
+    # (description, source, expected count)
+    ("plain formatted select",
+     'snprintf(q, sizeof(q), "SELECT a FROM t WHERE b = %d", b);', 1),
+    ("placeholders only are not data",
+     'snprintf(q, sizeof(q), "SELECT a FROM t WHERE b = ?");', 0),
+    ("block comment does not hide a site",
+     '/* SELECT %s */ snprintf(q, sizeof(q), "DELETE FROM t WHERE k = \'%s\'", k);', 1),
+    ("line comment site is not counted",
+     '// snprintf(q, sizeof(q), "SELECT a FROM t WHERE b = %d", b);\nint x;', 0),
+    ("line comment sequence inside a literal is kept",
+     'snprintf(q, sizeof(q), "SELECT a FROM t WHERE b = %d -- // note", b);', 1),
+    ("block comment sequence inside a literal is kept",
+     'snprintf(q, sizeof(q), "/* hint */ SELECT a FROM t WHERE b = %d", b);', 1),
+    ("comment opener inside a character literal",
+     "char c = '/'; char d = '*'; snprintf(q, sizeof(q), \"UPDATE t SET a = %d\", a);", 1),
+    ("escaped quote inside a literal",
+     'snprintf(q, sizeof(q), "INSERT INTO t (a) VALUES (\'%s\') /* \\" */", a);', 1),
+    ("non-sql format text",
+     'snprintf(buf, sizeof(buf), "You set %s down from where it came.", name);', 0),
+]
+
+
+def self_test():
+    failures = 0
+    for description, source, expected in SELF_TEST_CASES:
+        actual = count_sites_in_text(source)
+        if actual != expected:
+            failures += 1
+            print("self-test FAILED: %s (expected %d, got %d)" % (description, expected, actual),
+                  file=sys.stderr)
+    if failures:
+        return 1
+    print("sql interpolation self-test: %d cases passed" % len(SELF_TEST_CASES))
+    return 0
+
+
 def main(argv):
+    if "--self-test" in argv:
+        return self_test()
     sites = collect_sites()
     if "--list" in argv:
         for path in sorted(sites):
@@ -121,6 +202,15 @@ def main(argv):
         print("total: %d" % sum(len(lines) for lines in sites.values()))
         return 0
     if "--update" in argv:
+        baseline = read_baseline()
+        grown = [(path, baseline.get(path, 0), len(lines)) for path, lines in sorted(sites.items())
+                 if len(lines) > baseline.get(path, 0)]
+        if baseline and grown:
+            print("Refusing to record baseline growth; migrate or justify these sites first:",
+                  file=sys.stderr)
+            for path, allowed, now in grown:
+                print("  %s: %d site(s), baseline allows %d" % (path, now, allowed), file=sys.stderr)
+            return 1
         write_baseline(sites)
         print("baseline written: %d files, %d sites" % (len(sites), sum(map(len, sites.values()))))
         return 0

--- a/scripts/ci/check_sql_interpolation.py
+++ b/scripts/ci/check_sql_interpolation.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Block new formatted SQL that interpolates data values.
+
+Issue #98 migrates dynamic SQL to bound prepared statements. Until every call
+site is migrated, this check ratchets: each source file may contain at most the
+number of formatted-SQL sites recorded in the baseline. Adding a site fails the
+check; removing sites is allowed and should be followed by ``--update`` so the
+baseline only ever shrinks.
+
+A "formatted SQL site" is a printf-style call (snprintf, sprintf, asprintf,
+snprintf_append, strcat, strncat, strlcat) whose format string contains an SQL
+statement or clause opener (SELECT, INSERT INTO, UPDATE ... SET, DELETE FROM,
+REPLACE INTO, WHERE/AND/OR comparisons, ORDER BY, GROUP BY, LIMIT) and at least
+one ``%`` conversion. The match is lexical; a rare non-SQL format that reads
+like a clause is acceptable noise because only growth fails the check. Placeholder-only construction
+(``"%s(?,?)"``) is not a data interpolation, but it is counted conservatively
+when it mentions a keyword; keep placeholder building free of SQL keywords.
+
+Usage:
+  check_sql_interpolation.py            # compare against the baseline
+  check_sql_interpolation.py --list     # print every counted site
+  check_sql_interpolation.py --update   # rewrite the baseline from the tree
+"""
+
+import os
+import re
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SOURCE_ROOT = os.path.join(REPO_ROOT, "src")
+BASELINE_PATH = os.path.join(REPO_ROOT, "scripts", "ci", "sql_interpolation_baseline.txt")
+
+CALL_PATTERN = re.compile(
+    r"\b(snprintf|sprintf|asprintf|snprintf_append|strcat|strncat|strlcat)\s*\("
+)
+KEYWORD_PATTERN = re.compile(
+    r"\b(SELECT\s|INSERT\s+(?:IGNORE\s+)?INTO\s|DELETE\s+FROM\s|REPLACE\s+INTO\s"
+    r"|UPDATE\s+\w+\s+SET\s|(?:WHERE|AND|OR)\s+[\w.]+\s*(?:=|<|>|IN\b|LIKE\b)"
+    r"|ORDER\s+BY\s|GROUP\s+BY\s|LIMIT\s+%)",
+    re.IGNORECASE,
+)
+CONVERSION_PATTERN = re.compile(r"%[-+ #0]*\d*(?:\.\d+)?(?:hh|h|ll|l|z|j|t|L)?[diouxXeEfFgGscp]")
+STRING_LITERAL_PATTERN = re.compile(r'"((?:[^"\\]|\\.)*)"')
+
+
+def strip_comments(text):
+    text = re.sub(r"/\*.*?\*/", lambda match: " " * len(match.group(0)), text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def iter_calls(text):
+    """Yield (offset, call_text) for each printf-style call in the file."""
+    for match in CALL_PATTERN.finditer(text):
+        depth = 1
+        index = match.end()
+        while index < len(text) and depth:
+            char = text[index]
+            if char == '"':
+                literal = STRING_LITERAL_PATTERN.match(text, index)
+                index = literal.end() if literal else index + 1
+                continue
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            index += 1
+        yield match.start(), text[match.start():index]
+
+
+def call_format_string(call_text):
+    return "".join(STRING_LITERAL_PATTERN.findall(call_text))
+
+
+def collect_sites():
+    sites = {}
+    for directory, _, files in os.walk(SOURCE_ROOT):
+        for name in sorted(files):
+            if not name.endswith(".c"):
+                continue
+            path = os.path.join(directory, name)
+            relative = os.path.relpath(path, REPO_ROOT)
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                text = strip_comments(handle.read())
+            for offset, call_text in iter_calls(text):
+                fmt = call_format_string(call_text)
+                if KEYWORD_PATTERN.search(fmt) and CONVERSION_PATTERN.search(fmt):
+                    line = text.count("\n", 0, offset) + 1
+                    sites.setdefault(relative, []).append(line)
+    return sites
+
+
+def read_baseline():
+    baseline = {}
+    if not os.path.exists(BASELINE_PATH):
+        return baseline
+    with open(BASELINE_PATH, encoding="utf-8") as handle:
+        for raw in handle:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            path, count = line.rsplit(" ", 1)
+            baseline[path] = int(count)
+    return baseline
+
+
+def write_baseline(sites):
+    with open(BASELINE_PATH, "w", encoding="utf-8") as handle:
+        handle.write("# Formatted SQL sites per file (issue #98 ratchet).\n")
+        handle.write("# Regenerate only after removing sites:\n")
+        handle.write("#   python3 scripts/ci/check_sql_interpolation.py --update\n")
+        for path in sorted(sites):
+            handle.write("%s %d\n" % (path, len(sites[path])))
+
+
+def main(argv):
+    sites = collect_sites()
+    if "--list" in argv:
+        for path in sorted(sites):
+            for line in sites[path]:
+                print("%s:%d" % (path, line))
+        print("total: %d" % sum(len(lines) for lines in sites.values()))
+        return 0
+    if "--update" in argv:
+        write_baseline(sites)
+        print("baseline written: %d files, %d sites" % (len(sites), sum(map(len, sites.values()))))
+        return 0
+
+    baseline = read_baseline()
+    failures = []
+    for path, lines in sorted(sites.items()):
+        allowed = baseline.get(path, 0)
+        if len(lines) > allowed:
+            failures.append((path, allowed, lines))
+    if failures:
+        print("New formatted SQL with data values detected. Bind values with prepared", file=sys.stderr)
+        print("statements (see docs/systems/DATABASE_INTEGRATION.md) instead.", file=sys.stderr)
+        for path, allowed, lines in failures:
+            print("  %s: %d site(s), baseline allows %d; lines %s"
+                  % (path, len(lines), allowed, ",".join(map(str, lines))), file=sys.stderr)
+        return 1
+
+    shrunk = [(path, count, len(sites.get(path, []))) for path, count in sorted(baseline.items())
+              if len(sites.get(path, [])) < count]
+    total = sum(len(lines) for lines in sites.values())
+    print("sql interpolation check: %d formatted SQL sites, within baseline" % total)
+    for path, count, now in shrunk:
+        print("  %s dropped from %d to %d; run --update to lower the baseline" % (path, count, now))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci/sql_interpolation_baseline.txt
+++ b/scripts/ci/sql_interpolation_baseline.txt
@@ -1,0 +1,44 @@
+# Formatted SQL sites per file (issue #98 ratchet).
+# Regenerate only after removing sites:
+#   python3 scripts/ci/check_sql_interpolation.py --update
+src/act.wizard.c 15
+src/character/templates.c 22
+src/comms/mysql_boards.c 13
+src/comms/new_mail.c 16
+src/craft/craft.c 3
+src/db.c 6
+src/db_init.c 2
+src/db_init_data.c 3
+src/db_startup_init.c 3
+src/help.c 3
+src/interpreter.c 1
+src/magic/spell_lists.c 1
+src/modify.c 2
+src/mysql.c 9
+src/obj/act.item.c 3
+src/obj/house.c 1
+src/obj/objsave.c 13
+src/olc/bedit.c 1
+src/olc/hedit.c 15
+src/player_rename.c 10
+src/players.c 19
+src/quest/quest.c 15
+src/vessels/vehicles.c 3
+src/vessels/vessels_autopilot.c 17
+src/vessels/vessels_contracts.c 11
+src/vessels/vessels_crew.c 3
+src/vessels/vessels_db.c 25
+src/vessels/vessels_edit.c 7
+src/vessels/vessels_events.c 10
+src/vessels/vessels_hunters.c 9
+src/vessels/vessels_merchants.c 13
+src/vessels/vessels_ownership.c 13
+src/vessels/vessels_piracy.c 5
+src/vessels/vessels_rooms.c 1
+src/vessels/vessels_trade.c 7
+src/vessels/vessels_upgrades.c 6
+src/wilderness/narrative_weaver.c 5
+src/wilderness/region_hints.c 3
+src/wilderness/resource_cascade.c 6
+src/wilderness/resource_depletion.c 10
+src/wilderness/resource_regeneration.c 2

--- a/src/account.c
+++ b/src/account.c
@@ -44,7 +44,7 @@
     - strdup allocations are freed when reloading account data or character lists.
     - Account experience is clamped between 0 and 100,000,000 by change_account_xp.
     - Alignment is clamped to [-1000, 1000] after purchases in do_accexp.
-    - SQL injection protection via mysql_real_escape_string for user input in queries.
+    - SQL injection protection: every data value is bound through prepared statements.
 
   This file adds explanatory comments without changing behavior.
 */
@@ -535,6 +535,30 @@ ACMD(do_accexp)
 }
 
 /*
+  account_prepare_statement(const char *query)
+  Purpose: Create and prepare a bound statement on the primary connection.
+  Return:
+    - Prepared statement ready for parameter binding, or NULL after logging.
+  Notes:
+    - Every account query binds its data values; SQL text here is constant.
+    - The caller owns the result and must call mysql_stmt_cleanup().
+*/
+static PREPARED_STMT *account_prepare_statement(const char *query)
+{
+  PREPARED_STMT *statement;
+
+  statement = mysql_stmt_create(conn);
+  if (statement == NULL)
+    return NULL;
+  if (!mysql_stmt_prepare_query(statement, query))
+  {
+    mysql_stmt_cleanup(statement);
+    return NULL;
+  }
+  return statement;
+}
+
+/*
   load_account(char *name, struct account_data *account)
   Purpose: Load an account record (and then its characters/unlocks) from the DB by account name.
   Parameters:
@@ -553,9 +577,8 @@ ACMD(do_accexp)
 */
 int load_account(char *name, struct account_data *account)
 {
-  MYSQL_RES *result;
-  MYSQL_ROW row;
-  char buf[2048];
+  PREPARED_STMT *statement;
+  const char *value;
 
   /* Check if MySQL is available */
   if (!mysql_available || !conn)
@@ -593,42 +616,35 @@ int load_account(char *name, struct account_data *account)
     return -1;
   }
 
-  /* Escape the account name to prevent SQL injection */
-  char escaped_name[MAX_INPUT_LENGTH * 2 + 1];
-  mysql_real_escape_string(conn, escaped_name, name, strlen(name));
-
-  /* Case-insensitive match on the escaped account name */
-  snprintf(buf, sizeof(buf),
-           "SELECT id, name, password, experience, email, quit_survey_completed "
-           "from account_data where lower(name) = lower('%s')",
-           escaped_name);
-
-  if (mysql_query(conn, buf))
+  /* Case-insensitive match on the bound account name */
+  statement = account_prepare_statement(
+      "SELECT id, name, password, experience, email, quit_survey_completed "
+      "FROM account_data WHERE lower(name) = lower(?)");
+  if (statement == NULL || !mysql_stmt_bind_param_string(statement, 0, name) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to SELECT from account_data: %s", mysql_error(conn));
+    log("SYSERR: Unable to SELECT from account_data for account lookup.");
+    mysql_stmt_cleanup(statement);
     return -1;
   }
 
-  if (!(result = mysql_store_result(conn)))
+  if (!mysql_stmt_fetch_row(statement))
   {
-    log("SYSERR: Unable to SELECT from account_data: %s", mysql_error(conn));
-    return -1;
-  }
-
-  if (!(row = mysql_fetch_row(result)))
-  {
-    mysql_free_result(result);
+    mysql_stmt_cleanup(statement);
     return -1; /* Account not found. */
   }
 
-  account->id = atoi(row[0]);
-  account->name = strdup(row[1]);
-  strlcpy(account->password, row[2], sizeof(account->password));
-  account->experience = atoi(row[3]);
-  account->email = (row[4] ? strdup(row[4]) : NULL);
-  account->quit_survey_completed = (row[5] ? atoi(row[5]) : 0);
+  account->id = mysql_stmt_get_int(statement, 0);
+  value = mysql_stmt_get_string(statement, 1);
+  account->name = strdup(value != NULL ? value : name);
+  value = mysql_stmt_get_string(statement, 2);
+  strlcpy(account->password, value != NULL ? value : "", sizeof(account->password));
+  account->experience = mysql_stmt_get_int(statement, 3);
+  value = mysql_stmt_get_string(statement, 4);
+  account->email = value != NULL ? strdup(value) : NULL;
+  account->quit_survey_completed = mysql_stmt_get_int(statement, 5);
 
-  mysql_free_result(result);
+  mysql_stmt_cleanup(statement);
   load_account_characters(account);
   load_account_unlocks(account);
   account_persistence_mark_clean(account);
@@ -649,67 +665,51 @@ int load_account(char *name, struct account_data *account)
 */
 void cleanup_duplicate_characters(struct account_data *account)
 {
-  MYSQL_RES *result;
-  MYSQL_ROW row;
-  char buf[2048];
+  PREPARED_STMT *duplicates;
+  PREPARED_STMT *removal;
+  const char *name;
+  int count;
 
   if (!account || account->id <= 0)
     return;
 
   /* Get list of duplicate character names for this account */
-  snprintf(buf, sizeof(buf),
-           "SELECT name, COUNT(*) as cnt "
-           "FROM player_data "
-           "WHERE account_id = %d "
-           "GROUP BY name "
-           "HAVING cnt > 1",
-           account->id);
-
-  if (mysql_query(conn, buf))
+  duplicates = account_prepare_statement("SELECT name, COUNT(*) AS cnt FROM player_data "
+                                         "WHERE account_id = ? GROUP BY name HAVING cnt > 1");
+  if (duplicates == NULL || !mysql_stmt_bind_param_int(duplicates, 0, account->id) ||
+      !mysql_stmt_execute_prepared(duplicates))
   {
-    log("SYSERR: Unable to check for duplicate characters: %s", mysql_error(conn));
+    log("SYSERR: Unable to check for duplicate characters for account %d.", account->id);
+    mysql_stmt_cleanup(duplicates);
     return;
   }
 
-  if (!(result = mysql_store_result(conn)))
+  /* The duplicate list is buffered client-side, so removals may run inside the loop. */
+  while (mysql_stmt_fetch_row(duplicates))
   {
-    log("SYSERR: Unable to store duplicate check results: %s", mysql_error(conn));
-    return;
-  }
+    name = mysql_stmt_get_string(duplicates, 0);
+    count = (int)mysql_stmt_get_long(duplicates, 1);
+    if (name == NULL || count <= 1)
+      continue;
 
-  /* Process each duplicate character */
-  while ((row = mysql_fetch_row(result)))
-  {
-    char *name = row[0];
-    int count = atoi(row[1]);
-
-    /* Escape character name */
-    char escaped_name[MAX_INPUT_LENGTH * 2 + 1];
-    mysql_real_escape_string(conn, escaped_name, name, strlen(name));
-
-    /* Delete all but one - we delete count-1 duplicates
-     * ORDER BY ensures we keep a consistent row (the "first" one)
-     * This approach works regardless of table structure */
-    snprintf(buf, sizeof(buf),
-             "DELETE FROM player_data "
-             "WHERE account_id = %d "
-             "AND lower(name) = lower('%s') "
-             "ORDER BY name "
-             "LIMIT %d",
-             account->id, escaped_name, count - 1);
-
-    if (mysql_query(conn, buf))
+    /* Delete all but one; ORDER BY keeps a consistent survivor row. */
+    removal = account_prepare_statement("DELETE FROM player_data WHERE account_id = ? "
+                                        "AND lower(name) = lower(?) ORDER BY name LIMIT ?");
+    if (removal == NULL || !mysql_stmt_bind_param_int(removal, 0, account->id) ||
+        !mysql_stmt_bind_param_string(removal, 1, name) ||
+        !mysql_stmt_bind_param_int(removal, 2, count - 1) || !mysql_stmt_execute_prepared(removal))
     {
-      log("SYSERR: Unable to delete duplicate character %s: %s", name, mysql_error(conn));
+      log("SYSERR: Unable to delete duplicate character %s.", name);
     }
     else
     {
       log("Info: Cleaned up %ld duplicate(s) of character %s for account %s",
-          (long)mysql_affected_rows(conn), name, account->name);
+          (long)mysql_stmt_affected_rows_count(removal), name, account->name);
     }
+    mysql_stmt_cleanup(removal);
   }
 
-  mysql_free_result(result);
+  mysql_stmt_cleanup(duplicates);
 }
 
 /*
@@ -725,9 +725,10 @@ void cleanup_duplicate_characters(struct account_data *account)
 */
 void load_account_characters(struct account_data *account)
 {
-  MYSQL_RES *result;
-  MYSQL_ROW row;
-  char buf[2048];
+  PREPARED_STMT *statement;
+  const char *name;
+  long long total = 0;
+  long long unique_count = 0;
   int i = 0;
 
   /* Free existing names to avoid leaks on reload */
@@ -739,62 +740,47 @@ void load_account_characters(struct account_data *account)
     }
 
   /* First check if we need to clean up duplicates */
-  snprintf(buf, sizeof(buf),
-           "SELECT COUNT(*) as total, COUNT(DISTINCT name) as unique_names "
-           "FROM player_data WHERE account_id = %d",
-           account->id);
-
-  if (mysql_query(conn, buf))
+  statement = account_prepare_statement(
+      "SELECT COUNT(*), COUNT(DISTINCT name) FROM player_data WHERE account_id = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_int(statement, 0, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to check for duplicates: %s", mysql_error(conn));
+    log("SYSERR: Unable to check for duplicate characters for account %d.", account->id);
   }
-  else if ((result = mysql_store_result(conn)))
+  else if (mysql_stmt_fetch_row(statement))
   {
-    if ((row = mysql_fetch_row(result)))
-    {
-      int total = atoi(row[0]);
-      int unique_count = atoi(row[1]);
-      if (total > unique_count)
-      {
-        log("Info: Detected %d duplicate character entries for account %s, cleaning up...",
-            total - unique_count, account->name);
-        mysql_free_result(result);
-        cleanup_duplicate_characters(account);
-      }
-      else
-      {
-        mysql_free_result(result);
-      }
-    }
-    else
-    {
-      mysql_free_result(result);
-    }
+    total = mysql_stmt_get_long(statement, 0);
+    unique_count = mysql_stmt_get_long(statement, 1);
+  }
+  mysql_stmt_cleanup(statement);
+  if (total > unique_count)
+  {
+    log("Info: Detected %lld duplicate character entries for account %s, cleaning up...",
+        total - unique_count, account->name);
+    cleanup_duplicate_characters(account);
   }
 
   /* Now load the character names (duplicates have been cleaned) */
-  snprintf(buf, sizeof(buf), "select name from player_data where account_id = %d", account->id);
-
-  if (mysql_query(conn, buf))
+  statement = account_prepare_statement("SELECT name FROM player_data WHERE account_id = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_int(statement, 0, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to SELECT from player_data: %s", mysql_error(conn));
-    return;
-  }
-  if (!(result = mysql_store_result(conn)))
-  {
-    log("SYSERR: Unable to SELECT from player_data: %s", mysql_error(conn));
+    log("SYSERR: Unable to SELECT character names for account %d.", account->id);
+    mysql_stmt_cleanup(statement);
     return;
   }
 
   i = 0;
-  while ((row = mysql_fetch_row(result)) && i < MAX_CHARS_PER_ACCOUNT)
+  while (i < MAX_CHARS_PER_ACCOUNT && mysql_stmt_fetch_row(statement))
   {
-    account->character_names[i] = strdup(row[0]);
+    name = mysql_stmt_get_string(statement, 0);
+    if (name == NULL)
+      continue;
+    account->character_names[i] = strdup(name);
     i++;
   }
 
-  mysql_free_result(result);
-  return;
+  mysql_stmt_cleanup(statement);
 }
 
 /*
@@ -811,63 +797,45 @@ void load_account_characters(struct account_data *account)
 */
 void load_account_unlocks(struct account_data *account)
 {
-  MYSQL_RES *result;
-  MYSQL_ROW row;
-  char buf[2048];
+  PREPARED_STMT *statement;
   int i = 0;
 
-  /* load locked classes */
-  snprintf(buf, sizeof(buf),
-           "SELECT class_id from unlocked_classes "
-           "WHERE account_id = %d",
-           account->id);
-
-  if (mysql_query(conn, buf))
+  /* load unlocked classes */
+  statement =
+      account_prepare_statement("SELECT class_id FROM unlocked_classes WHERE account_id = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_int(statement, 0, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to SELECT from unlocked_classes: %s", mysql_error(conn));
-    return;
-  }
-
-  if (!(result = mysql_store_result(conn)))
-  {
-    log("SYSERR: Unable to SELECT from unlocked_classes: %s", mysql_error(conn));
+    log("SYSERR: Unable to SELECT from unlocked_classes for account %d.", account->id);
+    mysql_stmt_cleanup(statement);
     return;
   }
 
   i = 0;
-
-  while ((row = mysql_fetch_row(result)) && i < MAX_UNLOCKED_CLASSES)
+  while (i < MAX_UNLOCKED_CLASSES && mysql_stmt_fetch_row(statement))
   {
-    account->classes[i] = atoi(row[0]);
+    account->classes[i] = mysql_stmt_get_int(statement, 0);
     i++;
   }
-  mysql_free_result(result);
+  mysql_stmt_cleanup(statement);
 
-  /* load locked races */
-  snprintf(buf, sizeof(buf),
-           "SELECT race_id from unlocked_races "
-           "WHERE account_id = %d",
-           account->id);
-  if (mysql_query(conn, buf))
+  /* load unlocked races */
+  statement = account_prepare_statement("SELECT race_id FROM unlocked_races WHERE account_id = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_int(statement, 0, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to SELECT from unlocked_races: %s", mysql_error(conn));
+    log("SYSERR: Unable to SELECT from unlocked_races for account %d.", account->id);
+    mysql_stmt_cleanup(statement);
     return;
   }
-  if (!(result = mysql_store_result(conn)))
-  {
-    log("SYSERR: Unable to SELECT from unlocked_races: %s", mysql_error(conn));
-    return;
-  }
+
   i = 0;
-  while ((row = mysql_fetch_row(result)) && i < MAX_UNLOCKED_RACES)
+  while (i < MAX_UNLOCKED_RACES && mysql_stmt_fetch_row(statement))
   {
-    account->races[i] = atoi(row[0]);
+    account->races[i] = mysql_stmt_get_int(statement, 0);
     i++;
   }
-
-  /* cleanup */
-  mysql_free_result(result);
-  return;
+  mysql_stmt_cleanup(statement);
 }
 
 /*
@@ -885,37 +853,27 @@ void load_account_unlocks(struct account_data *account)
 */
 char *get_char_account_name(char *name)
 {
-  MYSQL_RES *result;
-  MYSQL_ROW row;
-  char buf[2048];
+  PREPARED_STMT *statement;
+  const char *value;
   char *acct_name = NULL;
 
-  /* Escape character name to prevent SQL injection */
-  char escaped_name[MAX_INPUT_LENGTH * 2 + 1];
-  mysql_real_escape_string(conn, escaped_name, name, strlen(name));
-
-  snprintf(buf, sizeof(buf),
-           "select a.name from account_data a, player_data p where p.account_id = a.id and p.name "
-           "= '%s'",
-           escaped_name);
-
-  if (mysql_query(conn, buf))
+  statement = account_prepare_statement("SELECT a.name FROM account_data a, player_data p "
+                                        "WHERE p.account_id = a.id AND p.name = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_string(statement, 0, name) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to retrieve account name for character %s: %s", name, mysql_error(conn));
+    log("SYSERR: Unable to retrieve account name for character %s.", name);
+    mysql_stmt_cleanup(statement);
     return NULL;
   }
-  if (!(result = mysql_store_result(conn)))
-  {
-    log("SYSERR: Unable to retreive account name for character %s: %s", name, mysql_error(conn));
-    return NULL;
-  }
-  while ((row = mysql_fetch_row(result)))
+  while (mysql_stmt_fetch_row(statement))
   {
     if (acct_name)
       free(acct_name); /* Free previous allocation if multiple rows */
-    acct_name = (row[0] ? strdup(row[0]) : NULL);
+    value = mysql_stmt_get_string(statement, 0);
+    acct_name = value != NULL ? strdup(value) : NULL;
   }
-  mysql_free_result(result);
+  mysql_stmt_cleanup(statement);
   return acct_name;
 }
 
@@ -1011,77 +969,122 @@ static void account_persistence_detect_dirty(struct account_data *account,
 static bool save_account_character_links(struct account_data *account, char *query,
                                          size_t query_size)
 {
-  char *escaped_name;
+  PREPARED_STMT *statement;
+  bool bound;
   int used;
   int i;
   int count;
 
-  used = snprintf(query, query_size,
-                  "UPDATE player_data SET account_id = %d WHERE lower(name) IN (", account->id);
   count = 0;
-  for (i = 0; i < MAX_CHARS_PER_ACCOUNT && account->character_names[i] != NULL; i++)
-  {
-    escaped_name = mysql_escape_string_alloc(conn, account->character_names[i]);
-    if (escaped_name == NULL)
-      return false;
-    used = snprintf_append(query, query_size, used, "%slower('%s')", count > 0 ? "," : "",
-                           escaped_name);
-    free(escaped_name);
-    if ((size_t)used >= query_size - 1)
-      return false;
+  while (count < MAX_CHARS_PER_ACCOUNT && account->character_names[count] != NULL)
     count++;
-  }
   if (count == 0)
     return true;
+
+  /* Only placeholders are appended here; every name is bound below. */
+  used =
+      snprintf(query, query_size, "UPDATE player_data SET account_id = ? WHERE lower(name) IN (");
+  for (i = 0; i < count; i++)
+  {
+    used = snprintf_append(query, query_size, used, "%slower(?)", i > 0 ? "," : "");
+    if ((size_t)used >= query_size - 1)
+      return false;
+  }
   used = snprintf_append(query, query_size, used, ")");
   if ((size_t)used >= query_size - 1)
     return false;
-  if (mysql_query(conn, query))
+
+  statement = account_prepare_statement(query);
+  bound = statement != NULL && mysql_stmt_bind_param_int(statement, 0, account->id);
+  for (i = 0; bound && i < count; i++)
+    bound = mysql_stmt_bind_param_string(statement, i + 1, account->character_names[i]);
+  if (!bound || !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to batch account character links: %s", mysql_error(conn));
+    log("SYSERR: Unable to batch account character links for account %d.", account->id);
+    mysql_stmt_cleanup(statement);
     return false;
   }
+  mysql_stmt_cleanup(statement);
   return true;
 }
 
-static bool save_account_integer_set(int account_id, const char *table, const char *column,
-                                     const int *values, int value_count, char *query,
-                                     size_t query_size)
+/* Unlock tables addressable by save_account_integer_set(). Identifiers never come from data. */
+enum account_unlock_set
 {
+  ACCOUNT_UNLOCK_RACES,
+  ACCOUNT_UNLOCK_CLASSES
+};
+
+static const struct
+{
+  const char *table;
+  const char *delete_sql;
+  const char *insert_prefix;
+  const char *insert_suffix;
+} account_unlock_sql[] = {
+    {"unlocked_races", "DELETE FROM unlocked_races WHERE account_id = ?",
+     "INSERT INTO unlocked_races (account_id, race_id) VALUES ",
+     " ON DUPLICATE KEY UPDATE race_id=VALUES(race_id)"},
+    {"unlocked_classes", "DELETE FROM unlocked_classes WHERE account_id = ?",
+     "INSERT INTO unlocked_classes (account_id, class_id) VALUES ",
+     " ON DUPLICATE KEY UPDATE class_id=VALUES(class_id)"},
+};
+
+static bool save_account_integer_set(int account_id, enum account_unlock_set set, const int *values,
+                                     int value_count, char *query, size_t query_size)
+{
+  PREPARED_STMT *statement;
+  bool bound;
   int count;
   int i;
   int used;
 
-  snprintf(query, query_size, "DELETE FROM %s WHERE account_id = %d", table, account_id);
-  if (mysql_query(conn, query))
+  statement = account_prepare_statement(account_unlock_sql[set].delete_sql);
+  if (statement == NULL || !mysql_stmt_bind_param_int(statement, 0, account_id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to replace %s: %s", table, mysql_error(conn));
+    log("SYSERR: Unable to replace %s for account %d.", account_unlock_sql[set].table, account_id);
+    mysql_stmt_cleanup(statement);
     return false;
   }
+  mysql_stmt_cleanup(statement);
 
-  used = snprintf(query, query_size, "INSERT INTO %s (account_id, %s) VALUES ", table, column);
+  /* Only placeholders are appended here; every value pair is bound below. */
+  used = snprintf(query, query_size, "%s", account_unlock_sql[set].insert_prefix);
   count = 0;
   for (i = 0; i < value_count; i++)
   {
     if (values[i] == 0)
       continue;
-    used = snprintf_append(query, query_size, used, "%s(%d,%d)", count > 0 ? "," : "", account_id,
-                           values[i]);
+    used = snprintf_append(query, query_size, used, "%s(?,?)", count > 0 ? "," : "");
     if ((size_t)used >= query_size - 1)
       return false;
     count++;
   }
   if (count == 0)
     return true;
-  used = snprintf_append(query, query_size, used, " ON DUPLICATE KEY UPDATE %s=VALUES(%s)", column,
-                         column);
+  used = snprintf_append(query, query_size, used, "%s", account_unlock_sql[set].insert_suffix);
   if ((size_t)used >= query_size - 1)
     return false;
-  if (mysql_query(conn, query))
+
+  statement = account_prepare_statement(query);
+  bound = statement != NULL;
+  count = 0;
+  for (i = 0; bound && i < value_count; i++)
   {
-    log("SYSERR: Unable to batch %s: %s", table, mysql_error(conn));
+    if (values[i] == 0)
+      continue;
+    bound = mysql_stmt_bind_param_int(statement, count * 2, account_id) &&
+            mysql_stmt_bind_param_int(statement, count * 2 + 1, values[i]);
+    count++;
+  }
+  if (!bound || !mysql_stmt_execute_prepared(statement))
+  {
+    log("SYSERR: Unable to batch %s for account %d.", account_unlock_sql[set].table, account_id);
+    mysql_stmt_cleanup(statement);
     return false;
   }
+  mysql_stmt_cleanup(statement);
   return true;
 }
 
@@ -1133,9 +1136,7 @@ static void synchronize_connected_account_views(const struct account_data *sourc
 bool save_account_checked(struct account_data *account)
 {
   char query[16384];
-  char *escaped_name;
-  char *escaped_password;
-  char *escaped_email;
+  PREPARED_STMT *statement;
   enum perf_sql_category previous_sql_category;
   bool success;
   bool transaction_started;
@@ -1154,9 +1155,6 @@ bool save_account_checked(struct account_data *account)
 
   PERF_PROF_ENTER_SAMPLED(pr_save_account_, "save.account");
   previous_sql_category = PERF_sql_scope_set(PERF_SQL_ACCOUNT);
-  escaped_name = NULL;
-  escaped_password = NULL;
-  escaped_email = NULL;
   success = false;
   transaction_started = false;
   account_persistence_detect_dirty(account, hashes);
@@ -1174,16 +1172,6 @@ bool save_account_checked(struct account_data *account)
     goto cleanup;
   }
 
-  escaped_name = mysql_escape_string_alloc(conn, account->name);
-  escaped_password = mysql_escape_string_alloc(conn, account->password);
-  escaped_email = account->email != NULL ? mysql_escape_string_alloc(conn, account->email) : NULL;
-  if (escaped_name == NULL || escaped_password == NULL ||
-      (account->email != NULL && escaped_email == NULL))
-  {
-    log("SYSERR: Unable to escape account data for persistence.");
-    goto cleanup;
-  }
-
   if (mysql_query(conn, "START TRANSACTION"))
   {
     log("SYSERR: Unable to start account save transaction: %s", mysql_error(conn));
@@ -1193,29 +1181,34 @@ bool save_account_checked(struct account_data *account)
 
   if (core_dirty)
   {
-    snprintf(query, sizeof(query),
-             "INSERT INTO account_data (id,name,password,experience,email,quit_survey_completed) "
-             "VALUES (%d,'%s','%s',%d,%s%s%s,%d) "
-             "ON DUPLICATE KEY UPDATE password=VALUES(password),experience=VALUES(experience),"
-             "email=VALUES(email),quit_survey_completed=VALUES(quit_survey_completed)",
-             account->id, escaped_name, escaped_password, account->experience,
-             escaped_email != NULL ? "'" : "", escaped_email != NULL ? escaped_email : "NULL",
-             escaped_email != NULL ? "'" : "", account->quit_survey_completed ? 1 : 0);
-    if (mysql_query(conn, query))
+    /* A NULL email binds as SQL NULL; nothing here is interpolated into the text. */
+    statement = account_prepare_statement(
+        "INSERT INTO account_data (id,name,password,experience,email,quit_survey_completed) "
+        "VALUES (?,?,?,?,?,?) "
+        "ON DUPLICATE KEY UPDATE password=VALUES(password),experience=VALUES(experience),"
+        "email=VALUES(email),quit_survey_completed=VALUES(quit_survey_completed)");
+    if (statement == NULL || !mysql_stmt_bind_param_int(statement, 0, account->id) ||
+        !mysql_stmt_bind_param_string(statement, 1, account->name) ||
+        !mysql_stmt_bind_param_string(statement, 2, account->password) ||
+        !mysql_stmt_bind_param_int(statement, 3, account->experience) ||
+        !mysql_stmt_bind_param_string(statement, 4, account->email) ||
+        !mysql_stmt_bind_param_int(statement, 5, account->quit_survey_completed ? 1 : 0) ||
+        !mysql_stmt_execute_prepared(statement))
     {
-      log("SYSERR: Unable to UPSERT account_data: %s", mysql_error(conn));
+      log("SYSERR: Unable to UPSERT account_data for account '%s'.", account->name);
+      mysql_stmt_cleanup(statement);
       goto rollback;
     }
     if (account->id == 0)
-      account->id = (int)mysql_insert_id(conn);
+      account->id = (int)mysql_stmt_insert_id(statement->stmt);
+    mysql_stmt_cleanup(statement);
   }
 
   if ((characters_dirty && !save_account_character_links(account, query, sizeof(query))) ||
-      (races_dirty &&
-       !save_account_integer_set(account->id, "unlocked_races", "race_id", account->races,
-                                 MAX_UNLOCKED_RACES, query, sizeof(query))) ||
+      (races_dirty && !save_account_integer_set(account->id, ACCOUNT_UNLOCK_RACES, account->races,
+                                                MAX_UNLOCKED_RACES, query, sizeof(query))) ||
       (classes_dirty &&
-       !save_account_integer_set(account->id, "unlocked_classes", "class_id", account->classes,
+       !save_account_integer_set(account->id, ACCOUNT_UNLOCK_CLASSES, account->classes,
                                  MAX_UNLOCKED_CLASSES, query, sizeof(query))))
     goto rollback;
 
@@ -1246,9 +1239,6 @@ cleanup:
   if (!success)
     log("SYSERR: Account '%s' was not durably saved; the current state remains retryable.",
         account->name);
-  free(escaped_name);
-  free(escaped_password);
-  free(escaped_email);
   PERF_sql_scope_restore(previous_sql_category);
   PERF_PROF_EXIT(pr_save_account_);
   return success;
@@ -1295,10 +1285,9 @@ void show_account_menu(struct descriptor_data *d)
     return;
   }
 
-  MYSQL_RES *res = NULL;
-  MYSQL_ROW row = NULL;
-
-  char query[MAX_INPUT_LENGTH] = {'\0'};
+  PREPARED_STMT *statement = NULL;
+  bool executed = false;
+  bool found = false;
 
   if (d->account)
   {
@@ -1319,29 +1308,22 @@ void show_account_menu(struct descriptor_data *d)
 
         write_to_output(d, " \tW%-3d\tn \tC|\tn \tW%-20s\tn\tC|\tn", i + 1,
                         d->account->character_names[i]);
-        char *escaped_name = mysql_escape_string_alloc(conn, d->account->character_names[i]);
-        if (!escaped_name)
+        statement =
+            account_prepare_statement("SELECT name FROM player_data WHERE lower(name) = lower(?)");
+        executed = statement != NULL &&
+                   mysql_stmt_bind_param_string(statement, 0, d->account->character_names[i]) &&
+                   mysql_stmt_execute_prepared(statement);
+        found = executed && mysql_stmt_fetch_row(statement);
+        mysql_stmt_cleanup(statement);
+        statement = NULL;
+        if (!executed)
         {
-          log("SYSERR: Failed to escape character name in display_account_menu");
-          continue;
-        }
-        snprintf(query, sizeof(query), "SELECT name FROM player_data WHERE lower(name)=lower('%s')",
-                 escaped_name);
-        free(escaped_name);
-
-        if (mysql_query(conn, query))
-        {
-          log("SYSERR: Unable to SELECT from player_data: %s", mysql_error(conn));
+          log("SYSERR: Unable to SELECT from player_data for the account menu.");
         }
 
-        if (!(res = mysql_store_result(conn)))
+        if (executed)
         {
-          log("SYSERR: Unable to SELECT from player_data: %s", mysql_error(conn));
-        }
-
-        if (res != NULL)
-        {
-          if ((row = mysql_fetch_row(res)) != NULL)
+          if (found)
           {
             /* Initialize another temporary char to format line output. */
             CREATE(tch, struct char_data, 1);
@@ -1356,7 +1338,6 @@ void show_account_menu(struct descriptor_data *d)
               {
                 write_to_output(d, " \tR---===||DELETED||===---\tn\r\n");
                 free_char(tch);
-                mysql_free_result(res);
                 continue;
               }
 
@@ -1390,9 +1371,8 @@ void show_account_menu(struct descriptor_data *d)
             }
             free_char(tch);
           }
+          write_to_output(d, "\r\n");
         }
-        mysql_free_result(res);
-        write_to_output(d, "\r\n");
       }
       else
       {
@@ -1540,7 +1520,8 @@ ACMD(do_account)
 */
 void remove_char_from_account(struct char_data *ch, struct account_data *account)
 {
-  char buf[2048];
+  PREPARED_STMT *statement;
+  long removed;
 
   if (ch == NULL)
   {
@@ -1553,86 +1534,73 @@ void remove_char_from_account(struct char_data *ch, struct account_data *account
     return;
   }
 
-  /* Escape character name to prevent SQL injection */
-  char escaped_name[MAX_INPUT_LENGTH * 2 + 1];
-  mysql_real_escape_string(conn, escaped_name, GET_NAME(ch), strlen(GET_NAME(ch)));
-
-  snprintf(buf, sizeof(buf),
-           "DELETE from player_data where lower(name) = lower('%s') and account_id = %d;",
-           escaped_name, account->id);
-
-  if (mysql_query(conn, buf))
+  statement = account_prepare_statement(
+      "DELETE FROM player_data WHERE lower(name) = lower(?) AND account_id = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_string(statement, 0, GET_NAME(ch)) ||
+      !mysql_stmt_bind_param_int(statement, 1, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to DELETE from player_data: %s", mysql_error(conn));
+    log("SYSERR: Unable to DELETE %s from player_data.", GET_NAME(ch));
+    mysql_stmt_cleanup(statement);
     return;
   }
+  removed = (long)mysql_stmt_affected_rows_count(statement);
+  mysql_stmt_cleanup(statement);
 
   /* Reload the character names */
   load_account_characters(account);
 
-  log("Info: Character %s removed from account %s : %s", GET_NAME(ch), account->name,
-      mysql_info(conn));
+  log("Info: Character %s removed from account %s : %ld row(s) affected", GET_NAME(ch),
+      account->name, removed);
 }
 
 bool link_character_to_account_checked(struct char_data *ch, struct account_data *account)
 {
-  char query[2048];
-  char *escaped_name = NULL;
+  PREPARED_STMT *statement;
 
   if (ch == NULL || account == NULL || !mysql_available || conn == NULL || GET_NAME(ch) == NULL)
     return FALSE;
 
-  escaped_name = mysql_escape_string_alloc(conn, GET_NAME(ch));
-  if (escaped_name == NULL)
-    return FALSE;
-
-  snprintf(query, sizeof(query),
-           "INSERT INTO player_data (name, account_id, last_online) "
-           "VALUES ('%s', %d, NOW()) "
-           "ON DUPLICATE KEY UPDATE account_id = VALUES(account_id)",
-           escaped_name, account->id);
-  free(escaped_name);
-
-  if (mysql_query(conn, query))
+  statement = account_prepare_statement("INSERT INTO player_data (name, account_id, last_online) "
+                                        "VALUES (?, ?, NOW()) "
+                                        "ON DUPLICATE KEY UPDATE account_id = VALUES(account_id)");
+  if (statement == NULL || !mysql_stmt_bind_param_string(statement, 0, GET_NAME(ch)) ||
+      !mysql_stmt_bind_param_int(statement, 1, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Unable to link new character %s to account %s: %s", GET_NAME(ch), account->name,
-        mysql_error(conn));
+    log("SYSERR: Unable to link new character %s to account %s.", GET_NAME(ch), account->name);
+    mysql_stmt_cleanup(statement);
     return FALSE;
   }
+  mysql_stmt_cleanup(statement);
   return TRUE;
 }
 
 bool begin_account_character_removal(struct char_data *ch, struct account_data *account)
 {
-  char query[2048];
-  char *escaped_name = NULL;
+  PREPARED_STMT *statement;
 
   if (ch == NULL || account == NULL || !mysql_available || conn == NULL || GET_NAME(ch) == NULL)
-    return FALSE;
-
-  escaped_name = mysql_escape_string_alloc(conn, GET_NAME(ch));
-  if (escaped_name == NULL)
     return FALSE;
 
   if (mysql_query(conn, "START TRANSACTION"))
   {
     log("SYSERR: Could not begin character-removal transaction: %s", mysql_error(conn));
-    free(escaped_name);
     return FALSE;
   }
 
-  snprintf(query, sizeof(query),
-           "DELETE FROM player_data WHERE lower(name) = lower('%s') AND account_id = %d",
-           escaped_name, account->id);
-  free(escaped_name);
-
-  if (mysql_query(conn, query))
+  statement = account_prepare_statement(
+      "DELETE FROM player_data WHERE lower(name) = lower(?) AND account_id = ?");
+  if (statement == NULL || !mysql_stmt_bind_param_string(statement, 0, GET_NAME(ch)) ||
+      !mysql_stmt_bind_param_int(statement, 1, account->id) ||
+      !mysql_stmt_execute_prepared(statement))
   {
-    log("SYSERR: Could not stage account unlink for character %s: %s", GET_NAME(ch),
-        mysql_error(conn));
+    log("SYSERR: Could not stage account unlink for character %s.", GET_NAME(ch));
+    mysql_stmt_cleanup(statement);
     mysql_query(conn, "ROLLBACK");
     return FALSE;
   }
+  mysql_stmt_cleanup(statement);
 
   return TRUE;
 }

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -9,6 +9,7 @@
 #include "conf.h"
 #include "sysdep.h"
 #include <stdint.h>
+#include <limits.h>
 #include <stdatomic.h>
 #include <math.h>
 #include "structs.h"
@@ -1634,10 +1635,13 @@ bool mysql_stmt_execute_prepared(PREPARED_STMT *pstmt)
         break;
 
       case MYSQL_TYPE_LONGLONG:
-        /* BIGINT columns and COUNT(*) aggregates arrive as 64-bit integers */
+        /* BIGINT columns and COUNT(*) aggregates arrive as 64-bit integers.
+         * The buffer signedness follows the column so the client library
+         * converts and range-checks correctly for BIGINT UNSIGNED. */
         CREATE(pstmt->results[i].buffer, long long, 1);
         pstmt->results[i].buffer_type = MYSQL_TYPE_LONGLONG;
         pstmt->results[i].buffer_length = sizeof(long long);
+        pstmt->results[i].is_unsigned = (my_bool)((field->flags & UNSIGNED_FLAG) != 0 ? 1 : 0);
         CREATE(pstmt->results[i].is_null, my_bool, 1);
         CREATE(pstmt->results[i].error, my_bool, 1);
         *pstmt->results[i].error = 0;
@@ -1815,7 +1819,8 @@ int mysql_stmt_get_int(PREPARED_STMT *pstmt, int col_index)
 
   if (pstmt->results[col_index].buffer_type == MYSQL_TYPE_LONGLONG)
   {
-    return (int)*(long long *)pstmt->results[col_index].buffer;
+    long long wide = mysql_stmt_get_long(pstmt, col_index);
+    return wide > INT_MAX ? INT_MAX : (wide < INT_MIN ? INT_MIN : (int)wide);
   }
 
   return *(int *)pstmt->results[col_index].buffer;
@@ -1844,10 +1849,52 @@ long long mysql_stmt_get_long(PREPARED_STMT *pstmt, int col_index)
 
   if (pstmt->results[col_index].buffer_type == MYSQL_TYPE_LONGLONG)
   {
+    if (pstmt->results[col_index].is_unsigned)
+    {
+      unsigned long long raw = *(unsigned long long *)pstmt->results[col_index].buffer;
+      return raw > (unsigned long long)LLONG_MAX ? LLONG_MAX : (long long)raw;
+    }
     return *(long long *)pstmt->results[col_index].buffer;
   }
 
   return *(int *)pstmt->results[col_index].buffer;
+}
+
+/**
+ * Gets an unsigned 64-bit integer value from the current result row.
+ *
+ * @param pstmt The prepared statement structure
+ * @param col_index The column index (0-based)
+ * @return Integer value, or 0 if column is NULL, negative, or error
+ *
+ * @note Use this for BIGINT UNSIGNED columns whose values may exceed LLONG_MAX.
+ */
+unsigned long long mysql_stmt_get_ulong(PREPARED_STMT *pstmt, int col_index)
+{
+  long long signed_value;
+
+  if (!pstmt || !pstmt->results || col_index < 0 || col_index >= pstmt->result_count)
+  {
+    return 0;
+  }
+
+  if (*pstmt->results[col_index].is_null)
+  {
+    return 0;
+  }
+
+  if (pstmt->results[col_index].buffer_type == MYSQL_TYPE_LONGLONG)
+  {
+    if (pstmt->results[col_index].is_unsigned)
+    {
+      return *(unsigned long long *)pstmt->results[col_index].buffer;
+    }
+    signed_value = *(long long *)pstmt->results[col_index].buffer;
+    return signed_value < 0 ? 0 : (unsigned long long)signed_value;
+  }
+
+  signed_value = *(int *)pstmt->results[col_index].buffer;
+  return signed_value < 0 ? 0 : (unsigned long long)signed_value;
 }
 
 /**

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -1191,6 +1191,7 @@ PREPARED_STMT *mysql_stmt_create(MYSQL *mysql_conn)
   pstmt->param_count = 0;
   pstmt->result_count = 0;
   pstmt->metadata = NULL;
+  pstmt->query_text = NULL;
 
   /* Select appropriate mutex based on connection */
   if (mysql_conn == conn)
@@ -1265,6 +1266,13 @@ bool mysql_stmt_prepare_query(PREPARED_STMT *pstmt, const char *query)
     MYSQL_UNLOCK(*mutex);
     return FALSE;
   }
+
+  /* Keep the statement text so executions are attributed like direct queries */
+  if (pstmt->query_text)
+  {
+    free(pstmt->query_text);
+  }
+  pstmt->query_text = strdup(query);
 
   /* Get parameter count and allocate bindings */
   pstmt->param_count = mysql_stmt_param_count(pstmt->stmt);
@@ -1469,6 +1477,9 @@ bool mysql_stmt_bind_param_long(PREPARED_STMT *pstmt, int param_index, long valu
 bool mysql_stmt_execute_prepared(PREPARED_STMT *pstmt)
 {
   pthread_mutex_t *mutex;
+  uint64_t start_usec;
+  uint64_t end_usec;
+  int execute_failed;
   int i;
 
   if (!pstmt || !pstmt->stmt)
@@ -1513,7 +1524,12 @@ bool mysql_stmt_execute_prepared(PREPARED_STMT *pstmt)
 
   /* Execute the statement */
   atomic_fetch_add_explicit(&query_execution_count, 1, memory_order_relaxed);
-  if (mysql_stmt_execute(pstmt->stmt))
+  start_usec = PERF_monotonic_usec();
+  execute_failed = mysql_stmt_execute(pstmt->stmt);
+  end_usec = PERF_monotonic_usec();
+  PERF_note_sql_query(pstmt->query_text != NULL ? pstmt->query_text : "",
+                      end_usec >= start_usec ? end_usec - start_usec : 0, execute_failed != 0);
+  if (execute_failed)
   {
     log("SYSERR: mysql_stmt_execute failed: %s (Error: %u, SQLState: %s)",
         mysql_stmt_error(pstmt->stmt), mysql_stmt_errno(pstmt->stmt),
@@ -1614,6 +1630,17 @@ bool mysql_stmt_execute_prepared(PREPARED_STMT *pstmt)
         /* Initialize error flag */
         *pstmt->results[i].error = 0;
         /* Integer types don't need length pointer */
+        pstmt->results[i].length = NULL;
+        break;
+
+      case MYSQL_TYPE_LONGLONG:
+        /* BIGINT columns and COUNT(*) aggregates arrive as 64-bit integers */
+        CREATE(pstmt->results[i].buffer, long long, 1);
+        pstmt->results[i].buffer_type = MYSQL_TYPE_LONGLONG;
+        pstmt->results[i].buffer_length = sizeof(long long);
+        CREATE(pstmt->results[i].is_null, my_bool, 1);
+        CREATE(pstmt->results[i].error, my_bool, 1);
+        *pstmt->results[i].error = 0;
         pstmt->results[i].length = NULL;
         break;
 
@@ -1786,6 +1813,40 @@ int mysql_stmt_get_int(PREPARED_STMT *pstmt, int col_index)
     return 0;
   }
 
+  if (pstmt->results[col_index].buffer_type == MYSQL_TYPE_LONGLONG)
+  {
+    return (int)*(long long *)pstmt->results[col_index].buffer;
+  }
+
+  return *(int *)pstmt->results[col_index].buffer;
+}
+
+/**
+ * Gets a 64-bit integer value from the current result row.
+ *
+ * @param pstmt The prepared statement structure
+ * @param col_index The column index (0-based)
+ * @return Integer value, or 0 if column is NULL or error
+ *
+ * @note Use this for BIGINT columns and COUNT(*) aggregates.
+ */
+long long mysql_stmt_get_long(PREPARED_STMT *pstmt, int col_index)
+{
+  if (!pstmt || !pstmt->results || col_index < 0 || col_index >= pstmt->result_count)
+  {
+    return 0;
+  }
+
+  if (*pstmt->results[col_index].is_null)
+  {
+    return 0;
+  }
+
+  if (pstmt->results[col_index].buffer_type == MYSQL_TYPE_LONGLONG)
+  {
+    return *(long long *)pstmt->results[col_index].buffer;
+  }
+
   return *(int *)pstmt->results[col_index].buffer;
 }
 
@@ -1884,6 +1945,11 @@ void mysql_stmt_cleanup(PREPARED_STMT *pstmt)
   if (pstmt->metadata)
   {
     mysql_free_result(pstmt->metadata);
+  }
+
+  if (pstmt->query_text)
+  {
+    free(pstmt->query_text);
   }
 
   /* Close the statement */

--- a/src/mysql.h
+++ b/src/mysql.h
@@ -142,6 +142,7 @@ typedef struct prepared_stmt
   int result_count;    /* Number of result columns */
   MYSQL_RES *metadata; /* Result metadata */
   MYSQL *connection;   /* Associated connection */
+  char *query_text;    /* Prepared SQL text, kept for performance accounting */
 } PREPARED_STMT;
 
 /* Create and initialize a prepared statement */
@@ -162,6 +163,7 @@ bool mysql_stmt_execute_prepared(PREPARED_STMT *pstmt);
 bool mysql_stmt_fetch_row(PREPARED_STMT *pstmt);
 char *mysql_stmt_get_string(PREPARED_STMT *pstmt, int col_index);
 int mysql_stmt_get_int(PREPARED_STMT *pstmt, int col_index);
+long long mysql_stmt_get_long(PREPARED_STMT *pstmt, int col_index);
 
 /* Get number of affected rows (for INSERT/UPDATE/DELETE) */
 my_ulonglong mysql_stmt_affected_rows_count(PREPARED_STMT *pstmt);

--- a/src/mysql.h
+++ b/src/mysql.h
@@ -164,6 +164,7 @@ bool mysql_stmt_fetch_row(PREPARED_STMT *pstmt);
 char *mysql_stmt_get_string(PREPARED_STMT *pstmt, int col_index);
 int mysql_stmt_get_int(PREPARED_STMT *pstmt, int col_index);
 long long mysql_stmt_get_long(PREPARED_STMT *pstmt, int col_index);
+unsigned long long mysql_stmt_get_ulong(PREPARED_STMT *pstmt, int col_index);
 
 /* Get number of affected rows (for INSERT/UPDATE/DELETE) */
 my_ulonglong mysql_stmt_affected_rows_count(PREPARED_STMT *pstmt);

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -2466,8 +2466,19 @@ void Test_pet_bounded_restore_selects_capacity_and_stables_the_rest(CuTest *tc)
  * SQL-looking fragments must round-trip byte for byte, and the result must not
  * depend on the session's escaping mode.
  */
-static void check_account_tier_binds_values(CuTest *tc, MYSQL *connection, const char *sql_mode,
-                                            const char *account_name, const char *lookup_name)
+#define ACCOUNT_CHECK(condition, label)                                                            \
+  do                                                                                               \
+  {                                                                                                \
+    if (!(condition))                                                                              \
+      return (label);                                                                              \
+  } while (0)
+
+/* Returns NULL on success or a label naming the first failed check. The helper
+ * never asserts: a CuTest assertion longjmps past the caller's cleanup, which
+ * would leave the test connection installed in the globals. */
+static const char *check_account_tier_binds_values(MYSQL *connection, const char *sql_mode,
+                                                   const char *account_name,
+                                                   const char *lookup_name)
 {
   const char *queries[] = {
       "DROP TEMPORARY TABLE IF EXISTS account_data, player_data, unlocked_races, unlocked_classes",
@@ -2509,11 +2520,12 @@ static void check_account_tier_binds_values(CuTest *tc, MYSQL *connection, const
   ch.player_specials = &specials;
   ch.player.name = (char *)character_name;
 
-  CuAssertIntEquals(tc, 0, mysql_query(connection, sql_mode));
+  ACCOUNT_CHECK((0) == (mysql_query(connection, sql_mode)),
+                "(0) == (mysql_query(connection, sql_mode))");
   for (query_index = 0; queries[query_index] != NULL; query_index++)
     if (mysql_query(connection, queries[query_index]))
       schema_created = false;
-  CuAssertTrue(tc, schema_created);
+  ACCOUNT_CHECK(schema_created, "schema_created");
 
   /* Core row with every string carrying hostile characters, plus unlock sets. */
   account.name = (char *)account_name;
@@ -2524,25 +2536,30 @@ static void check_account_tier_binds_values(CuTest *tc, MYSQL *connection, const
   account.races[0] = 3;
   account.races[1] = 7;
   account.classes[0] = 2;
-  CuAssertTrue(tc, save_account_checked(&account));
-  CuAssertTrue(tc, account.id > 0);
+  ACCOUNT_CHECK(save_account_checked(&account), "save_account_checked(&account)");
+  ACCOUNT_CHECK(account.id > 0, "account.id > 0");
 
-  CuAssertIntEquals(tc, 0, load_account((char *)lookup_name, &loaded));
-  CuAssertStrEquals(tc, account_name, loaded.name);
-  CuAssertStrEquals(tc, password, loaded.password);
-  CuAssertStrEquals(tc, email, loaded.email);
-  CuAssertIntEquals(tc, 1234, loaded.experience);
-  CuAssertTrue(tc, loaded.quit_survey_completed);
-  CuAssertIntEquals(tc, account.id, loaded.id);
+  ACCOUNT_CHECK((0) == (load_account((char *)lookup_name, &loaded)),
+                "(0) == (load_account((char *)lookup_name, &loaded))");
+  ACCOUNT_CHECK((loaded.name) != NULL && strcmp(account_name, loaded.name) == 0,
+                "(loaded.name) != NULL && strcmp(account_name, loaded.name) == 0");
+  ACCOUNT_CHECK((loaded.password) != NULL && strcmp(password, loaded.password) == 0,
+                "(loaded.password) != NULL && strcmp(password, loaded.password) == 0");
+  ACCOUNT_CHECK((loaded.email) != NULL && strcmp(email, loaded.email) == 0,
+                "(loaded.email) != NULL && strcmp(email, loaded.email) == 0");
+  ACCOUNT_CHECK((1234) == (loaded.experience), "(1234) == (loaded.experience)");
+  ACCOUNT_CHECK(loaded.quit_survey_completed, "loaded.quit_survey_completed");
+  ACCOUNT_CHECK((account.id) == (loaded.id), "(account.id) == (loaded.id)");
   for (slot = 0; slot < MAX_UNLOCKED_RACES; slot++)
     if (loaded.races[slot] == 7)
       race_found = true;
   for (slot = 0; slot < MAX_UNLOCKED_CLASSES; slot++)
     if (loaded.classes[slot] == 2)
       class_found = true;
-  CuAssertTrue(tc, race_found);
-  CuAssertTrue(tc, class_found);
-  CuAssertPtrEquals(tc, NULL, loaded.character_names[0]);
+  ACCOUNT_CHECK(race_found, "race_found");
+  ACCOUNT_CHECK(class_found, "class_found");
+  ACCOUNT_CHECK((void *)(NULL) == (void *)(loaded.character_names[0]),
+                "(void *)(NULL) == (void *)(loaded.character_names[0])");
   free(loaded.name);
   free(loaded.email);
   memset(&loaded, 0, sizeof(loaded));
@@ -2551,54 +2568,76 @@ static void check_account_tier_binds_values(CuTest *tc, MYSQL *connection, const
   account.email = NULL;
   account.experience = 99;
   account.quit_survey_completed = false;
-  CuAssertTrue(tc, save_account_checked(&account));
-  CuAssertIntEquals(tc, 0, load_account((char *)account_name, &loaded));
-  CuAssertPtrEquals(tc, NULL, loaded.email);
-  CuAssertIntEquals(tc, 99, loaded.experience);
-  CuAssertTrue(tc, !loaded.quit_survey_completed);
+  ACCOUNT_CHECK(save_account_checked(&account), "save_account_checked(&account)");
+  ACCOUNT_CHECK((0) == (load_account((char *)account_name, &loaded)),
+                "(0) == (load_account((char *)account_name, &loaded))");
+  ACCOUNT_CHECK((void *)(NULL) == (void *)(loaded.email),
+                "(void *)(NULL) == (void *)(loaded.email)");
+  ACCOUNT_CHECK((99) == (loaded.experience), "(99) == (loaded.experience)");
+  ACCOUNT_CHECK(!loaded.quit_survey_completed, "!loaded.quit_survey_completed");
   free(loaded.name);
   memset(&loaded, 0, sizeof(loaded));
 
   /* Character links: create, list, resolve owner, batch relink, dedupe, remove. */
-  CuAssertTrue(tc, link_character_to_account_checked(&ch, &account));
+  ACCOUNT_CHECK(link_character_to_account_checked(&ch, &account),
+                "link_character_to_account_checked(&ch, &account)");
   load_account_characters(&account);
-  CuAssertPtrNotNull(tc, account.character_names[0]);
-  CuAssertStrEquals(tc, character_name, account.character_names[0]);
-  CuAssertPtrEquals(tc, NULL, account.character_names[1]);
+  ACCOUNT_CHECK((account.character_names[0]) != NULL, "(account.character_names[0]) != NULL");
+  ACCOUNT_CHECK((account.character_names[0]) != NULL &&
+                    strcmp(character_name, account.character_names[0]) == 0,
+                "(account.character_names[0]) != NULL && strcmp(character_name, "
+                "account.character_names[0]) == 0");
+  ACCOUNT_CHECK((void *)(NULL) == (void *)(account.character_names[1]),
+                "(void *)(NULL) == (void *)(account.character_names[1])");
   owner_name = get_char_account_name((char *)character_name);
-  CuAssertPtrNotNull(tc, owner_name);
-  CuAssertStrEquals(tc, account_name, owner_name);
+  ACCOUNT_CHECK((owner_name) != NULL, "(owner_name) != NULL");
+  ACCOUNT_CHECK((owner_name) != NULL && strcmp(account_name, owner_name) == 0,
+                "(owner_name) != NULL && strcmp(account_name, owner_name) == 0");
   free(owner_name);
 
   /* The dirty character set drives the placeholder IN (...) relink. */
-  CuAssertTrue(tc, save_account_checked(&account));
+  ACCOUNT_CHECK(save_account_checked(&account), "save_account_checked(&account)");
   escaped_name = mysql_escape_string_alloc(connection, character_name);
-  CuAssertPtrNotNull(tc, escaped_name);
+  ACCOUNT_CHECK((escaped_name) != NULL, "(escaped_name) != NULL");
   snprintf(count_query, sizeof(count_query),
            "SELECT COUNT(*) FROM player_data WHERE account_id = %d", account.id);
-  CuAssertIntEquals(tc, 1, query_single_int(connection, count_query, -1));
+  ACCOUNT_CHECK((1) == (query_single_int(connection, count_query, -1)),
+                "(1) == (query_single_int(connection, count_query, -1))");
 
   snprintf(count_query, sizeof(count_query),
            "INSERT INTO player_data (name, account_id) VALUES ('%s', %d)", escaped_name,
            account.id);
-  CuAssertIntEquals(tc, 0, mysql_query(connection, count_query));
+  ACCOUNT_CHECK((0) == (mysql_query(connection, count_query)),
+                "(0) == (mysql_query(connection, count_query))");
   snprintf(count_query, sizeof(count_query),
            "SELECT COUNT(*) FROM player_data WHERE account_id = %d", account.id);
-  CuAssertIntEquals(tc, 2, query_single_int(connection, count_query, -1));
+  ACCOUNT_CHECK((2) == (query_single_int(connection, count_query, -1)),
+                "(2) == (query_single_int(connection, count_query, -1))");
   load_account_characters(&account);
-  CuAssertIntEquals(tc, 1, query_single_int(connection, count_query, -1));
-  CuAssertStrEquals(tc, character_name, account.character_names[0]);
-  CuAssertPtrEquals(tc, NULL, account.character_names[1]);
+  ACCOUNT_CHECK((1) == (query_single_int(connection, count_query, -1)),
+                "(1) == (query_single_int(connection, count_query, -1))");
+  ACCOUNT_CHECK((account.character_names[0]) != NULL &&
+                    strcmp(character_name, account.character_names[0]) == 0,
+                "(account.character_names[0]) != NULL && strcmp(character_name, "
+                "account.character_names[0]) == 0");
+  ACCOUNT_CHECK((void *)(NULL) == (void *)(account.character_names[1]),
+                "(void *)(NULL) == (void *)(account.character_names[1])");
 
   remove_char_from_account(&ch, &account);
-  CuAssertIntEquals(tc, 0, query_single_int(connection, count_query, -1));
-  CuAssertPtrEquals(tc, NULL, account.character_names[0]);
-  CuAssertPtrEquals(tc, NULL, get_char_account_name((char *)character_name));
+  ACCOUNT_CHECK((0) == (query_single_int(connection, count_query, -1)),
+                "(0) == (query_single_int(connection, count_query, -1))");
+  ACCOUNT_CHECK((void *)(NULL) == (void *)(account.character_names[0]),
+                "(void *)(NULL) == (void *)(account.character_names[0])");
+  ACCOUNT_CHECK((void *)(NULL) == (void *)(get_char_account_name((char *)character_name)),
+                "(void *)(NULL) == (void *)(get_char_account_name((char *)character_name))");
   free(escaped_name);
 
   for (slot = 0; slot < MAX_CHARS_PER_ACCOUNT; slot++)
     free(account.character_names[slot]);
+  return NULL;
 }
+
+#undef ACCOUNT_CHECK
 
 void Test_account_tier_binds_hostile_values_in_every_sql_mode(CuTest *tc)
 {
@@ -2607,6 +2646,8 @@ void Test_account_tier_binds_hostile_values_in_every_sql_mode(CuTest *tc)
   const char *lookup_name = "oL'r\xc3\xa9\\ILLE\"); drop TABLE account_data; --";
   MYSQL *connection;
   MYSQL *saved_conn;
+  const char *default_mode_failure;
+  const char *no_backslash_failure;
   bool saved_available;
 
   if (enabled == NULL || strcmp(enabled, "1") != 0)
@@ -2628,12 +2669,18 @@ void Test_account_tier_binds_hostile_values_in_every_sql_mode(CuTest *tc)
   conn = connection;
   mysql_available = true;
 
-  check_account_tier_binds_values(tc, connection, "SET SESSION sql_mode = ''", account_name,
-                                  lookup_name);
-  check_account_tier_binds_values(tc, connection, "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'",
-                                  account_name, lookup_name);
+  default_mode_failure = check_account_tier_binds_values(connection, "SET SESSION sql_mode = ''",
+                                                         account_name, lookup_name);
+  no_backslash_failure = check_account_tier_binds_values(
+      connection, "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'", account_name, lookup_name);
 
+  /* Restore the globals before any assertion can longjmp out of this test. */
   mysql_close(connection);
   conn = saved_conn;
   mysql_available = saved_available;
+
+  CuAssert(tc, default_mode_failure != NULL ? default_mode_failure : "default sql_mode",
+           default_mode_failure == NULL);
+  CuAssert(tc, no_backslash_failure != NULL ? no_backslash_failure : "NO_BACKSLASH_ESCAPES",
+           no_backslash_failure == NULL);
 }

--- a/unittests/CuTest/test_database_persistence.c
+++ b/unittests/CuTest/test_database_persistence.c
@@ -10,6 +10,7 @@
 #include "../../src/comm.h"
 #include "../../src/db.h"
 #include "../../src/handler.h"
+#include "../../src/interpreter.h"
 #include "../../src/mysql.h"
 #include "../../src/net/protocol.h"
 #include "../../src/db_init.h"
@@ -2457,4 +2458,182 @@ void Test_pet_bounded_restore_selects_capacity_and_stables_the_rest(CuTest *tc)
   CuAssertTrue(tc, reclaim_denied);
   CuAssertTrue(tc, reclaim_allowed);
   CuAssertTrue(tc, partial_refused);
+}
+
+/*
+ * The account tier binds every data value through prepared statements. Names,
+ * passwords, and emails carrying quotes, backslashes, multibyte text, and
+ * SQL-looking fragments must round-trip byte for byte, and the result must not
+ * depend on the session's escaping mode.
+ */
+static void check_account_tier_binds_values(CuTest *tc, MYSQL *connection, const char *sql_mode,
+                                            const char *account_name, const char *lookup_name)
+{
+  const char *queries[] = {
+      "DROP TEMPORARY TABLE IF EXISTS account_data, player_data, unlocked_races, unlocked_classes",
+      "CREATE TEMPORARY TABLE account_data ("
+      "id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64) NOT NULL UNIQUE, "
+      "password VARCHAR(255) NOT NULL, experience INT NOT NULL DEFAULT 0, "
+      "email VARCHAR(255) NULL, "
+      "quit_survey_completed TINYINT(1) NULL) ENGINE=InnoDB",
+      /* No primary key: duplicate-name cleanup needs duplicate rows to exist. */
+      "CREATE TEMPORARY TABLE player_data ("
+      "name VARCHAR(64) NOT NULL, account_id INT NULL, last_online DATETIME NULL) ENGINE=InnoDB",
+      "CREATE TEMPORARY TABLE unlocked_races ("
+      "account_id INT NOT NULL, race_id INT NOT NULL, "
+      "UNIQUE KEY unique_account_race (account_id, race_id)) ENGINE=InnoDB",
+      "CREATE TEMPORARY TABLE unlocked_classes ("
+      "account_id INT NOT NULL, class_id INT NOT NULL, "
+      "UNIQUE KEY unique_account_class (account_id, class_id)) ENGINE=InnoDB",
+      NULL};
+  const char *password = "$y$j9T$salt'ss\\\"; DROP TABLE account_data; --";
+  const char *email = "o'mall\\ey@example.test";
+  const char *character_name = "Bob'; DELETE FROM player_data; --";
+  struct account_data account;
+  struct account_data loaded;
+  struct char_data ch;
+  struct player_special_data specials;
+  char count_query[512];
+  char *escaped_name;
+  char *owner_name;
+  bool schema_created = true;
+  int query_index;
+  int slot;
+  bool race_found = false;
+  bool class_found = false;
+
+  memset(&account, 0, sizeof(account));
+  memset(&loaded, 0, sizeof(loaded));
+  memset(&ch, 0, sizeof(ch));
+  memset(&specials, 0, sizeof(specials));
+  ch.player_specials = &specials;
+  ch.player.name = (char *)character_name;
+
+  CuAssertIntEquals(tc, 0, mysql_query(connection, sql_mode));
+  for (query_index = 0; queries[query_index] != NULL; query_index++)
+    if (mysql_query(connection, queries[query_index]))
+      schema_created = false;
+  CuAssertTrue(tc, schema_created);
+
+  /* Core row with every string carrying hostile characters, plus unlock sets. */
+  account.name = (char *)account_name;
+  strlcpy(account.password, password, sizeof(account.password));
+  account.email = (char *)email;
+  account.experience = 1234;
+  account.quit_survey_completed = true;
+  account.races[0] = 3;
+  account.races[1] = 7;
+  account.classes[0] = 2;
+  CuAssertTrue(tc, save_account_checked(&account));
+  CuAssertTrue(tc, account.id > 0);
+
+  CuAssertIntEquals(tc, 0, load_account((char *)lookup_name, &loaded));
+  CuAssertStrEquals(tc, account_name, loaded.name);
+  CuAssertStrEquals(tc, password, loaded.password);
+  CuAssertStrEquals(tc, email, loaded.email);
+  CuAssertIntEquals(tc, 1234, loaded.experience);
+  CuAssertTrue(tc, loaded.quit_survey_completed);
+  CuAssertIntEquals(tc, account.id, loaded.id);
+  for (slot = 0; slot < MAX_UNLOCKED_RACES; slot++)
+    if (loaded.races[slot] == 7)
+      race_found = true;
+  for (slot = 0; slot < MAX_UNLOCKED_CLASSES; slot++)
+    if (loaded.classes[slot] == 2)
+      class_found = true;
+  CuAssertTrue(tc, race_found);
+  CuAssertTrue(tc, class_found);
+  CuAssertPtrEquals(tc, NULL, loaded.character_names[0]);
+  free(loaded.name);
+  free(loaded.email);
+  memset(&loaded, 0, sizeof(loaded));
+
+  /* A missing email binds as SQL NULL rather than the text "NULL". */
+  account.email = NULL;
+  account.experience = 99;
+  account.quit_survey_completed = false;
+  CuAssertTrue(tc, save_account_checked(&account));
+  CuAssertIntEquals(tc, 0, load_account((char *)account_name, &loaded));
+  CuAssertPtrEquals(tc, NULL, loaded.email);
+  CuAssertIntEquals(tc, 99, loaded.experience);
+  CuAssertTrue(tc, !loaded.quit_survey_completed);
+  free(loaded.name);
+  memset(&loaded, 0, sizeof(loaded));
+
+  /* Character links: create, list, resolve owner, batch relink, dedupe, remove. */
+  CuAssertTrue(tc, link_character_to_account_checked(&ch, &account));
+  load_account_characters(&account);
+  CuAssertPtrNotNull(tc, account.character_names[0]);
+  CuAssertStrEquals(tc, character_name, account.character_names[0]);
+  CuAssertPtrEquals(tc, NULL, account.character_names[1]);
+  owner_name = get_char_account_name((char *)character_name);
+  CuAssertPtrNotNull(tc, owner_name);
+  CuAssertStrEquals(tc, account_name, owner_name);
+  free(owner_name);
+
+  /* The dirty character set drives the placeholder IN (...) relink. */
+  CuAssertTrue(tc, save_account_checked(&account));
+  escaped_name = mysql_escape_string_alloc(connection, character_name);
+  CuAssertPtrNotNull(tc, escaped_name);
+  snprintf(count_query, sizeof(count_query),
+           "SELECT COUNT(*) FROM player_data WHERE account_id = %d", account.id);
+  CuAssertIntEquals(tc, 1, query_single_int(connection, count_query, -1));
+
+  snprintf(count_query, sizeof(count_query),
+           "INSERT INTO player_data (name, account_id) VALUES ('%s', %d)", escaped_name,
+           account.id);
+  CuAssertIntEquals(tc, 0, mysql_query(connection, count_query));
+  snprintf(count_query, sizeof(count_query),
+           "SELECT COUNT(*) FROM player_data WHERE account_id = %d", account.id);
+  CuAssertIntEquals(tc, 2, query_single_int(connection, count_query, -1));
+  load_account_characters(&account);
+  CuAssertIntEquals(tc, 1, query_single_int(connection, count_query, -1));
+  CuAssertStrEquals(tc, character_name, account.character_names[0]);
+  CuAssertPtrEquals(tc, NULL, account.character_names[1]);
+
+  remove_char_from_account(&ch, &account);
+  CuAssertIntEquals(tc, 0, query_single_int(connection, count_query, -1));
+  CuAssertPtrEquals(tc, NULL, account.character_names[0]);
+  CuAssertPtrEquals(tc, NULL, get_char_account_name((char *)character_name));
+  free(escaped_name);
+
+  for (slot = 0; slot < MAX_CHARS_PER_ACCOUNT; slot++)
+    free(account.character_names[slot]);
+}
+
+void Test_account_tier_binds_hostile_values_in_every_sql_mode(CuTest *tc)
+{
+  const char *enabled = getenv("LUMINARI_TEST_MYSQL_ENABLE");
+  const char *account_name = "Ol'R\xc3\xa9\\ille\"); DROP TABLE account_data; --";
+  const char *lookup_name = "oL'r\xc3\xa9\\ILLE\"); drop TABLE account_data; --";
+  MYSQL *connection;
+  MYSQL *saved_conn;
+  bool saved_available;
+
+  if (enabled == NULL || strcmp(enabled, "1") != 0)
+  {
+    CuAssertTrue(tc, 1);
+    return;
+  }
+
+  connection = open_test_database();
+  if (connection == NULL)
+  {
+    CuFail(tc, "could not connect to the explicitly configured test database");
+    return;
+  }
+  mysql_set_character_set(connection, "utf8mb4");
+
+  saved_conn = conn;
+  saved_available = mysql_available;
+  conn = connection;
+  mysql_available = true;
+
+  check_account_tier_binds_values(tc, connection, "SET SESSION sql_mode = ''", account_name,
+                                  lookup_name);
+  check_account_tier_binds_values(tc, connection, "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'",
+                                  account_name, lookup_name);
+
+  mysql_close(connection);
+  conn = saved_conn;
+  mysql_available = saved_available;
 }


### PR DESCRIPTION
## Summary

Part of #98 (Security modernization: migrate dynamic SQL construction to bound prepared statements). This PR verifies the issue against the current tree, migrates the first risk tier named in the issue (authentication and account recovery), adds the blocking regression check the acceptance criteria call for, and leaves the remaining inventory measurable.

### Validity check

A lexical sweep of `src/` at the base commit found 649 `mysql_query` calls, 95 `mysql_real_escape_string` uses, and 332 printf-style constructions of SQL text with `%` conversions across 41 files. Every site that interpolates user- or database-derived text was escaped; the unescaped ones interpolate compile-time constants or validated player names. So there is no live injection to fix, but the issue's core claim stands: correctness depends on every caller remembering to escape and on the session `sql_mode` matching the escaping assumptions, and nothing blocks new formatted SQL.

### Changes

- `src/account.c`: every data-carrying statement now uses the `PREPARED_STMT` wrapper with bound values. Account lookup, duplicate-character detection and cleanup, character listing, unlock loading, owner lookup by character, the account upsert (NULL email binds as SQL NULL), the batched character relink, unlock-set replacement, the account menu probe, and character link, unlink, and staged removal. `IN (...)` and multi-row `VALUES` lists append placeholders only, then bind each value. Unlock table and column identifiers come from an enum-indexed compile-time table. Every error path releases its statement. Static `START TRANSACTION`, `COMMIT`, and `ROLLBACK` remain direct queries.
- `src/mysql.c`, `src/mysql.h`: `BIGINT` and `COUNT(*)` results bind as 64-bit integers with a new `mysql_stmt_get_long()`; `mysql_stmt_get_int()` handles those columns too. Previously they fell into the string default and `mysql_stmt_get_int()` reinterpreted text bytes (this also corrects the existing help-entry count in `hedit.c`). Executions now report to the performance monitor with the prepared text, so SQL family attribution survives migration.
- `scripts/ci/check_sql_interpolation.py` plus `scripts/ci/sql_interpolation_baseline.txt`: counts printf-style calls whose format carries an SQL statement or clause opener and a `%` conversion, per file, and fails when a file exceeds its baseline. `make test` runs it as `test-sql-interpolation`. `--list` prints the remaining inventory for #98; `--update` lowers the baseline after a migration. Baseline: 332 sites in 41 files, none in `src/account.c`.
- Tests: `Test_account_tier_binds_hostile_values_in_every_sql_mode` saves and reloads an account whose name, password hash, email, and character name carry quotes, backslashes, multibyte text, and SQL fragments; covers case-insensitive lookup, NULL email, linking, duplicate cleanup, batched relink, and removal; runs under the default mode and `NO_BACKSLASH_ESCAPES`.
- Docs: `DATABASE_INTEGRATION.md` now documents the wrapper as the default, the identifier allowlist rule, and the ratchet; `TESTING_GUIDE.md` and the changelog updated.

### Verification

- `make -j` with `-Wall -Wextra`: no warnings.
- `make test` against an isolated MariaDB instance on loopback (fresh data directory, `sql/master_schema.sql`, runtime prepared with `scripts/ci/prepare_test_runtime.sh`): 1388 CuTests pass, all shell checks pass, `test-sql-interpolation` reports 332 sites within baseline. `make install` run afterwards; no root-level binary left.
- The new account test executed against the database in both session modes (log shows the duplicate cleanup and removal of the hostile-named character).
- Rebased onto master after #152 (yescrypt passwords); `load_account` uses the widened hash buffer.

### Remaining for #98

Not in this PR: the other 332 formatted sites (mail/boards, OLC/help, player persistence, economy, vessels), transaction/retry policy, connection charset centralization, and versioned schema tooling. The ratchet prevents growth and gives each follow-up a measurable target.

https://claude.ai/code/session_01T6jCs5zKn4KWUjXidujR19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Account database operations now use safer parameter binding, improving protection against SQL injection and ensuring special characters are handled correctly.

- **Reliability**
  - Account data, including large numeric values and unusual names, is handled more consistently across supported database modes.
  - Database activity monitoring now includes prepared queries.

- **Testing**
  - Added automated coverage for hostile account values, character links, unlock data, and multiple SQL modes.
  - Added checks to prevent new unsafe SQL interpolation from being introduced.

- **Documentation**
  - Updated database security and testing guidance, including safe test-database configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->