### PR TITLE
Close the pet persistence durability boundaries as accepted limits

### DIFF
--- a/docs/systems/SAVE_SYSTEMS_BREAKDOWN.md
+++ b/docs/systems/SAVE_SYSTEMS_BREAKDOWN.md
@@ -116,9 +116,14 @@ every follower row before starting the transaction, then replaces active pet and
 object rows together. Stored rows remain intact. Existing `pet_data_id` values
 survive replacement; `owner_id` and `owner_created` bind them to the pfile owner,
 including across a rename. SQL player IDs are not interchangeable with pfile IDs.
-A known query failure rolls back the replacement. An uncertain COMMIT outcome
-still needs reconciliation; a transaction does not make pfiles, world items,
-and SQL jointly crash-atomic.
+A known query failure rolls back the replacement. A COMMIT that reports an
+error is treated as a failure: `save_char_pets()` and the keeper store both
+issue a ROLLBACK, but the server may already have applied the commit, so the
+rollback's effect is uncertain. The live pets stay in play and the next
+snapshot replaces the active rows again, so the worst case is a stale active
+row until then. A transaction does not make pfiles, world items, and SQL
+jointly crash-atomic; pet data is not treated as critical, and no cross-store
+reconciliation is attempted.
 
 Before copyover closes sockets or writes its handoff file, `save_player_pets()`
 in `src/limits.c` snapshots players in the world, including linkdead owners.
@@ -196,8 +201,20 @@ are moved to `PET_STATE_STORED` in one transaction before anything is published,
 so the next active snapshot cannot drop them; a rejected timed follower is spent
 and its row leaves with the next snapshot. Keeper reclaim applies the same check
 to the staged pet, so classification uses the saved source and flags rather than
-the prototype. Post-publication callback reconciliation remains open. Legacy rows with a NULL runtime state retain the compatibility
-load path. Custom names use the existing name/short/long text fields.
+the prototype. A restored hireling keeps the prototype's category; the runtime
+state carries only its one-time hit-point roll marker plus any flag that was
+set on the live mobile, so a purchased mercenary counts against the same slot
+before and after a restore. Placement and mobile load triggers that extract or
+detach the pet during publication discard the roomless copy. On login the row
+is untouched. On keeper reclaim the row was already committed active, so a
+separate recovery transaction moves it back to `PET_STATE_STORED`; if that
+recovery fails or its commit outcome is uncertain, the row stays active with
+no live pet, and the owner's next login restores it from there. Once
+published, the pet is an ordinary live NPC: anything that happens to it
+afterward is captured by the next snapshot or lost with it, and no further
+reconciliation is performed. Legacy rows with a NULL runtime state
+retain the compatibility load path; older saved data is not repaired or
+migrated beyond the schema migrations. Custom names use the existing name/short/long text fields.
 `pets <pet|#id> name <name>` stages the new strings and restores the old pointers
 on known save failure. Prototype keywords remain available for targeting;
 repeated renaming does not accumulate prior custom names. Saved eidolon identity
@@ -221,10 +238,24 @@ lycanthrope, totem spirit); they are skipped by the snapshot and a saved record
 of one is rejected on restore. The keeper boards only durable and timed-control
 followers; reclaiming a stored row whose lifetime has ended deletes that row
 and its objects inside the reclaim transaction. `pets` shows each pet's
-policy and remaining real time. Expiry gear handling and uncertain-commit
-reconciliation remain open; see
-[issue #162](https://github.com/LuminariMUD/Luminari-Source/issues/162).
-Save/load tests do not replace the executable copyover acceptance gate tracked there.
+policy and remaining real time.
+
+Accepted durability limits:
+
+- When a timed follower's deadline fires, live or during an offline restore,
+  its equipment and inventory are destroyed with it. Nothing is returned to
+  the owner or the room.
+- A keeper store whose COMMIT reports an error keeps the live pet and gear in
+  play. If the commit had in fact applied, a stored copy also exists until the
+  owner reclaims or a staff member removes it.
+- A keeper reclaim whose activation COMMIT reports an error discards the
+  roomless copy. If the commit had in fact applied, the row is now active and
+  the owner's next login restores it; otherwise it stays with the keeper.
+- Uncertain outcomes are not reconciled against pfiles or live objects. Losing
+  or duplicating a pet in these windows is accepted.
+
+The copyover and restart acceptance run is recorded in
+`docs/testing/pet-copyover-restart-acceptance-2026-09-12.txt`.
 
 #### 3. Wilderness System Data
 - **Tables**: `region_data`, `path_data`, `region_index`, `path_index`

--- a/docs/testing/pet-copyover-restart-acceptance-2026-09-12.txt
+++ b/docs/testing/pet-copyover-restart-acceptance-2026-09-12.txt
@@ -1,0 +1,67 @@
+Pet copyover and restart acceptance - 2026-09-12
+=================================================
+
+Scope
+-----
+
+Closes the executable gate from issue #162 under its overriding rule: a
+minimal pass, with the remaining durability boundaries recorded as accepted
+limits in docs/systems/SAVE_SYSTEMS_BREAKDOWN.md rather than implemented.
+
+Tested revision
+---------------
+
+Branch fix/issue-162-pet-durability-limits on top of master 4bfc60abb, with
+the src/players.c change that stops the restore path from adding the
+mercenary flag to a hireling that did not carry it live.  Installed release
+ELF build ID 6f24742333ca2d65b1863cad3d0b735790924a05.
+
+Production-linked suite
+-----------------------
+
+  LUMINARI_TEST_MYSQL_ENABLE=1 make -j$(nproc) test    (database tests then
+  rerun through ./cutest with the test database variables pointed at the
+  development database, because this checkout's database user cannot create
+  a separate schema)
+
+  OK (1424 tests)
+
+make install completed without compiler warnings and removed the root-level
+luminari artifact.
+
+Live acceptance on port 4100 (autorun, Kohdee)
+----------------------------------------------
+
+1. Purchase: buy token in room 103489 created an owned mercenary rogue
+   (pet #47345984).  A leather bag (3032) was given to it.
+2. Copyover with the owner online: after "Copyover recovery complete." the
+   pet was present with the same row id and still carried the bag.
+   Observed defect: the pet was listed as General before the copyover and as
+   Mercenary after it, moving it out of the general slot accounting.  Cause:
+   load_char_pets() and apply_pet_runtime_state() forced MOB_MERCENARY onto
+   any pet whose prototype special is mercenary, while a live purchase never
+   sets that flag.  Fixed; the runtime state's kept-flag line still carries a
+   flag that was set on the live mobile.
+3. Rebuilt and installed.  A second purchase (pet #47345986, with its own bag)
+   stayed General through a copyover and through logout and relogin.  The
+   first pet kept the Mercenary flag it had already saved, as documented.
+4. Full restart: shutdown reboot, autorun restarted the server (new pid
+   3499574).  On relogin both pets were restored with their bags and the
+   same row ids and categories.
+5. Cleanup: each pet returned its bag through order, the bags were junked,
+   both pets were dismissed, and the roster reads 0 pets.  The 2000 gold
+   spent on the two tokens was not refunded.
+
+Session logs (scratch, not committed): pet-copyover-live2.log,
+pet-copyover-live3.log, pet-copyover-live4.log, pet-postcopyover-live5.log,
+pet-postrestart-live6.log, pet-cleanup-live7.log.
+
+Not exercised
+-------------
+
+Summoner, necromancer, divine, mount, construct, and source-item acquisition
+routes, owner death and reclaim, finite expiry, reduced-capacity restore, and
+failed-operation recovery remain covered by the production-linked suites and
+the Phase 1 records; they were not repeated live under the minimal rule.  The
+CMake build and focused memory checks were not rerun for this three-line
+change.

--- a/src/players.c
+++ b/src/players.c
@@ -6284,6 +6284,8 @@ parse_failure:
   return false;
 }
 
+/* Reapply a decoded runtime-state record to a freshly read prototype copy:
+ * stats, flags beyond the prototype, feats, spell slots, and affects. */
 static void apply_pet_runtime_state(struct char_data *pet, const struct pet_runtime_state *state)
 {
   struct affected_type af;
@@ -6333,11 +6335,11 @@ static void apply_pet_runtime_state(struct char_data *pet, const struct pet_runt
     affect_to_char(pet, &af);
   }
 
+  /* The mercenary category comes from the prototype or the kept flag line;
+   * only the one-time hit-point roll marker is carried here so a restored
+   * hireling matches its live category accounting. */
   if (state->hired_mercenary)
-  {
-    SET_BIT_AR(MOB_FLAGS(pet), MOB_MERCENARY);
     PROC_FIRED(pet) = state->mercenary_proc_fired;
-  }
   if (!AFF_FLAGGED(pet, AFF_CHARM))
     SET_BIT_AR(AFF_FLAGS(pet), AFF_CHARM);
 }
@@ -7251,10 +7253,7 @@ static struct char_data *prepare_saved_pet_row(struct char_data *ch, MYSQL_ROW r
   {
     SET_BIT_AR(AFF_FLAGS(mob), AFF_CHARM);
     if (hired_mercenary)
-    {
-      SET_BIT_AR(MOB_FLAGS(mob), MOB_MERCENARY);
       PROC_FIRED(mob) = TRUE;
-    }
   }
   affect_total(mob);
   update_pos(mob);


### PR DESCRIPTION
Closes #162 under its overriding rule (minimal pass; losing pet data is acceptable).

## What changed

- `docs/systems/SAVE_SYSTEMS_BREAKDOWN.md`: the post-publication callback, expiry-gear, uncertain-commit, and legacy-data boundaries are now recorded as explicit accepted limits, traced from the current `save_char_pets()`, keeper store, and keeper reclaim code. The "remains open" pointers to the issue are gone.
- `docs/testing/pet-copyover-restart-acceptance-2026-09-12.txt`: records the copyover and full-restart acceptance run with the tested revision.
- `src/players.c`: the live run exposed a defect. Restoring a purchased mercenary forced `MOB_MERCENARY` from its prototype special, so a pet listed as General before a copyover came back as Mercenary in a different capacity slot. Restore now carries only the hit-point roll marker; a flag that was set on the live mobile still round-trips through the runtime state's kept-flag line (the existing round-trip test covers that path).

## Verification

- `LUMINARI_TEST_MYSQL_ENABLE=1 make -j$(nproc) test`, with the database tests rerun against the development database: `OK (1424 tests)`.
- `make install` clean, no warnings, no root `luminari` artifact.
- Live on port 4100: purchase, gear, copyover (same row id, bag retained), second purchase stays General across copyover and relogin, `shutdown reboot` restart restores both pets with gear, cleanup back to 0 pets.

## Not done (by the minimal rule)

No new code for cross-store reconciliation, expiry gear return, or legacy data repair; no help changes (no command behavior changed); CMake build and memory checks not rerun for this three-line change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored hired followers now retain their correct category and status.
  * Pet restoration and persistence behavior is more reliable across copyovers and restarts.
  * Save failures are handled consistently, with documented limits for uncertain outcomes.

* **Documentation**
  * Updated pet persistence documentation to clarify durability limits and recovery behavior.
  * Added an acceptance record covering pet purchase, copyover, restart, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->