### PR TITLE
Mark shop rooms on ASCII maps

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -123,6 +123,15 @@ jobs:
             exit 1
           fi
 
+      - name: Verify map help migration lookup and replay
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mariadb-server
+          python3 -m pip install -r scripts/help-sync/requirements.txt
+          LUMINARI_HELP_SYNC_INTEGRATION=1 python3 -m unittest \
+            scripts/help-sync/tests/test_endpoint_integration.py \
+            -k test_map_shop_migration -v
+
   world-validation:
     name: World File Validation
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1002,6 +1002,7 @@ add_custom_target(test-help-sync-integration
 
 # Keep this list synchronized with cutest_test_files in Makefile.am.
 set(CUTEST_TEST_SOURCES
+    unittests/CuTest/test_asciimap_production.c
     unittests/CuTest/test_syntax_check_boot.c
     unittests/CuTest/test_web_onboarding.c
     unittests/CuTest/test_race_equivalence.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -953,6 +953,7 @@ EXTRA_DIST = \
 	sql/components/help_thrown_weapons_entries.sql \
 	sql/components/help_vessel_entries.sql \
 	sql/components/help_character_backgrounds.sql \
+	sql/components/help_map_shop_markers.sql \
 	sql/components/help_necromancer_entries.sql \
 	sql/components/help_rol_object_trap_entries.sql \
 	sql/components/help_worship_entries.sql \

--- a/Makefile.am
+++ b/Makefile.am
@@ -397,6 +397,7 @@ bsd_snprintf_fallback_test_LDADD = -lm
 
 # CuTest sources
 cutest_SOURCES = \
+	unittests/CuTest/test_asciimap_production.c \
 	unittests/CuTest/test_syntax_check_boot.c \
 	unittests/CuTest/test_web_onboarding.c \
 	unittests/CuTest/test_race_equivalence.c \
@@ -473,6 +474,7 @@ cutest_CFLAGS = $(AM_CFLAGS) -DLUMINARI_CUTEST
 cutest_LDADD = $(luminari_LDADD)
 
 cutest_test_files = \
+	unittests/CuTest/test_asciimap_production.c \
 	unittests/CuTest/test_syntax_check_boot.c \
 	unittests/CuTest/test_bounds_checking.c \
 	unittests/CuTest/test_help_sync.c \

--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -2402,32 +2402,27 @@ See Also: TOGGLE, TAKE, SPLIT
 #0
 AUTOMAPPING MAPS
 
-Usage: map <#1-12>
+Usage: map [distance] [normal|world]
 
-   This command prints a text generated map of your current surroundings. 
-Including a number allows you to expand or shrink the map to show a wider 
-or smaller area. 
+The map command prints an ASCII map of your surroundings. Distance can be
+1 to 12; omitting it uses the configured default. Normal mode shows rooms
+and exits. World mode shows one symbol per room. For example, use map,
+map world, map 6 normal, or map 6 world.
+
+Shop rooms appear as [$] in normal mode and $ in world mode. Your current
+room always shows &, including when you are standing in a shop. A room with
+several shops shows one $; the marker remains when a shop is closed or its
+keeper is absent. It marks a shop location, not current vendor availability.
+Other rooms keep their terrain symbols. The same shop markers appear on
+the automatic minimap. Wilderness uses its separate terrain map.
 
 Usage: toggle automap on
 
-   Toggle automap on will turn on the automap, which shows a mini-map to the 
-right of the room descriptions. 
-   
- -LuminariMUD Map System-
-  .-.__--.,--.__.-.
- | 	R+	n Up            |                                                      
- | 	R-	n Down          |                                                      
- | [	B!	n] You         |                                                      
- | [	W.	n] Inside      |                                                      
- | [	wC	n] City        |                                                      
- | [	g,	n] Field       |                                                      
- | [	gY	n] Forest      |                                                      
- | [	mm	n] Hills       |                                                      
- | [	RM	n] Mountain    |                         	C[	W.	C]	n                          
- | [	C~	n] Swim        |                          	W| 	R+	n                         
- | [	B=	n] Boat        |                   	C[	W.	C] 	W- 	C[	B!	C] 	W- 	C[	W.	C]	n                    
- | [	W^	n] Flying      |                          	W| 	R-	n                         
- | [	BU	n] Underwater  |                         	C[	W.	C]	n                          
+Automap displays a minimap with room descriptions. Use toggle automap off
+to hide it. Screen-reader mode also hides automatic maps; the map command
+remains available.
+
+See also: MAP, GUI-MAP, WILDERNESS, SCREEN-READER
 #0
 AUTOPILOT
 
@@ -19823,6 +19818,11 @@ It is able to fly, has darkvision and can launch tail spikes once per round
 as a swift action, dealing 1d6+5 damage to all foes in the room.
 #0
 GUI-MAP MAP MAPPER MAPPING
+
+Use map or map world for an ASCII map of nearby rooms. Shop locations show
+$ (even when closed), and & marks your current room, including inside a shop.
+You can set the distance with map 6 normal or map 6 world. See AUTOMAPPING
+for the ASCII map and automatic minimap options.
 
 If you are using Luminari's GUI, a mapper will appear on the top right.
 

--- a/scripts/ci/check_clean_archive.sh
+++ b/scripts/ci/check_clean_archive.sh
@@ -50,6 +50,14 @@ trap cleanup EXIT
 printf '==> Exporting git archive HEAD from %s\n' "$repo_root"
 git -C "$repo_root" archive --format=tar HEAD | tar -x -C "$work_dir"
 
+# The server accepts only relative config paths. Keep an external runtime's
+# configuration reachable after moving into the exported source tree.
+if [[ -n ${LUMINARI_TEST_CONFIG_FILE:-} ]]; then
+  mkdir -p "$work_dir/lib/etc"
+  cp -- "$LUMINARI_TEST_CONFIG_FILE" "$work_dir/lib/etc/config"
+  export LUMINARI_TEST_CONFIG_FILE=lib/etc/config
+fi
+
 cd "$work_dir"
 cp src/campaign.example.h src/campaign.h
 cp src/mud_options.example.h src/mud_options.h

--- a/scripts/help-sync/tests/test_endpoint_integration.py
+++ b/scripts/help-sync/tests/test_endpoint_integration.py
@@ -30,6 +30,7 @@ from catalog import (  # noqa: E402
     HelpEntry,
     MergeResult,
     build_plan_core,
+    parse_help_hlp,
     render_help_hlp,
     seal_plan,
 )
@@ -617,6 +618,78 @@ class EndpointDatabaseIntegrationTests(unittest.TestCase):
                 "sync_plan_id",
             }.issubset(schema.tables["help_versions"])
         )
+
+    def test_map_shop_migration_updates_imported_entry_and_reclaims_aliases(self):
+        entries = {
+            entry.keywords[0].lower(): entry
+            for entry in parse_help_hlp(
+                (REPOSITORY_ROOT / "lib/text/help/help.hlp").read_bytes()
+            )
+            if entry.keywords[0].lower() in ("automapping", "gui-map")
+        }
+        self.assertEqual(set(entries), {"automapping", "gui-map"})
+        migration = (REPOSITORY_ROOT / "sql/components/help_map_shop_markers.sql").read_bytes()
+        client = shutil.which("mariadb") or shutil.which("mysql")
+        connection = self.config.connect(autocommit=True)
+        try:
+            with connection.cursor(pymysql.cursors.Cursor) as cursor:
+                for previously_applied in (False, True):
+                    with self.subTest(previously_applied=previously_applied):
+                        cursor.execute("DELETE FROM help_keywords")
+                        cursor.execute("DELETE FROM help_entries")
+                        for tag, entry in entries.items():
+                            cursor.execute(
+                                "INSERT INTO help_entries (tag, entry) VALUES (%s, %s)",
+                                (tag, "Legacy help without shop markers.\n"),
+                            )
+                            cursor.executemany(
+                                "INSERT INTO help_keywords (help_tag, keyword) VALUES (%s, %s)",
+                                [(tag, keyword) for keyword in entry.keywords],
+                            )
+                        if previously_applied:
+                            cursor.execute(
+                                "INSERT INTO help_entries (tag, entry) VALUES ('map', 'Keep body')"
+                            )
+                            cursor.executemany(
+                                "INSERT INTO help_keywords (help_tag, keyword) VALUES ('map', %s)",
+                                [(keyword.lower(),) for keyword in entries["gui-map"].keywords]
+                                + [("UNRELATED",)],
+                            )
+                        for _ in range(2):
+                            subprocess.run(
+                                [client, "--no-defaults", "--protocol=tcp", "--host=127.0.0.1",
+                                 f"--port={self.config.port}", "--user=root", self.database_name],
+                                input=migration, capture_output=True, check=True,
+                            )
+                            for tag, entry in entries.items():
+                                cursor.execute(
+                                    "SELECT entry, min_level FROM help_entries WHERE tag=%s", (tag,)
+                                )
+                                self.assertEqual(cursor.fetchone(), (entry.body, entry.min_level))
+                                for keyword in entry.keywords:
+                                    cursor.execute(
+                                        "SELECT help_tag FROM help_keywords "
+                                        "WHERE LOWER(keyword)=LOWER(%s)", (keyword,)
+                                    )
+                                    self.assertEqual(cursor.fetchall(), ((tag,),))
+                            # Match search_help's prefix lookup and first-result selection.
+                            for keyword in entries["gui-map"].keywords:
+                                cursor.execute(
+                                    "SELECT he.tag, he.entry FROM help_entries he "
+                                    "JOIN help_keywords hk ON he.tag=hk.help_tag "
+                                    "WHERE LOWER(hk.keyword) LIKE LOWER(%s) AND he.min_level<=0 "
+                                    "ORDER BY LENGTH(hk.keyword) ASC LIMIT 1", (keyword + "%",)
+                                )
+                                self.assertEqual(
+                                    cursor.fetchone(), ("gui-map", entries["gui-map"].body)
+                                )
+                        cursor.execute("SELECT entry FROM help_entries WHERE tag='map'")
+                        self.assertEqual(cursor.fetchall(), (("Keep body",),) if previously_applied else ())
+                        if previously_applied:
+                            cursor.execute("SELECT help_tag FROM help_keywords WHERE keyword='UNRELATED'")
+                            self.assertEqual(cursor.fetchone(), ("map",))
+        finally:
+            connection.close()
 
 
 if __name__ == "__main__":

--- a/sql/components/ci_schema_manifest.txt
+++ b/sql/components/ci_schema_manifest.txt
@@ -23,6 +23,7 @@ apply help_dg_damage_trigger.sql
 apply help_duris_racial_innate_entries.sql
 skip help_gdb_binary_path.sql
 apply help_intermud3_entries.sql
+apply help_map_shop_markers.sql
 apply help_nature_survival_entries.sql
 apply help_necromancer_entries.sql
 apply help_oedit_values_armor_ac.sql

--- a/sql/components/help_map_shop_markers.sql
+++ b/sql/components/help_map_shop_markers.sql
@@ -32,7 +32,7 @@ INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
 ('automapping', 'MAPS');
 
 INSERT INTO help_entries (tag, entry, min_level, auto_generated) VALUES
-('map', 'Use map or map world for an ASCII map of nearby rooms. Shop locations show
+('gui-map', 'Use map or map world for an ASCII map of nearby rooms. Shop locations show
 $ (even when closed), and & marks your current room, including inside a shop.
 You can set the distance with map 6 normal or map 6 world. See AUTOMAPPING
 for the ASCII map and automatic minimap options.
@@ -55,10 +55,15 @@ See also:  AUTOMAPPING
 ON DUPLICATE KEY UPDATE entry=VALUES(entry), min_level=VALUES(min_level),
                         auto_generated=VALUES(auto_generated);
 
+-- Reclaim aliases from earlier imports or the previous migration's map tag.
+DELETE FROM help_keywords
+WHERE UPPER(keyword) IN ('GUI-MAP', 'MAP', 'MAPPER', 'MAPPING')
+  AND help_tag <> 'gui-map';
+
 INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
-('map', 'GUI-MAP'),
-('map', 'MAP'),
-('map', 'MAPPER'),
-('map', 'MAPPING');
+('gui-map', 'GUI-MAP'),
+('gui-map', 'MAP'),
+('gui-map', 'MAPPER'),
+('gui-map', 'MAPPING');
 
 COMMIT;

--- a/sql/components/help_map_shop_markers.sql
+++ b/sql/components/help_map_shop_markers.sql
@@ -1,0 +1,64 @@
+-- ASCII map shop markers and command usage. Matches lib/text/help/help.hlp.
+START TRANSACTION;
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated) VALUES
+('automapping', 'Usage: map [distance] [normal|world]
+
+The map command prints an ASCII map of your surroundings. Distance can be
+1 to 12; omitting it uses the configured default. Normal mode shows rooms
+and exits. World mode shows one symbol per room. For example, use map,
+map world, map 6 normal, or map 6 world.
+
+Shop rooms appear as [$] in normal mode and $ in world mode. Your current
+room always shows &, including when you are standing in a shop. A room with
+several shops shows one $; the marker remains when a shop is closed or its
+keeper is absent. It marks a shop location, not current vendor availability.
+Other rooms keep their terrain symbols. The same shop markers appear on
+the automatic minimap. Wilderness uses its separate terrain map.
+
+Usage: toggle automap on
+
+Automap displays a minimap with room descriptions. Use toggle automap off
+to hide it. Screen-reader mode also hides automatic maps; the map command
+remains available.
+
+See also: MAP, GUI-MAP, WILDERNESS, SCREEN-READER
+', 0, 0)
+ON DUPLICATE KEY UPDATE entry=VALUES(entry), min_level=VALUES(min_level),
+                        auto_generated=VALUES(auto_generated);
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+('automapping', 'AUTOMAPPING'),
+('automapping', 'MAPS');
+
+INSERT INTO help_entries (tag, entry, min_level, auto_generated) VALUES
+('map', 'Use map or map world for an ASCII map of nearby rooms. Shop locations show
+$ (even when closed), and & marks your current room, including inside a shop.
+You can set the distance with map 6 normal or map 6 world. See AUTOMAPPING
+for the ASCII map and automatic minimap options.
+
+If you are using Luminari''s GUI, a mapper will appear on the top right.
+
+To use the mapper:
+start mapping - to begin actively mapping, move slower, check your map accuracy
+stop mapping - to pause active mapping, this will help protect your map during
+     fast movement
+
+The mapper does try to sync actively with the server, BUT due to network latency,
+etc...  it is very possible to manually mess up your map while you are actively
+mapping (start mapping).  You can manually modify your map by clicking, right-
+clicking and dragging elements.  You can also add labels and do various other
+functions using the mapper.
+
+See also:  AUTOMAPPING
+', 0, 0)
+ON DUPLICATE KEY UPDATE entry=VALUES(entry), min_level=VALUES(min_level),
+                        auto_generated=VALUES(auto_generated);
+
+INSERT IGNORE INTO help_keywords (help_tag, keyword) VALUES
+('map', 'GUI-MAP'),
+('map', 'MAP'),
+('map', 'MAPPER'),
+('map', 'MAPPING');
+
+COMMIT;

--- a/src/asciimap.c
+++ b/src/asciimap.c
@@ -18,6 +18,7 @@
 #include "db.h"
 #include "magic/spells.h"
 #include "obj/house.h"
+#include "obj/shop.h"
 #include "constants.h"
 #include "dgscript/dg_scripts.h"
 #include "asciimap.h"
@@ -45,6 +46,7 @@
 #define SECT_EMPTY (NUM_ROOM_SECTORS + 1)
 #define SECT_STRANGE (SECT_EMPTY + 1)
 #define SECT_HERE (SECT_STRANGE + 1)
+#define SECT_SHOP (SECT_HERE + 1)
 
 #define DOOR_NS -1
 #define DOOR_EW -2
@@ -102,7 +104,7 @@ static struct map_info_type compact_door_info[] = {{DOOR_NONE, " "},
                                                    {DOOR_NS, " | "}};
 
 /* Add new sector types below for both map_info and world_map_info     */
-/* The last 3 MUST remain the same, although the symbol can be changed */
+/* Entries must stay indexed by their sector or reserved map value.   */
 /* New sectors also need to be added to the perform_map function below */
 static struct map_info_type map_info[] = {
     {SECT_INSIDE, "\tc[\tn.\tc]\tn"}, /* 0 */
@@ -147,6 +149,7 @@ static struct map_info_type map_info[] = {
     {SECT_EMPTY, "   "}, /* NUM_ROOM_SECTORS + 1 */
     {SECT_STRANGE, "\tc[\tR?\tc]\tn"},
     {SECT_HERE, "\tc[\tW&\tc]\tn"},
+    {SECT_SHOP, "\tc[\ty$\tc]\tn"},
 };
 
 static struct map_info_type world_map_info[] = {
@@ -192,6 +195,7 @@ static struct map_info_type world_map_info[] = {
     {SECT_EMPTY, " "},
     {SECT_STRANGE, "\tR?\tn"},
     {SECT_HERE, "\tW&\tn"},
+    {SECT_SHOP, "\ty$\tn"},
 };
 
 static int map[MAX_MAP][MAX_MAP];
@@ -238,6 +242,25 @@ bool can_see_map(struct char_data *ch)
   return TRUE;
 }
 
+/* Shop locations remain useful even when their keeper is absent or closed. */
+static bool room_has_shop(room_vnum room)
+{
+  int shop_nr, room_index;
+
+  if (shop_index == NULL)
+    return FALSE;
+
+  for (shop_nr = 0; shop_nr <= top_shop; shop_nr++)
+  {
+    if (shop_index[shop_nr].in_room == NULL)
+      continue;
+    for (room_index = 0; SHOP_ROOM(shop_nr, room_index) != NOWHERE; room_index++)
+      if (SHOP_ROOM(shop_nr, room_index) == room)
+        return TRUE;
+  }
+  return FALSE;
+}
+
 /* MapArea function - create the actual map */
 static void MapArea(room_rnum room, struct char_data *ch, int x, int y, int min, int max,
                     sh_int xpos, sh_int ypos, bool worldmap)
@@ -253,6 +276,8 @@ static void MapArea(room_rnum room, struct char_data *ch, int x, int y, int min,
   /* marks the room as visited */
   if (room == IN_ROOM(ch))
     map[x][y] = SECT_HERE;
+  else if (room_has_shop(GET_ROOM_VNUM(room)))
+    map[x][y] = SECT_SHOP;
   else
     map[x][y] = SECT(room);
 
@@ -534,7 +559,12 @@ void perform_map(struct char_data *ch, const char *argument, bool worldmap)
   int mapshape = MAP_CIRCLE;
 
   two_arguments(argument, arg1, sizeof(arg1), arg2, sizeof(arg2));
-  if (*arg1)
+  /* A mode alone keeps the configured distance, as in "map world". */
+  if (*arg1 && !*arg2 && (is_abbrev(arg1, "normal") || is_abbrev(arg1, "world")))
+  {
+    strlcpy(arg2, arg1, sizeof(arg2));
+  }
+  else if (*arg1)
   {
     size = atoi(arg1);
   }
@@ -546,7 +576,7 @@ void perform_map(struct char_data *ch, const char *argument, bool worldmap)
       worldmap = TRUE;
     else
     {
-      send_to_char(ch, "Usage: \tymap <distance> [ normal | world ]\tn");
+      send_to_char(ch, "Usage: \tymap [distance] [ normal | world ]\tn");
       return;
     }
   }
@@ -588,6 +618,7 @@ void perform_map(struct char_data *ch, const char *argument, bool worldmap)
   count += sprintf(buf + count, "\tn\tn\tn%s Up\\\\", door_info[NUM_DOOR_TYPES + DOOR_UP].disp);
   count += sprintf(buf + count, "\tn\tn\tn%s Down\\\\", door_info[NUM_DOOR_TYPES + DOOR_DOWN].disp);
   count += sprintf(buf + count, "\tn%s You\\\\", map_info[SECT_HERE].disp);
+  count += snprintf(buf + count, sizeof(buf) - count, "\tn%s Shop\\\\", map_info[SECT_SHOP].disp);
   count += sprintf(buf + count, "\tn%s Inside\\\\", map_info[SECT_INSIDE].disp);
   count += sprintf(buf + count, "\tn%s City\\\\", map_info[SECT_CITY].disp);
   count += sprintf(buf + count, "\tn%s Field\\\\", map_info[SECT_FIELD].disp);

--- a/unittests/CuTest/test_asciimap_production.c
+++ b/unittests/CuTest/test_asciimap_production.c
@@ -1,0 +1,174 @@
+#include "CuTest.h"
+
+#include "conf.h"
+#include "../../src/sysdep.h"
+#include "../../src/structs.h"
+#include "../../src/utils.h"
+#include "../../src/asciimap.h"
+#include "../../src/comm.h"
+#include "../../src/db.h"
+#include "../../src/interpreter.h"
+#include "../../src/net/protocol.h"
+#include "../../src/obj/shop.h"
+
+/* Synthetic VNUMs deliberately differ from the room array indices. */
+#define MAP_TEST_VNUM_BASE 910000
+
+static void strip_map_terminal_styles(char *text)
+{
+  char *read = text;
+  char *write = text;
+
+  while (*read != '\0')
+  {
+    if (*read == '\033' && read[1] == '[')
+    {
+      read += 2;
+      while (*read != '\0' && *read != 'm')
+        read++;
+      if (*read == 'm')
+        read++;
+    }
+    else
+      *write++ = *read++;
+  }
+  *write = '\0';
+}
+
+static void assert_shop_map(CuTest *tc, const char *argument, bool standing_in_shop,
+                            bool duplicate_shop, bool no_shops, bool default_world,
+                            const char *expected_row)
+{
+  struct room_data rooms[4] = {0};
+  struct zone_data zone = {0};
+  struct room_direction_data exits[4] = {0};
+  struct shop_data shops[3] = {0};
+  room_vnum shop_rooms[] = {MAP_TEST_VNUM_BASE, MAP_TEST_VNUM_BASE + 3, NOWHERE, NOWHERE};
+  struct char_data player = {0};
+  struct player_special_data specials = {0};
+  struct descriptor_data descriptor = {0};
+  struct room_data *saved_world = world;
+  struct zone_data *saved_zones = zone_table;
+  struct shop_data *saved_shops = shop_index;
+  room_rnum saved_top_world = top_of_world;
+  zone_rnum saved_top_zone = top_of_zone_table;
+  int saved_top_shop = top_shop;
+  int saved_map_mode = CONFIG_MAP;
+  int saved_map_size = CONFIG_MAP_SIZE;
+  int saved_minimap_size = CONFIG_MINIMAP_SIZE;
+  char output[MAX_STRING_LENGTH];
+  char minimap[MAX_STRING_LENGTH];
+  bool legend_present;
+  int i;
+
+  descriptor.pProtocol = ProtocolCreate();
+  CuAssertPtrNotNull(tc, descriptor.pProtocol);
+  descriptor.pProtocol->pVariables[eMSDP_ANSI_COLORS]->ValueInt = 0;
+  descriptor.output = descriptor.small_outbuf;
+  descriptor.bufspace = SMALL_BUFSIZE - 1;
+  descriptor.character = &player;
+  player.desc = &descriptor;
+  player.player_specials = &specials;
+  GET_LEVEL(&player) = LVL_IMMORT;
+  IN_ROOM(&player) = 2;
+
+  for (i = 0; i < 4; i++)
+  {
+    rooms[i].number = MAP_TEST_VNUM_BASE + i;
+    rooms[i].sector_type = SECT_INSIDE;
+    rooms[i].light = 1;
+  }
+  rooms[1].sector_type = SECT_CITY;
+  rooms[3].sector_type = SECT_FOREST;
+  rooms[1].dir_option[EAST] = &exits[0];
+  exits[0].to_room = 2;
+  rooms[2].dir_option[WEST] = &exits[1];
+  exits[1].to_room = 1;
+  rooms[2].dir_option[EAST] = &exits[2];
+  exits[2].to_room = 3;
+  rooms[3].dir_option[WEST] = &exits[3];
+  exits[3].to_room = 2;
+  if (default_world)
+    SET_BIT_AR(zone.zone_flags, ZONE_WORLDMAP);
+
+  /* The first shop has no room list. The last shop uses its second room.
+   * No keepers exist, and impossible opening hours model a closed shop. */
+  shops[1].in_room = shop_rooms;
+  shops[1].open1 = shops[1].open2 = 25;
+  shops[1].close1 = shops[1].close2 = 26;
+  if (standing_in_shop)
+    shop_rooms[2] = rooms[2].number;
+  shops[2] = shops[1];
+
+  world = rooms;
+  top_of_world = 3;
+  zone_table = &zone;
+  top_of_zone_table = 0;
+  shop_index = no_shops ? NULL : shops;
+  top_shop = no_shops ? -1 : (duplicate_shop ? 2 : 1);
+  CONFIG_MAP = MAP_ON;
+  CONFIG_MAP_SIZE = 4;
+  CONFIG_MINIMAP_SIZE = 4;
+
+  do_map(&player, argument, 0, 0);
+  snprintf(output, sizeof(output), "%s", descriptor.output);
+  strip_map_terminal_styles(output);
+  legend_present = strstr(output, "[$] Shop") != NULL;
+  snprintf(minimap, sizeof(minimap), "%s", get_map_string(&player, IN_ROOM(&player)));
+
+  world = saved_world;
+  top_of_world = saved_top_world;
+  zone_table = saved_zones;
+  top_of_zone_table = saved_top_zone;
+  shop_index = saved_shops;
+  top_shop = saved_top_shop;
+  CONFIG_MAP = saved_map_mode;
+  CONFIG_MAP_SIZE = saved_map_size;
+  CONFIG_MINIMAP_SIZE = saved_minimap_size;
+  ProtocolDestroy(descriptor.pProtocol);
+  if (descriptor.large_outbuf != NULL)
+  {
+    free(descriptor.large_outbuf->text);
+    free(descriptor.large_outbuf);
+    buf_largecount--;
+  }
+
+  /* Assert actual neighboring map cells, so a '$' in the legend cannot pass. */
+  CuAssert(tc, output, strstr(output, expected_row) != NULL);
+  CuAssertTrue(tc, legend_present);
+  CuAssertTrue(tc, strstr(output, "OVERFLOW") == NULL);
+  CuAssertTrue(tc, (strchr(minimap, '$') != NULL) == !no_shops);
+  CuAssertTrue(tc, strchr(minimap, '&') != NULL);
+}
+
+void Test_asciimap_shop_and_terrain_render_through_map_commands(CuTest *tc)
+{
+  assert_shop_map(tc, "", FALSE, FALSE, FALSE, FALSE, "[C] - [&] - [$]");
+  assert_shop_map(tc, "world", FALSE, FALSE, FALSE, FALSE, "C&$");
+  assert_shop_map(tc, "4 normal", FALSE, FALSE, FALSE, FALSE, "[C] - [&] - [$]");
+  assert_shop_map(tc, "4 world", FALSE, FALSE, FALSE, FALSE, "C&$");
+}
+
+void Test_asciimap_player_marker_wins_in_shop_in_both_modes(CuTest *tc)
+{
+  assert_shop_map(tc, "", TRUE, FALSE, FALSE, FALSE, "[C] - [&] - [$]");
+  assert_shop_map(tc, "world", TRUE, FALSE, FALSE, FALSE, "C&$");
+}
+
+void Test_asciimap_multiple_shops_keep_one_marker(CuTest *tc)
+{
+  assert_shop_map(tc, "", FALSE, TRUE, FALSE, FALSE, "[C] - [&] - [$]");
+  assert_shop_map(tc, "world", FALSE, TRUE, FALSE, FALSE, "C&$");
+}
+
+void Test_asciimap_without_shops_keeps_terrain(CuTest *tc)
+{
+  assert_shop_map(tc, "", FALSE, FALSE, TRUE, FALSE, "[C] - [&] - [Y]");
+  assert_shop_map(tc, "world", FALSE, FALSE, TRUE, FALSE, "C&Y");
+}
+
+void Test_asciimap_zone_default_and_mode_override(CuTest *tc)
+{
+  assert_shop_map(tc, "", FALSE, FALSE, FALSE, TRUE, "C&$");
+  assert_shop_map(tc, "normal", FALSE, FALSE, FALSE, TRUE, "[C] - [&] - [$]");
+}


### PR DESCRIPTION
Shop rooms now show `[$]` on normal ASCII maps and `$` on world maps, with a Shop legend. The player keeps `&`; closed or absent keepers do not hide shop locations, and multiple shops in one room share one marker. Automatic minimaps use the same rendering. `map world` now selects world mode with the configured default distance; `map <distance> world` remains supported.

The ASCII-map and GUI-mapper help entries are updated in `lib/text/help/help.hlp` and the local development database. The repeatable migration updates the canonical `gui-map` tag and reassigns its four aliases, including recovery from an earlier application under `map`. A MariaDB regression verifies imported entries, alias ownership, prefix lookups, repeated application, exact agreement with the help file, and preservation of unrelated content. The migration is included in the CI schema manifest and source distribution.

The clean-archive harness now copies an externally supplied test config into the archive so the server can use its required relative config path.

Local validation at `8212fae0d`:
- `make test-all` with both libevent and select: passed (1,429 production-linked tests, 31 protocol-parser tests, and supporting checks per run); `make install` passed.
- `scripts/ci/check_clean_archive.sh --keep`: passed through Autotools and CMake, including tests and installations. Strict `ci-gcc` and `ci-clang` builds each passed all 26 CTest entries.
- Hardened Autotools builds with GCC 13, Clang 18, and GCC 14, plus hardened CMake builds with GCC and Clang: builds, tests, and ELF-property checks passed. Compiler builds emitted no warnings.
- ASan/UBSan with leak detection, bounded protocol fuzzing, and Valgrind: passed; Valgrind reported zero errors.
- Coverage: 27.3% lines and 17.4% branches, above the 10.50% / 7.16% CI floors.
- All 60 applicable SQL components applied to fresh master schemas; all nine help database integration tests passed.
- World-data tools, world-file/lookup smoke checks, source-distribution hygiene, build parity, formatting, hooks, and static-analysis commands passed.
- CodeQL C/C++ security-extended and Python security/quality analyses completed, with no findings on changed lines. Gitleaks found no leaks. No dependency manifests or dependency versions changed.
- Server startup via `autorun.sh` on port 4100 passed TCP, HTTP health, clean-log, and graceful-shutdown checks. The original development MUD was restored afterward.

Local environment adaptations: the machine's unpacked libevent development package was supplied through pkg-config; hardened CMake checks used `CMAKE_SKIP_RPATH=ON`; isolated database runs used `MYSQL_TCP_PORT`. GitHub CI completion is not a merge gate for this review pass.

Fixes #170.
